### PR TITLE
LAYERS: Ability to merge standard VSS models

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -1,57 +1,61 @@
 name: Standard Build Check
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+concurrency:
+  group: ci-check-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  VSS_PATH: ${{ github.workspace }}/vehicle_signal_specification
+  VSS_TOOLS_PATH: ${{ github.workspace }}/vehicle_signal_specification/vss-tools
+  PYTHON_VERSION: "3.8.12"  # keep in sync with vss-tools/Pipfile!
+  CI: 1  # shall any script needs to know if it's running in the CI
 
 jobs:
   buildtest:
+    if: github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - name: Install pyenv
+      - name: Checkout VSS as parent
+        uses: actions/checkout@v3
+        with:
+          repository: COVESA/vehicle_signal_specification
+          path: ${{ env.VSS_PATH }}
+          submodules: false
+      - name: Remove VSS vss-tools from parent
         run: |
-          # Needed for using exact python version, which is
-          # required in `Pipfile`.
-          curl https://pyenv.run | bash
-          export PATH="$HOME/.pyenv/bin:$PATH"
-          pyenv install 3.8.12
-      - name: Install dependencies
+          rm -rf ${{ env.VSS_TOOLS_PATH }}
+      - name: Checkout vss-tools inside vehicle_signal_specification/
+        uses: actions/checkout@v3
+        with:
+          path: ${{ env.VSS_TOOLS_PATH }}
+      - uses: actions/setup-python@v3
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pipenv
+      - name: Install pipenv
         run: |
-          python -V
-          python -m pip --quiet --no-input install --upgrade pip 
+          python -m pip --quiet --no-input install --upgrade pip
           python -m pip --quiet --no-input install --upgrade pipenv wheel
-          pipenv install
-          pipenv run python setup.py -q install
-        env:
-          PIPENV_VENV_IN_PROJECT: 1
-
-      - name: Prepare vss-tools inside VSS
+      - name: Install dependencies with pipenv
         run: |
-          # Go up to parent dir and fetch VSS (master branch) there
-          cd ..
-          git clone https://github.com/GENIVI/vehicle_signal_specification
-
-          # In the parent dir we should find our dir, i.e. vss-tools with
-          # the version that is being tested now.  Put that inside of VSS
-          # dir where it is expected to be.
-          # (Later jobs fail if we remove the working dir entirely, so copy instead of move)
-          rm -rf vehicle_signal_specification/vss-tools
-          cp -a vss-tools vehicle_signal_specification/
-
+          cd ${{ env.VSS_TOOLS_PATH }}
+          pipenv install --deploy --dev
       - name: Test mandatory targets
         run: |
-          # "Our" version of vss-tools was prepared inside VSS => go there and run tests
-          cd ../vehicle_signal_specification
-          pipenv install
-          pipenv run make travis_targets
-        env:
-          PIPENV_PIPFILE: ./vss-tools/Pipfile
-          PIPENV_VENV_IN_PROJECT: 1
-      - name: Test optional targets. NOTE - always succeeds
+          cd ${{ env.VSS_TOOLS_PATH }}
+          pipenv run make -C "${{ env.VSS_PATH }}" travis_targets
+      - name: Test optional targets.
         run: |
-          cd ../vehicle_signal_specification
-          pipenv install
-          pipenv run make -k travis_optional || true
-        env:
-          PIPENV_PIPFILE: ./vss-tools/Pipfile
-          PIPENV_VENV_IN_PROJECT: 1
+          cd ${{ env.VSS_TOOLS_PATH }}
+          pipenv run make -C "${{ env.VSS_PATH }}" -k travis_optional ||
+            echo "::warning title=travis_optional::optional targets FAILED"

--- a/binary/go_parser/go.mod
+++ b/binary/go_parser/go.mod
@@ -3,6 +3,6 @@ module github.com/COVESA/vss-tools/binary/go_parser
 go 1.14
 
 require (
-	github.com/COVESA/vss-tools/binary/go_parser/datamodel v0.0.0-20220112071239-487b135d7f74
-	github.com/COVESA/vss-tools/binary/go_parser/parserlib v0.0.0-20220112071239-487b135d7f74
+	github.com/COVESA/vss-tools/binary/go_parser/datamodel v0.0.0-20220329142604-d2e9f2e54f70
+	github.com/COVESA/vss-tools/binary/go_parser/parserlib v0.0.0-20220329142604-d2e9f2e54f70
 )

