### PR TITLE
facilitate VSSNode copy

### DIFF
--- a/vspec/model/vsstree.py
+++ b/vspec/model/vsstree.py
@@ -74,6 +74,12 @@ class VSSNode(Node):
                 print("You asked for strict checking. Terminating.")
                 sys.exit(-1)
 
+        # keeping the source dict allows to:
+        #   - create a deep copy of a VSSNode at a later point in time
+        #      by instantiating a new VSSNode with the same source dict
+        #   - trace from which spec file the VSSNode originated
+        self.source_dict = source_dict
+
         self.description = source_dict["description"]
         self.type = VSSType.from_str(source_dict["type"])
         self.uuid = source_dict["uuid"]


### PR DESCRIPTION
In an internal BMW project we have code that creates a copy of a VSSNode but changes the children and parent reference of the freshly created VSSNode. It used to be possible to do that. Since the constructor of the VSSNode now requires the `source_dict` it is no longer easy to create a deep copy of an existing VSSNode. 

To create a deep copy of a VSSNode you currently have to "reconstruct" the source_dict with the info from the VSSNode that is about to be copied:

```
reconstructed_source_dict = { name: old_vsss_node.name, desc: old_vss_node.desc, .... }
copy_of_vss_node = new_vss_node(..., reconstructed_source_dict, ...)
```

Reconstructing the `source_dict` however requires copying all member attributes one by one and would break every time a member attribute is added, removed or renamed in COVESA. Saving the source dict in the VSSNode makes it much easier and more stable to instantiate a new VSSNode with the same source information during runtime.

Additionally this would keep the information which spec file created the VSSNode. This information is currently not saved during instantiating a VSSNode.