### PR TITLE
[vspec2ttl] Add dependencies, align with newest rdflib version

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ stringcase = ">=1.2.0"
 deprecation = ">=2.1.0"
 pytest = ">=2.7.2"
 PyYAML = ">=5.1"
+rdflib = ">=6.0.0"
 vss-tools = {editable = true, path = "."}
 
 [dev-packages]

--- a/contrib/vspec2ttl/vspec2ttl.py
+++ b/contrib/vspec2ttl/vspec2ttl.py
@@ -65,7 +65,7 @@ def setup_graph():
 
     holdsValue = VssoConcepts.HOLDS_VALUE.uri
     g.add((holdsValue, RDF.type, OWL.DatatypeProperty))
-    g.add((holdsValue,RDFS.subPropertyOf, OWL.topDatatypeProperty))
+    g.add((holdsValue,RDFS.subPropertyOf, OWL.topDataProperty))
     g.add((holdsValue,RDFS.domain, VssoConcepts.VEHICLE_PROP.uri))
     g.add((holdsValue,RDFS.label, Literal(VssoConcepts.HOLDS_VALUE.value,lang="en")))
 
@@ -85,7 +85,7 @@ def setup_graph():
 
     hasComponentInstance = VssoConcepts.HAS_COMP_INST.uri
     g.add((hasComponentInstance, RDF.type, OWL.DatatypeProperty))
-    g.add((hasComponentInstance,RDFS.subPropertyOf, OWL.topDatatypeProperty))
+    g.add((hasComponentInstance,RDFS.subPropertyOf, OWL.topDataProperty))
     g.add((hasComponentInstance,RDFS.label, Literal(VssoConcepts.HAS_COMP_INST.value,lang="en")))
 
 
@@ -156,7 +156,7 @@ def setup_graph():
 
     # print all the data in the Notation3 format
     print("--- printing mboxes ---")
-    print(g.serialize(format='ttl').decode("utf-8"))
+    print(g.serialize(format='ttl'))
 
     return g
 
@@ -271,7 +271,7 @@ def print_ttl_content(file, tree):
                 enums += 1
 
 
-    file.write(graph.serialize(format='ttl').decode("utf-8"))
+    file.write(graph.serialize(format='ttl'))
 
     print (duplication)
     print (duplication_vsso)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ anytree>=2.8.0
 stringcase>=1.2.0
 deprecation>=2.1.0
 pytest>=2.7.2
+rdflib>=6.0.0


### PR DESCRIPTION
* added rdflib dependency to requirements.txt
* used newest rdflib version and fixed issues (decode)
* fixed one wrong pointer to owl topDataProperty

related to: #106
fixes: #108 

Signed-off-by: Daniel Wilms <Daniel.DW.Wilms@bmw.de>