### PR TITLE
Adding config.yaml to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,4 +22,7 @@ setup(
     python_requires='>=3.7',
     install_requires=['pyyaml>=5.1', 'anytree>=2.8.0', 'stringcase>=1.2.0', 'deprecation>=2.1.0'],
     tests_require=['pytest>=2.7.2'],
+    package_data={'vspec': [
+        'config.yaml'
+    ]},
 )


### PR DESCRIPTION
This PR solves the issue of `config.yaml` not being found in the package when the package is installed (only found when cloning the repository). 

Here `package_data` is a keyword on `setup.py` that says: hey, look on `vspec` module and include the file `config.yaml` in the package so when the package is installed, this file gets copied too.