### PR TITLE
[CORE] Move from `enum` to `allowed`

### DIFF
--- a/binary/README.md
+++ b/binary/README.md
@@ -54,16 +54,16 @@ The binary node file format is as follows:<br>
     Max         | chararray | MaxLen<br>
     UnitLen     | uint8     | 1<br>
     Unit        | chararray | UnitLen<br>
-    EnumLen     | uint8     | 1<br>
-    Enums       | chararray | EnumLen<br>
+    AllowedLen  | uint8     | 1<br>
+    Allowed     | chararray | AllowedLen<br>
     DefaultLen  | uint8     | 1<br>
-    Default     | chararray | EnumLen<br>
+    Default     | chararray | AllowedLen<br>
     ValidateLen | uint8     | 1<br>
     Validate    | chararray | ValidateLen<br>
     Children    | uint8     | 1<br><br>
 
-The Enums string contains an array of enums, each enum is preceeded by two characters holding the size of the enum sub-string. 
-The size is in hex format, with values from "01" to "FF". An example is "03abc0A012345678902cd" which contains the three enums "abc", "0123456789", and "cd".<br><br>
+The Allowed string contains an array of allowed, each Allowed is preceeded by two characters holding the size of the Allowed sub-string. 
+The size is in hex format, with values from "01" to "FF". An example is "03abc0A012345678902cd" which contains the three Alloweds "abc", "0123456789", and "cd".<br><br>
 
 The nodes are written into the file in the order given by an iterative method as shown in the following pseudocode.<br>
 def traverseAndWriteNode(thisNode):<br>

--- a/binary/binarytool.c
+++ b/binary/binarytool.c
@@ -19,8 +19,8 @@
 
 FILE* treeFp;
 