--- a/binary/go_parser/testparser.go
+++ b/binary/go_parser/testparser.go
@@ -96,12 +96,12 @@ func main() {
                 var searchPath string
                 fmt.Printf("\nPath to resource(s): ")
                 fmt.Scanf("%s", &searchPath)
-                searchData, foundResponses := parser.VSSsearchNodes(searchPath, root, parser.MAXFOUNDNODES, true, true, nil)
+                searchData, foundResponses := parser.VSSsearchNodes(searchPath, root, parser.MAXFOUNDNODES, true, true, 0, nil, nil)
                 fmt.Printf("\nNumber of elements found=%d\n", foundResponses)
                 for i := 0 ; i < foundResponses ; i++ {
-                    fmt.Printf("Found node type=%s\n", getTypeName(parser.VSSgetType(searchData[i].FoundNodeHandles)))
-                    fmt.Printf("Found node datatype=%d\n", parser.VSSgetDatatype(searchData[i].FoundNodeHandles))
-                    fmt.Printf("Found path=%s\n", searchData[i].ResponsePaths)
+                    fmt.Printf("Found node type=%s\n", getTypeName(parser.VSSgetType(searchData[i].NodeHandle)))
+                    fmt.Printf("Found node datatype=%d\n", parser.VSSgetDatatype(searchData[i].NodeHandle))
+                    fmt.Printf("Found path=%s\n", searchData[i].NodePath)
                 }
             }
             case 'n':  //create node list file "nodelist.txt"
@@ -123,19 +123,19 @@ func main() {
                 var depth int
                 fmt.Printf("\nSubtree depth: ")
                 fmt.Scanf("%d", &depth)
-                searchData, foundResponses := parser.VSSsearchNodes(subTreePath, root, parser.MAXFOUNDNODES, false, false, nil)
-                subtreeNode := searchData[foundResponses-1].FoundNodeHandles
-                subTreeRootName := parser.VSSgetName(searchData[foundResponses-1].FoundNodeHandles)
+                searchData, foundResponses := parser.VSSsearchNodes(subTreePath, root, parser.MAXFOUNDNODES, false, false, 0, nil, nil)
+                subtreeNode := searchData[foundResponses-1].NodeHandle
+                subTreeRootName := parser.VSSgetName(searchData[foundResponses-1].NodeHandle)
                 for i := 1 ; i < depth ; i++ {
                     subTreeRootName += ".*"
                 }
                 fmt.Printf("\nsubTreeRootName=%s\n", subTreeRootName)
-                searchData, foundResponses = parser.VSSsearchNodes(subTreeRootName, subtreeNode, parser.MAXFOUNDNODES, false, false, nil)
+                searchData, foundResponses = parser.VSSsearchNodes(subTreeRootName, subtreeNode, parser.MAXFOUNDNODES, false, false, 0, nil, nil)
                 fmt.Printf("\nNumber of elements found=%d\n", foundResponses)
                 for i := 0 ; i < foundResponses ; i++ {
-                    fmt.Printf("Node type=%d\n", parser.VSSgetType(searchData[i].FoundNodeHandles))
-                    fmt.Printf("Node path=%s\n", searchData[i].ResponsePaths)
-                    fmt.Printf("Node validation=%d\n", parser.VSSgetValidation(searchData[i].FoundNodeHandles))
+                    fmt.Printf("Node type=%d\n", parser.VSSgetType(searchData[i].NodeHandle))
+                    fmt.Printf("Node path=%s\n", searchData[i].NodePath)
+                    fmt.Printf("Node validation=%d\n", parser.VSSgetValidation(searchData[i].NodeHandle))
                 }
             }
             case 'h':  //help

