### PR TITLE
Fixing versioning at setup.py

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -80,11 +80,11 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4",
-                "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"
+                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
+                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.0.6"
+            "version": "==3.0.7"
         },
         "pytest": {
             "hashes": [
@@ -140,14 +140,6 @@
             ],
             "index": "pypi",
             "version": "==6.1.1"
-        },
-        "setuptools": {
-            "hashes": [
-                "sha256:2404879cda71495fc4d5cbc445ed52fdaddf352b36e40be8dcc63147cb4edabe",
-                "sha256:68eb94073fc486091447fcb0501efd6560a0e5a1839ba249e5ff3c4c93f05f90"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==60.5.0"
         },
         "six": {
             "hashes": [

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ version = r.stdout.rstrip().decode('UTF-8')
 # ...otherwise, use abbreviated git commit hash
 if version == '':
     r = subprocess.run(['git', 'rev-parse', '--short=8', 'HEAD'], stdout=subprocess.PIPE)
-    version = r.stdout.rstrip().decode('UTF-8')
+    version ='3.0.dev+' +  r.stdout.rstrip().decode('UTF-8')
 
 setup(
     name='vss-tools',


### PR DESCRIPTION
This may be the error that was making it not possible to install without the editable part issue https://github.com/COVESA/vss-tools/issues/75.

Please look at versioning at

https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#version
https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#pre-release-versioning