### PR TITLE
Adding support for comments in node descriptions

### DIFF
--- a/vspec/model/vsstree.py
+++ b/vspec/model/vsstree.py
@@ -29,6 +29,7 @@ class NonCoreAttributeException(Exception):
 class VSSNode(Node):
     """Representation of an VSS element according to the vehicle signal specification."""
     description = None
+    comment = ""
     uuid = None
     type: VSSType
     data_type: VSSDataType
@@ -98,6 +99,9 @@ class VSSNode(Node):
 
         if "deprecation" in source_dict.keys():
             self.deprecation = source_dict["deprecation"]
+            
+        if "comment" in source_dict.keys():
+            self.comment = source_dict["comment"]
 
     def is_private(self) -> bool:
         """Checks weather this instance is in private branch of VSS.
@@ -250,7 +254,7 @@ class VSSNode(Node):
 
         for aKey in element.keys():
             if aKey not in ["type", "children", "datatype", "description", "unit", "uuid", "min", "max", "enum",
-                            "aggregate", "default" , "instances", "deprecation", "arraysize"]:
+                            "aggregate", "default" , "instances", "deprecation", "arraysize", "comment"]:
                 raise NonCoreAttributeException('Non-core attribute "%s" in element %s found.' % (aKey, name))
 
         if "default" in element.keys():

--- a/vspec2csv.py
+++ b/vspec2csv.py
@@ -45,7 +45,7 @@ def format_csv_line(*csv_fields):
 
 #Write the header line
 def print_csv_header(file):
-    file.write(format_csv_line("Signal","Type","DataType","Deprecated","Complex","Unit","Min","Max","Desc","Enum","Id","Instance"))
+    file.write(format_csv_line("Signal","Type","DataType","Deprecated","Complex","Unit","Min","Max","Desc","Comment","Enum","Id","Instance"))
 
 #Write the data lines
 def print_csv_content(file, tree):
@@ -57,10 +57,10 @@ def print_csv_content(file, tree):
         if tree_node.instances:
             for instance in tree_node.instances:
                 file.write(format_csv_line(
-                    tree_node.qualified_name('.'),tree_node.type.value,data_type_str,tree_node.deprecation,"true",unit_str,tree_node.min,tree_node.max,tree_node.description,tree_node.enum,tree_node.uuid,instance))
+                    tree_node.qualified_name('.'),tree_node.type.value,data_type_str,tree_node.deprecation,"true",unit_str,tree_node.min,tree_node.max,tree_node.description,tree_node.comment,tree_node.enum,tree_node.uuid,instance))
         else:
             file.write(format_csv_line(
-                tree_node.qualified_name('.'),tree_node.type.value,data_type_str,tree_node.deprecation,"false",unit_str,tree_node.min,tree_node.max,tree_node.description,tree_node.enum,tree_node.uuid))
+                tree_node.qualified_name('.'),tree_node.type.value,data_type_str,tree_node.deprecation,"false",unit_str,tree_node.min,tree_node.max,tree_node.description,tree_node.comment,tree_node.enum,tree_node.uuid))
 
 
 if __name__ == "__main__":

--- a/vspec2json.py
+++ b/vspec2json.py
@@ -51,6 +51,8 @@ def export_node(json_dict, node, generate_uuid):
         pass
 
     json_dict[node.name]["description"] = node.description
+    if node.comment != "":
+        json_dict[node.name]["comment"] = node.comment
 
     if generate_uuid:
         json_dict[node.name]["uuid"] = node.uuid


### PR DESCRIPTION
Related to: 

https://github.com/COVESA/vehicle_signal_specification/issues/364
https://github.com/COVESA/vehicle_signal_specification/pull/367

This PR cover two parts:

- General model support for `comment`. I.e. tool will recognize `comment` as a valid but optional item and save it in the internal model.
- Support to output `comment` for CSV and JSON tools. We can discuss how we want to handle the tools. Try to update all or none or just some?