### PR TITLE
Add Ampere hours as unit

### DIFF
--- a/vspec/config.yaml
+++ b/vspec/config.yaml
@@ -95,6 +95,10 @@ units:
     label: ampere
     description: Electric current measured in amperes
     domain: electric current
+  Ah:
+    label: ampere hours
+    description: Electric charge measured in ampere hours
+    domain: electric charge
   ms:
     label: millisecond
     description: Time measured in milliseconds


### PR DESCRIPTION
We have identified some use-cases that we might contribute to VSS where Ampere hours (Ah) is needed. `Ah` is e.g. a common unit to describe capacity of supply voltage batteries.

If accepted, I will create a corresponding PR for VSS to update documentation.