### PR TITLE
Fixing instantiation error

### DIFF
--- a/vspec/__init__.py
+++ b/vspec/__init__.py
@@ -379,11 +379,21 @@ def expand_instances(flat_model):
     cont = True
 
     def extend_entry(new_entry, instance, name):
+        # It is expected that name exist in new_entry, either in "name" or "prefix", so two use-cases exist
+        # 1. Name part shall be refactored, e.g. Axle.TireAspectRatio -> Axle.Row1.TireAspectRatio
+        # 2. Prefix part shall be instantiated, e.g. Vehicle.Chassis.Axle.Wheel -> Vehicle.Chassis.Axle.Row2.Wheel
 
-        if base_name in new_entry["$name$"]:
+        if (name==new_entry["$name$"]) or new_entry["$name$"].startswith(name + "."):
             new_entry["$name$"] = new_entry["$name$"].replace(name, "{}.{}".format(name, instance), 1)
         else:
-            new_entry["$prefix$"] = new_entry["$prefix$"].replace(name, "{}.{}".format(name, instance), 1)
+            tmp = new_entry["$prefix$"]
+            search_str = "." + name
+            if tmp.endswith(search_str):
+              # If base is "Seat" and prefix "Vehicle.CabinSeat.Seat" then we want to match last Seat
+              new_entry["$prefix$"] = tmp[:-len(search_str)] + "." + "{}.{}".format(name, instance)
+            else:
+              # If base is "Axle" and prefix "Vehicle.ChassisAxle.Axle.Wheel" then we want to match last Axle
+              new_entry["$prefix$"] = new_entry["$prefix$"].replace("." + name + ".", "." + "{}.{}".format(name, instance) + ".", 1)
         return new_entry
 
     # repetition for nested instances
@@ -458,7 +468,6 @@ def createInstantiationEntries(instances, prefix=''):
 
     if prefix and not prefix.endswith("."):
         prefix += "."
-
     # parse string instantiation elements (e.g. Row[1,5])
     if isinstance(i, str):
         if re.match(reg_ex, i):
@@ -579,14 +588,12 @@ def create_nested_model(flat_model, file_name):
         # we update its fields with the fields from the new element
         if name in parent_branch["children"]:
             old_elem = parent_branch["children"][name]
-            # print "Found: " + str(old_elem)
             # never update the type
             elem.pop("type", None)
             # concatenate file names
             fname = "{}:{}".format(old_elem["$file_name$"], elem["$file_name$"])
             old_elem.update(elem)
             old_elem["$file_name$"] = fname
-            # print "Set: " + str(parent_branch["children"][name])
         else:
             parent_branch["children"][name] = elem
 


### PR DESCRIPTION
Previously instantion failed in some cases

How to reproduce:

Add this at bottom of SingleSeat.vspec

```
Seating:
  type: branch
  description: Describes signals related to the seating/base of the seat.
```

Do "make csv" or any other generation

You will get an error like:

`Error: Cabin/Cabin.vspec: 166: Missing branch: Seat in Vehicle.Cabin.Seat.Seat.Row1.`

Reason is that instantiation code has a bug, in this case it looks for "Seat" branch
but reacts also if it finds "Seating". This PR fixes that.