-void writeNodeData(char* name, char* type, char* uuid, char* descr, char* datatype, char* min, char* max, char* unit, char* enums, char* defaultEnum, char* validate, int children) {
-printf("Name=%s, Type=%s, uuid=%s, validate=%s, children=%d, Descr=%s, datatype=%s, min=%s, max=%s Unit=%s, Enums=%s\n", name, type, uuid, validate, children, descr, datatype, min, max, unit, enums);
+void writeNodeData(char* name, char* type, char* uuid, char* descr, char* datatype, char* min, char* max, char* unit, char* allowed, char* defaultAllowed, char* validate, int children) {
+printf("Name=%s, Type=%s, uuid=%s, validate=%s, children=%d, Descr=%s, datatype=%s, min=%s, max=%s Unit=%s, Allowed=%s\n", name, type, uuid, validate, children, descr, datatype, min, max, unit, allowed);
     uint8_t nameLen  = (uint8_t)strlen(name);
     uint8_t typeLen = (uint8_t)strlen(type);
     uint8_t uuidLen  = (uint8_t)strlen(uuid);
@@ -29,17 +29,17 @@ printf("Name=%s, Type=%s, uuid=%s, validate=%s, children=%d, Descr=%s, datatype=
     uint8_t minLen = (uint8_t)strlen(min);
     uint8_t maxLen = (uint8_t)strlen(max);
     uint8_t unitLen = (uint8_t)strlen(unit);
-    uint8_t enumsLen = (uint8_t)strlen(enums);
-    uint8_t defaultEnumLen = (uint8_t)strlen(defaultEnum);
+    uint8_t allowedLen = (uint8_t)strlen(allowed);
+    uint8_t defaultAllowedLen = (uint8_t)strlen(defaultAllowed);
     uint8_t validateLen = (uint8_t)strlen(validate);
     
     if (descrLen > 255) {
         printf("Description length=%d, is larger than 255.\n", descrLen);
         descrLen = 255;
     }
-    if (enumsLen > 255) {
-        printf("Enums length=%d, is larger than 255.\n", enumsLen);
-        enumsLen = 255;
+    if (allowedLen > 255) {
+        printf("Allowed length=%d, is larger than 255.\n", allowedLen);
+        allowedLen = 255;
     }
 
     fwrite(&nameLen, sizeof(uint8_t), 1, treeFp);
@@ -66,13 +66,13 @@ printf("Name=%s, Type=%s, uuid=%s, validate=%s, children=%d, Descr=%s, datatype=
     if (unitLen > 0) {
         fwrite(unit, sizeof(char)*unitLen, 1, treeFp);
     }
-    fwrite(&enumsLen, sizeof(uint8_t), 1, treeFp);
-    if (enumsLen > 0) {
-        fwrite(enums, sizeof(char)*enumsLen, 1, treeFp);
+    fwrite(&allowedLen, sizeof(uint8_t), 1, treeFp);
+    if (allowedLen > 0) {
+        fwrite(allowed, sizeof(char)*allowedLen, 1, treeFp);
     }
-    fwrite(&defaultEnumLen, sizeof(uint8_t), 1, treeFp);
-    if (defaultEnumLen > 0) {
-        fwrite(defaultEnum, sizeof(char)*defaultEnumLen, 1, treeFp);
+    fwrite(&defaultAllowedLen, sizeof(uint8_t), 1, treeFp);
+    if (defaultAllowedLen > 0) {
+        fwrite(defaultAllowed, sizeof(char)*defaultAllowedLen, 1, treeFp);
     }
     fwrite(&validateLen, sizeof(uint8_t), 1, treeFp);
     if (validateLen > 0) {
@@ -81,13 +81,13 @@ printf("Name=%s, Type=%s, uuid=%s, validate=%s, children=%d, Descr=%s, datatype=
     fwrite(&children, sizeof(uint8_t), 1, treeFp);
 }
 
-void createBinaryCnode(char*fname, char* name, char* type, char* uuid, char* descr, char* datatype, char* min, char* max, char* unit, char* enums, char* defaultEnum, char* validate, int children) {
+void createBinaryCnode(char*fname, char* name, char* type, char* uuid, char* descr, char* datatype, char* min, char* max, char* unit, char* allowed, char* defaultAllowed, char* validate, int children) {
     treeFp = fopen(fname, "a");
     if (treeFp == NULL) {
         printf("Could not open file for writing of tree.\n");
         return;
     }
-    writeNodeData(name, type, uuid, descr, datatype, min, max, unit, enums, defaultEnum, validate, children);
+    writeNodeData(name, type, uuid, descr, datatype, min, max, unit, allowed, defaultAllowed, validate, children);
     fclose(treeFp);
 }
 

--- a/binary/c_parser/cparserlib.h
+++ b/binary/c_parser/cparserlib.h
@@ -13,8 +13,8 @@
 typedef enum {SENSOR=1, ACTUATOR, ATTRIBUTE, BRANCH } nodeTypes_t;
 typedef enum {INT8=1, UINT8, INT16, UINT16, INT32, UINT32, DOUBLE, FLOAT, BOOLEAN, STRING, INT8ARRAY, UINT8ARRAY, INT16ARRAY, UINT16ARRAY, INT32ARRAY, UINT32ARRAY, DOUBLEARRAY, FLOATARRAY, BOOLEANARRAY, STRINGARRAY} nodeDatatypes_t;
 
-#define MAXENUMELEMENTLEN 20
-typedef char enum_t[MAXENUMELEMENTLEN];
+#define MAXALLOWEDELEMENTLEN 20
+typedef char allowed_t[MAXALLOWEDELEMENTLEN];
 
 typedef struct node_t {
     uint16_t nameLen;
@@ -31,10 +31,10 @@ typedef struct node_t {
     char* min;
     uint8_t unitLen;
     char* unit;
-    uint8_t enums;
-    enum_t *enumDef;
+    uint8_t allowed;
+    allowed_t *allowedDef;
     uint8_t defaultLen;
-    char* defaultEnum;
+    char* defaultAllowed;
     uint8_t validate;
     uint8_t children;
     struct node_t* parent;
@@ -69,7 +69,7 @@ char* VSSgetName(long nodeHandle);
 char* VSSgetUUID(long nodeHandle);
 int VSSgetValidation(long nodeHandle);
 char* VSSgetDescr(long nodeHandle);
-int VSSgetNumOfEnumElements(long nodeHandle);
-char* VSSgetEnumElement(long nodeHandle, int index);
+int VSSgetNumOfAllowedElements(long nodeHandle);
+char* VSSgetAllowedElement(long nodeHandle, int index);
 char* VSSgetUnit(long nodeHandle);
 

--- a/binary/c_parser/testparser.c
+++ b/binary/c_parser/testparser.c
@@ -91,9 +91,9 @@ void showNodeData(long currentNode, int currentChild) {
         printf("\nNode: name = %s, type = %s, uuid = %s, validate = %d, children = %d,\ndescription = %s\n", VSSgetName(currentNode), getTypeName(VSSgetType(currentNode)), VSSgetUUID(currentNode), VSSgetValidation(currentNode), VSSgetNumOfChildren(currentNode), VSSgetDescr(currentNode));
         if (VSSgetNumOfChildren(currentNode) > 0)
             printf("Node child[%d]=%s\n", currentChild, VSSgetName(VSSgetChild(currentNode, currentChild)));
-//        for (int i = 0 ; i < VSSgetNumOfEnumElements(currentNode) ; i++)
-//            printf("Enum[%d]=%s\n", i, VSSgetEnumElement(currentNode, i));
-        printf("#enums=%d\n", VSSgetNumOfEnumElements(currentNode));
+//        for (int i = 0 ; i < VSSgetNumOfAllowedElements(currentNode) ; i++)
+//            printf("Allowed[%d]=%s\n", i, VSSgetAllowedElement(currentNode, i));
+        printf("#allowed=%d\n", VSSgetNumOfAllowedElements(currentNode));
         nodeDatatypes_t dtype = VSSgetDatatype(currentNode);
         if (dtype != -1)
             printf("Datatype = %d\n", dtype);

--- a/binary/go_parser/datamodel/datamodel.go
+++ b/binary/go_parser/datamodel/datamodel.go
@@ -14,7 +14,7 @@ import "fmt"
 
 type NodeTypes_t uint8
 
-const (   // enum elements of nodeTypes_t
+const (   // allowed elements of nodeTypes_t
     SENSOR = 1
     ACTUATOR = 2
     ATTRIBUTE = 3
@@ -23,7 +23,7 @@ const (   // enum elements of nodeTypes_t
 
 type NodeDatatypes_t uint8
 
-const (   // enum elements of nodeDatatypes_t
+const (   // allowed elements of nodeDatatypes_t
     INT8 = 1
     UINT8 = 2
     INT16 = 3
@@ -55,9 +55,9 @@ type Node_t struct {
     Min string
     Max string
     Unit string
-    Enums uint8
-    EnumDef []string
-    DefaultEnum string
+    Allowed uint8
+    AllowedDef []string
+    DefaultAllowed string
     Validate uint8
     Children uint8
     Parent *Node_t

--- a/binary/go_parser/testparser.go
+++ b/binary/go_parser/testparser.go
@@ -41,8 +41,8 @@ func showNodeData(currentNode *def.Node_t, currentChild int) {
         if (parser.VSSgetNumOfChildren(currentNode) > 0) {
             fmt.Printf("Node child[%d]=%s\n", currentChild, parser.VSSgetName(parser.VSSgetChild(currentNode, currentChild)))
         }
-        for i := 0 ; i < parser.VSSgetNumOfEnumElements(currentNode) ; i++ {
-            fmt.Printf("Enum[%d]=%s\n", i, parser.VSSgetEnumElement(currentNode, i))
+        for i := 0 ; i < parser.VSSgetNumOfAllowedElements(currentNode) ; i++ {
+            fmt.Printf("Allowed[%d]=%s\n", i, parser.VSSgetAllowedElement(currentNode, i))
         }
         dtype := parser.VSSgetDatatype(currentNode)
         if (dtype != 0) {

--- a/tests/model/test_vsstree.py
+++ b/tests/model/test_vsstree.py
@@ -24,7 +24,7 @@ class TestVSSNode(unittest.TestCase):
         Test complex object construction.
         """
         source = {"description": "some desc", "type": "sensor", "uuid": "26d6e362-a422-11ea-bb37-0242ac130002",
-                  "datatype": "uint8", "unit": "km", "min": 0, "max": 100, "enum": ["one", "two"], "aggregate": False,
+                  "datatype": "uint8", "unit": "km", "min": 0, "max": 100, "allowed": ["one", "two"], "aggregate": False,
                   "default": "test-default", "instances": ["i1", "i2"], "$file_name$": "testfile" }
         node = VSSNode("test", source)
         self.assertIsNotNone(node)
@@ -35,7 +35,7 @@ class TestVSSNode(unittest.TestCase):
         self.assertEqual(Unit.KILOMETER, node.unit)
         self.assertEqual(0, node.min)
         self.assertEqual(100, node.max)
-        self.assertEqual(["one", "two"], node.enum)
+        self.assertEqual(["one", "two"], node.allowed)
         self.assertEqual(False, node.aggregate)
         self.assertEqual("test-default", node.default_value)
         self.assertEqual(["i1", "i2"], node.instances)

--- a/vspec/__init__.py
+++ b/vspec/__init__.py
@@ -270,7 +270,7 @@ def load_flat_model(file_name, prefix, include_paths):
 # 1. If no type is specified, default it to "branch".
 # 2. Check that the declared type is a FrancaIDL.
 # 3. Correct the  casing of type.
-# 4, Check that enums are provided as arrays.
+# 4, Check that allowed values are provided as arrays.
 #
 def cleanup_flat_entries(flat_model):
     available_types = ["sensor", "actuator", "branch", "attribute", "UInt8", "Int8", "UInt16", "Int16",
@@ -296,8 +296,8 @@ def cleanup_flat_entries(flat_model):
         # Get the correct casing for the type.
         elem["type"] = available_types[available_downcase_types.index(elem["type"].lower())]
 
-        if "enum" in elem and not isinstance(elem["enum"], list):
-            raise VSpecError(elem["$file_name$"], elem["$line$"], "Enum is not an array.")
+        if "allowed" in elem and not isinstance(elem["allowed"], list):
+            raise VSpecError(elem["$file_name$"], elem["$line$"], "Allowed values are not represented as array.")
 
     return flat_model
 

--- a/vspec/model/vsstree.py
+++ b/vspec/model/vsstree.py
@@ -40,7 +40,7 @@ class VSSNode(Node):
     unit: Unit
     min = ""
     max = ""
-    enum = ""
+    allowed = ""
 
     ttl_name = ""
 
@@ -90,8 +90,8 @@ class VSSNode(Node):
         if "max" in source_dict.keys():
             self.max = source_dict["max"]
 
-        if "enum" in source_dict.keys():
-            self.enum = source_dict["enum"]
+        if "allowed" in source_dict.keys():
+            self.allowed = source_dict["allowed"]
 
         if "aggregate" in source_dict.keys():
             self.aggregate = source_dict["aggregate"]
@@ -280,7 +280,7 @@ class VSSNode(Node):
             raise Exception("Invalid VSS element %s, must have UUID" % name)
 
         for aKey in element.keys():
-            if aKey not in ["type", "children", "datatype", "description", "unit", "uuid", "min", "max", "enum",
+            if aKey not in ["type", "children", "datatype", "description", "unit", "uuid", "min", "max", "allowed",
                             "aggregate", "default" , "instances", "deprecation", "arraysize", "comment", "$file_name$"]:
                 raise NonCoreAttributeException('Non-core attribute "%s" in element %s found.' % (aKey, name))
 

--- a/vspec2binary.py
+++ b/vspec2binary.py
@@ -27,23 +27,23 @@ _cbinary = ctypes.CDLL(dllAbsPath)
 
 out_file="undefined"
 
-#void createBinaryCnode(char* fname, char* name, char* type, char* uuid, char* descr, char* datatype, char* min, char* max, char* unit, char* enums, char* defaultEnum, char* validate, int children);
+#void createBinaryCnode(char* fname, char* name, char* type, char* uuid, char* descr, char* datatype, char* min, char* max, char* unit, char* allowed, char* defaultAllowed, char* validate, int children);
 _cbinary.createBinaryCnode.argtypes = (ctypes.c_char_p,ctypes.c_char_p,ctypes.c_char_p,ctypes.c_char_p,ctypes.c_char_p,ctypes.c_char_p,ctypes.c_char_p,ctypes.c_char_p,ctypes.c_char_p,ctypes.c_char_p,ctypes.c_char_p,ctypes.c_char_p,ctypes.c_int)
 
-def createBinaryCnode(fname, nodename, nodetype, uuid, description, nodedatatype, nodemin, nodemax, unit, enums, defaultEnum, validate, children):
+def createBinaryCnode(fname, nodename, nodetype, uuid, description, nodedatatype, nodemin, nodemax, unit, allowed, defaultAllowed, validate, children):
     global _cbinary
-    _cbinary.createBinaryCnode(fname, nodename, nodetype, uuid, description, nodedatatype, nodemin, nodemax, unit, enums, defaultEnum, validate, children)
+    _cbinary.createBinaryCnode(fname, nodename, nodetype, uuid, description, nodedatatype, nodemin, nodemax, unit, allowed, defaultAllowed, validate, children)
 
-def enumString(enumList):
-    enumStr = ""
-    for elem in enumList:
-        enumStr += hexEnumLen(elem) + elem
-#    print("enumstr=" + enumStr + "\n")
-    return enumStr
+def allowedString(allowedList):
+    allowedStr = ""
+    for elem in allowedList:
+        allowedStr += hexAllowedLen(elem) + elem
+#    print("allowedstr=" + allowedStr + "\n")
+    return allowedStr
 
-def hexEnumLen(enum):
-    hexDigit1 = len(enum) // 16
-    hexDigit2 = len(enum) - hexDigit1*16
+def hexAllowedLen(allowed):
+    hexDigit1 = len(allowed) // 16
+    hexDigit2 = len(allowed) - hexDigit1*16
 #    print("Hexdigs:" + str(hexDigit1) + str(hexDigit2))
     return "".join([intToHexChar(hexDigit1), intToHexChar(hexDigit2)])
 
@@ -58,7 +58,7 @@ def create_node_legacy(key, val, b_nodename, b_nodetype, b_nodeuuid, b_nodedescr
     nodemin = ""
     nodemax = ""
     nodeunit = ""
-    nodeenum = ""
+    nodeallowed = ""
     nodedefault = ""
     nodevalidate = ""
 
@@ -74,8 +74,8 @@ def create_node_legacy(key, val, b_nodename, b_nodetype, b_nodeuuid, b_nodedescr
     if "unit" in val:
         nodeunit = val["unit"]
 
-    if "enum" in val:
-        nodeenum = enumString(val["enum"])
+    if "allowed" in val:
+        nodeallowed = allowedString(val["allowed"])
 
     if "default" in val:
         nodedefault = str(val["default"])
@@ -87,13 +87,13 @@ def create_node_legacy(key, val, b_nodename, b_nodetype, b_nodeuuid, b_nodedescr
     b_nodemin = nodemin.encode('utf-8')
     b_nodemax = nodemax.encode('utf-8')
     b_nodeunit = nodeunit.encode('utf-8')
-    b_nodeenum = nodeenum.encode('utf-8')
+    b_nodeallowed = nodeallowed.encode('utf-8')
     b_nodedefault = nodedefault.encode('utf-8')
     b_nodevalidate = nodevalidate.encode('utf-8')
 
     b_fname = out_file.encode('utf-8')
 
-    createBinaryCnode(b_fname, b_nodename, b_nodetype, b_nodeuuid, b_nodedescription, b_nodedatatype, b_nodemin, b_nodemax, b_nodeunit, b_nodeenum, b_nodedefault, b_nodevalidate, children)
+    createBinaryCnode(b_fname, b_nodename, b_nodetype, b_nodeuuid, b_nodedescription, b_nodedatatype, b_nodemin, b_nodemax, b_nodeunit, b_nodeallowed, b_nodedefault, b_nodevalidate, children)
 
 def create_node(key, val):
     nodename = key

--- a/vspec2csv.py
+++ b/vspec2csv.py
@@ -31,7 +31,7 @@ def format_csv_line(*csv_fields):
 
 #Write the header line
 def print_csv_header(file):
-    file.write(format_csv_line("Signal","Type","DataType","Deprecated","Unit","Min","Max","Desc","Comment","Enum","Id"))
+    file.write(format_csv_line("Signal","Type","DataType","Deprecated","Unit","Min","Max","Desc","Comment","Allowed","Id"))
 
 #Write the data lines
 def print_csv_content(file, tree):
@@ -41,7 +41,7 @@ def print_csv_content(file, tree):
         unit_str = tree_node.unit.value if tree_node.has_unit() else ""
 
         file.write(format_csv_line(
-            tree_node.qualified_name('.'),tree_node.type.value,data_type_str,tree_node.deprecation,unit_str,tree_node.min,tree_node.max,tree_node.description,tree_node.comment,tree_node.enum,tree_node.uuid))
+            tree_node.qualified_name('.'),tree_node.type.value,data_type_str,tree_node.deprecation,unit_str,tree_node.min,tree_node.max,tree_node.description,tree_node.comment,tree_node.allowed,tree_node.uuid))
 
 
 if __name__ == "__main__":

--- a/vspec2franca.py
+++ b/vspec2franca.py
@@ -63,8 +63,8 @@ def traverse_tree(tree, outf, prefix_arr, is_first_element):
         if "unit" in val:
             outf.write("    unit: {}\n".format(val["unit"]))
 
-        if "enum" in val:
-            outf.write("    enum: {}\n".format(val["enum"]))
+        if "allowed" in val:
+            outf.write("    allowed: {}\n".format(val["allowed"]))
 
         if "sensor" in val:
             outf.write("    sensor: {}\n".format(val["sensor"]))

--- a/vspec2json.py
+++ b/vspec2json.py
@@ -33,8 +33,8 @@ def export_node(json_dict, node, generate_uuid):
         json_dict[node.name]["min"] = node.min
     if node.max != "":
         json_dict[node.name]["max"] = node.max
-    if node.enum != "":
-        json_dict[node.name]["enum"] = node.enum
+    if node.allowed != "":
+        json_dict[node.name]["allowed"] = node.allowed
     if node.default_value != "":
         json_dict[node.name]["default"] = node.default_value
     if node.deprecation != "":

--- a/vspec2yaml.py
+++ b/vspec2yaml.py
@@ -35,8 +35,8 @@ def export_node(yaml_dict, node, generate_uuid):
         yaml_dict[node_path]["min"] = node.min
     if node.max != "":
         yaml_dict[node_path]["max"] = node.max
-    if node.enum != "":
-        yaml_dict[node_path]["enum"] = node.enum
+    if node.allowed != "":
+        yaml_dict[node_path]["allowed"] = node.allowed
     if node.default_value != "":
         yaml_dict[node_path]["default"] = node.default_value
     if node.deprecation != "":


### PR DESCRIPTION
With https://github.com/COVESA/vehicle_signal_specification/pull/381 we
decided to move from `enum` to `allowed`. This change enables
the tools in doing so.

What has been done:
* adapted the core parsing (init, vsstree)
* adapted the test cases
* changed serialization `csv`, `franca`, `json`, `yaml`

**TODO**: @UlfBj could you please check what has to be done in the binary serialization
**TODO**: Check contrib

Signed-off-by: Daniel Wilms <Daniel.DW.Wilms@bmw.de>