--- a/tests/model/test_vsstree.py
+++ b/tests/model/test_vsstree.py
@@ -25,7 +25,7 @@ class TestVSSNode(unittest.TestCase):
         """
         source = {"description": "some desc", "type": "sensor", "uuid": "26d6e362-a422-11ea-bb37-0242ac130002",
                   "datatype": "uint8", "unit": "km", "min": 0, "max": 100, "allowed": ["one", "two"], "aggregate": False,
-                  "default": "test-default", "instances": ["i1", "i2"], "$file_name$": "testfile" }
+                  "default": "test-default", "$file_name$": "testfile" }
         node = VSSNode("test", source)
         self.assertIsNotNone(node)
         self.assertEqual("some desc", node.description)
@@ -38,7 +38,6 @@ class TestVSSNode(unittest.TestCase):
         self.assertEqual(["one", "two"], node.allowed)
         self.assertEqual(False, node.aggregate)
         self.assertEqual("test-default", node.default_value)
-        self.assertEqual(["i1", "i2"], node.instances)
         self.assertTrue(node.has_unit())
         self.assertTrue(node.has_data_type())
         self.assertFalse(node.is_private())

--- a/vspec/__init__.py
+++ b/vspec/__init__.py
@@ -664,14 +664,18 @@ def merge_tree(base: VSSNode, overlay: VSSNode):
         element_name = "/" + overlay_element.qualified_name("/")
 
         if not VSSNode.node_exists(base, element_name):
+            #The node in the overlay does not exist, so we connect it
+            #print(f"Not exists {overlay_element.qualified_name()} does not exist, creating.")
             new_parent_name = "/" + overlay_element.parent.qualified_name("/")
             new_parent = r.get(base, new_parent_name)
             overlay_element.parent = new_parent
 
-        elif overlay_element.is_leaf:
+        else:
+            # else we merge the node. The merge function of VSSNode is not recursive
+            # so children in base will not be overwritten
+            #print(f"Merging {overlay_element.qualified_name()}")
             other_node: VSSNode = r.get(base, element_name)
             other_node.merge(overlay_element)
-            overlay_element.parent = None
 
 
 def create_tree_uuids(root: VSSNode):

--- a/vspec/__init__.py
+++ b/vspec/__init__.py
@@ -762,6 +762,22 @@ def detect_and_merge(tree_root: VSSNode, private_root: VSSNode):
             private_element.parent = None
 
 
+def merge_tree(base: VSSNode, overlay: VSSNode):
+    r = Resolver()
+    overlay_element: VSSNode
+    for overlay_element in LevelOrderIter(overlay):
+        element_name = "/" + overlay_element.qualified_name("/")
+
+        if not VSSNode.node_exists(base, element_name):
+            new_parent_name = "/" + overlay_element.parent.qualified_name("/")
+            new_parent = r.get(base, new_parent_name)
+            overlay_element.parent = new_parent
+
+        elif overlay_element.is_leaf:
+            other_node = r.get(base, element_name)
+            other_node.merge(overlay_element)
+            overlay_element.parent = None
+
 db_mgr = SignalUUIDManager()
 
 load_flat_model.include_index = 1

--- a/vspec2franca.py
+++ b/vspec2franca.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-#
+# (c) 2022 BMW Group
 # (C) 2016 Jaguar Land Rover
 #
 # All files and artifacts in this repository are licensed under the
@@ -11,122 +11,7 @@
 #
 
 import sys
-import vspec
-import argparse
-
-
-def traverse_tree(tree, outf, prefix_arr, is_first_element):
-    # Convert a prefix array of path elements to a string
-    def prefix_to_string(prefix_arr):
-        if len(prefix_arr) == 0:
-            return ""
-
-        res = prefix_arr[0]
-        for elem in prefix_arr[1:]:
-            res = "{}.{}".format(res, elem)
-
-        return res
-
-
-    # Traverse all elemnts in tree.
-    for key, val in tree.items():
-        # Is this a branch?
-        if "children" in val:
-            # Yes. Recurse
-            traverse_tree(val['children'], outf, prefix_arr + [ key ], is_first_element)
-            continue
-
-        # Drop a comma in before the next element.
-        if not is_first_element:
-            outf.write(",\n")
-
-        outf.write("""{{
-    name: "{}"
-    type: "{}"
-    description: "{}"
-""".format(prefix_to_string(prefix_arr + [ key ]),
-           val['type'],
-           val['description']))
-
-        if "datatype" in val:
-            outf.write("    datatype: {}\n".format(val["datatype"]))
-
-        if "uuid" in val:
-            outf.write("    uuid: {}\n".format(val["uuid"]))
-
-        if "min" in val:
-            outf.write("    min: {}\n".format(val["min"]))
-
-        if "max" in val:
-            outf.write("    max: {}\n".format(val["max"]))
-
-        if "unit" in val:
-            outf.write("    unit: {}\n".format(val["unit"]))
-
-        if "allowed" in val:
-            outf.write("    allowed: {}\n".format(val["allowed"]))
-
-        if "sensor" in val:
-            outf.write("    sensor: {}\n".format(val["sensor"]))
-
-        if "actuator" in val:
-            outf.write("    actuator: {}\n".format(val["actuator"]))
-
-        outf.write("}\n")
-        is_first_element = False
-
+import vspec2x
 
 if __name__ == "__main__":
-    # The arguments we accept
-
-    parser = argparse.ArgumentParser(description='Convert vspec to franca.')
-    parser.add_argument('-I', '--include-dir', action='append',  metavar='dir', type=str, default=[],
-                    help='Add include directory to search for included vspec files.')
-    parser.add_argument('-s', '--strict', action='store_true', help='Use strict checking: Terminate when non-core attribute is found.' )
-    parser.add_argument('-v', '--vssversion', type=str, default="unspecified version",  help='VSS version' )
-    parser.add_argument('vspec_file', metavar='<vspec_file>', help='The vehicle specification file to convert.')
-    parser.add_argument('franca_file', metavar='<franca file>', help='The file to output the Franca IDL spec to.')
-
-    args = parser.parse_args()
-
-    strict=args.strict
-    
-    include_dirs = ["."]
-    include_dirs.extend(args.include_dir)
-
-    franca_out = open(args.franca_file, "w")
-
-    
-    try:
-        tree = vspec.load(args.vspec_file, include_dirs)
-    except vspec.VSpecError as e:
-        print("Error: {}".format(e))
-        sys.exit(255)
-
-    franca_out.write(
-"""// Copyright (C) 2016, GENIVI Alliance
-//
-// This program is licensed under the terms and conditions of the
-// Mozilla Public License, version 2.0.  The full text of the
-// Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
-
-const UTF8String VSS_VERSION = "{}"
-
-struct SignalSpec {{
-    UInt32 id
-    String name
-    String type
-    String description
-}}
-
-const SignalSpec[] signal_spec = [
-""".format(args.vssversion))
-
-    traverse_tree(tree, franca_out, [], True)
-
-    franca_out.write(
-"""
-]
-""")
-
-    franca_out.close()
+    vspec2x.main(["--format", "franca"]+sys.argv[1:])

--- a/vspec2x.py
+++ b/vspec2x.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+# (c) 2022 BMW Group
 # (c) 2022 Robert Bosch GmbH
 # (c) 2016 Jaguar Land Rover
 #
@@ -15,7 +16,7 @@ from enum import Enum
 import sys
 import vspec
 
-from vssexporters import vss2json, vss2csv, vss2yaml, vss2binary
+from vssexporters import vss2json, vss2csv, vss2yaml, vss2binary, vss2franca
 
 
 
@@ -32,6 +33,7 @@ class Exporter(Enum):
     csv = vss2csv
     yaml = vss2yaml
     binary = vss2binary
+    franca = vss2franca
 
     def __str__(self):
         return self.name

--- a/vssexporters/vss2franca.py
+++ b/vssexporters/vss2franca.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+
+# (c) 2021 BMW Group
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
+#
+#
+# Convert vspec tree to franca
+
+
+
+import argparse
+from vspec.model.vsstree import VSSNode, VSSType
+from anytree import PreOrderIter
+    
+def add_arguments(parser: argparse.ArgumentParser):
+   #no additional output for Franca at this moment
+   parser.description="The Franca exporter does not currently support the no-uuid option."
+   parser.add_argument('-v', metavar='version', help=" Add version information to franca file.")
+
+#Write the header line
+def print_franca_header(file, version="unknown"):
+    file.write(f"""
+// Copyright (C) 2022, COVESA
+//
+// This program is licensed under the terms and conditions of the
+// Mozilla Public License, version 2.0.  The full text of the
+// Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
+
+const UTF8String VSS_VERSION = "{version}"
+
+struct SignalSpec {{
+    UInt32 id
+    String name
+    String type
+    String description
+    String datatype
+    String unit
+    Double min
+    Double max
+}}
+
+const SignalSpec[] signal_spec = [
+""")
+
+
+#Write the data lines
+def print_franca_content(file, tree):
+    output = ""
+    for tree_node in PreOrderIter(tree):
+        if tree_node.parent:
+            if output:
+                output += ",\n{"
+            else:
+                output += "{"
+            output += f"\tname: \"{tree_node.qualified_name('.')}\""
+            output += f",\n\ttype: \"{tree_node.type.value}\""
+            output += f",\n\tdescription: \"{tree_node.description}\""
+            if tree_node.has_data_type():
+                output += f",\n\tdatatype: \"{tree_node.data_type.value}\""
+            output += f",\n\tuuid: \"{tree_node.uuid}\""
+            if tree_node.has_unit():
+                output += f",\n\tunit: \"{tree_node.unit.value}\""
+            if tree_node.min:
+                output += f",\n\tmin: {tree_node.min}"
+            if tree_node.max:
+                output += f",\n\tmax: {tree_node.max}"
+            if tree_node.allowed:
+                output += f",\n\tallowed: {tree_node.allowed}"
+            
+            output += "\n}"
+    file.write(f"{output}")
+
+def export(config: argparse.Namespace, root: VSSNode):
+    print("Generating Franca output...")
+    outfile=open(config.output_file,'w')
+    print_franca_header(outfile, config.v)
+    print_franca_content(outfile, root)
+    outfile.write("\n]")
+    outfile.close()


### PR DESCRIPTION
This will enable layers in vss-tools

wave-1 will only support merging "standard" models, adding support for non-standard metadata will be another PR

In all `vspec2x`based tooling, you can add an arbitrary number of overlays that will be applied in the order they appear on the commandline.

The instance expansion needed to be rewritten (to operate on anytree, in the old code it was applied to early, so that overwriting instances would not have ben possible)

Without overlays, it is expected the output of vspec2x is similar to the previous version

## State after this is merged
 - VSS tree can be "extended" via overlays
 - no support for deletion
 - instances can be overwritten
 - no warnings yet hen overwriting core attributes, i.e. you can change a datatype in the VSS standard catalogue using an overlay, and get no warning that this might not be clever
 - no support for arbitrary metadata (accuracy, access control etc.) yet.
 

For sanity check

```bash
sebastian@armbuntu:~/vehicle_signal_specification/vss-tools$ python3 vspec2json.py -I ../spec/ --json-pretty  ../spec/VehicleSignalSpecification.vspec  single.json
Output to json format
Loading vspec from ../spec/VehicleSignalSpecification.vspec...
Calling exporter...
Generating JSON output...
Serializing pretty JSON...
All done.
sebastian@armbuntu:~/vehicle_signal_specification/vss-tools$ python3 vspec2json.py -I ../spec/ --json-pretty  ../spec/VehicleSignalSpecification.vspec  overlay.json
Output to json format
Loading vspec from ../spec/VehicleSignalSpecification.vspec...
Calling exporter...
Generating JSON output...
Serializing pretty JSON...
All done.
sebastian@armbuntu:~/vehicle_signal_specification/vss-tools$ md5sum single.json overlay.json 
15fb22ccb8dd0b19adea16ad44b569bb  single.json
15fb22ccb8dd0b19adea16ad44b569bb  overlay.json
sebastian@armbuntu:~/vehicle_signal_specification/vss-tools$ 
```

For an example with overlay

```
python3 vspec2json.py -I ../spec/ --json-pretty -o test.vspec ../spec/VehicleSignalSpecification.vspec  test.json
```

This is a valid overlay

```yaml
#
# Example overlay
#
Vehicle:
  type: branch



Vehicle.RandomSpeed:
  datatype: float
  type: sensor
  unit: km/h
  description: Average speed for the current trip.


Vehicle.AmbientAirTemperature:
  datatype: float
  type: sensor
  unit: celsius
  min: 2500
  description: Temperature at the surface of the sun



Vehicle.Cabin:
  type: branch
  description: Fancy description for cabin

Vehicle.Ashtray:
  type: branch
  description: Describes stuff in  the Ashtray
```


The failed CI is "fine" it should work after https://github.com/COVESA/vss-tools/pull/156 is merged and this is rebased (because Franka tolling is not optional  in CI even tough it used deprecated parser)

The overlay feature should work with __all__ vspec2x exporters (yaml, json, vs, binary)

Please test @erikbosch @danielwilms
