### PR TITLE
Fix strict checking

### DIFF
--- a/vspec/__init__.py
+++ b/vspec/__init__.py
@@ -725,7 +725,7 @@ def render_subtree(subtree, parent, break_on_noncore_attribute=False):
         new_element = VSSNode(element_name, current_element, parent=parent, break_on_noncore_attribute=break_on_noncore_attribute)
         if "children" in current_element.keys():
             child_nodes = current_element["children"]
-            render_subtree(child_nodes, new_element)
+            render_subtree(child_nodes, new_element, break_on_noncore_attribute)
 
 
 def merge_private_into_main_tree(tree_root: VSSNode):


### PR DESCRIPTION
We had a regression with strict attribute checking in the main parser code.

When using the -s option in any  vspec2x tool supporting the feature, we expect them to terminate when an attrinbute that is not defined in the standard catalogue is detected. However, currently only a warning is printed, as the desire to abort on an unknown attribute was not propagated when processing sub tress.

This changes fixes that. Just look at the diff, that is easier than explaining this :) It is used in VSSNode creation (see line 67 in vsstree.py)