### PR TITLE
Exclude marked nodes from instantiation

### DIFF
--- a/tests/instances/resources/instance_exclude_node.vspec
+++ b/tests/instances/resources/instance_exclude_node.vspec
@@ -1,0 +1,31 @@
+Vehicle:
+  type: branch
+  instances: Test[1,4]
+  description: High-level vehicle data.
+
+Vehicle.SomeThing:
+  type: Branch
+  description: "SomeThing description"
+  datatype: string
+
+Vehicle.SomeThing.SomethingLeaf:
+  type: sensor
+  description: "SomethingLeaf description"
+  datatype: string
+
+Vehicle.ExcludeSomeThing:
+  type: Branch
+  description: "ExcludeSomeThing description"
+  datatype: string
+  instantiate: False
+
+Vehicle.ExcludeSomeThing.ExcludeSomethingLeaf:
+  type: actuator
+  description: "ExcludeSomethingLeaf description"
+  datatype: string
+
+Vehicle.ExcludeNode:
+  type: attribute
+  description: "ExcludeNode description"
+  datatype: string
+  instantiate: False

--- a/tests/instances/test_instances.py
+++ b/tests/instances/test_instances.py
@@ -116,3 +116,41 @@ def test_complex_structures (request):
                     assert child_4.children[0].type == VSSType.SENSOR
                     assert child_4.children[0].description == "test"
     
+
+
+### TEST EXCLUSION FROM INSTANCE STRUCTURE ###
+# Goal: Check if exclusion of certain nodes during instantiation work
+# 
+# How: Exclude some nodes from instantiation and check if the
+# structure is the expected one
+#
+### TEST EXCLUSION FROM INSTANCE STRUCTURE ###
+
+# Needed test files
+TEST_FILES_EXCLUDE = [  "resources/instance_exclude_node.vspec"]
+
+def test_exclusion_from_instance (request):
+    test_path = os.path.dirname(request.fspath)
+    for tfs in TEST_FILES_EXCLUDE:
+        # load the file
+        tree = vspec.load_tree(os.path.join(test_path, tfs), [os.path.join(test_path, "resources/")])
+        assert 6 == len (tree.children)
+        name_list = []
+        for child in tree.children:
+            name_list.append(child.qualified_name())
+            if "Vehicle.ExcludeSomeThing" == child.qualified_name():
+                assert VSSType.BRANCH == child.type 
+                assert "ExcludeSomeThing description" == child.description
+                assert 1 == len(child.children)
+                child_2 = child.children[0]
+                assert "Vehicle.ExcludeSomeThing.ExcludeSomethingLeaf" == child_2.qualified_name()
+                assert "ExcludeSomethingLeaf description" == child_2.description
+                assert VSSType.ACTUATOR == child_2.type
+
+            elif "Vehicle.ExcludeNode" == child.qualified_name():
+                assert "Vehicle.ExcludeNode" == child.qualified_name()
+                assert "ExcludeNode description" == child.description
+                assert VSSType.ATTRIBUTE == child.type
+                
+        assert "Vehicle.ExcludeSomeThing" in name_list
+        assert "Vehicle.ExcludeNode" in name_list

--- a/vspec/__init__.py
+++ b/vspec/__init__.py
@@ -330,10 +330,21 @@ def expand_tree_instances(tree):
             # If a node has instances, we first remove all its subbranches.
             # The new children will be branch nodes according to the instance
             # specification.
+            # If a node is be excluded (= instantiate == False), it stays at the current parent.
+            # Otherwise, it's good to go with the instantiation
 
-            savetree = deepcopy(tree_node.children)
+            nodes_to_stay = [] #< nodes excluded from instantiation
+            nodes_to_go = [] #< nodes shall use the instances as parent
 
-            tree_node.children = []
+            for child in tree_node.children:
+                if child.is_instantiated():
+                    nodes_to_go.append(child)
+                else:
+                    nodes_to_stay.append(child)    
+
+            savetree = deepcopy(nodes_to_go)
+
+            tree_node.children = deepcopy(nodes_to_stay)
             unrolled_instances = []
 
             # Instances can be  many things: A string Row[1,4] that is shorthand for a list,
@@ -399,8 +410,7 @@ def expand_tree_instances(tree):
                     # just add them all in parallel as childs of the current loop
                     newbranch = VSSNode(instance, {
                                         "type": "branch", "description": tree_node.description, "$file_name$": "Generated"}, tree_node)
-                    newchilds = []
-
+                    
                     newbranch.children = deepcopy(savetree)
                     #print(f"Created {newbranch}")
 

--- a/vspec/model/vsstree.py
+++ b/vspec/model/vsstree.py
@@ -55,7 +55,7 @@ class VSSNode(Node):
     type: VSSType
     datatype: VSSDataType
 
-    core_attributes = ["type", "children", "datatype", "description", "unit", "uuid", "min", "max", "allowed",
+    core_attributes = ["type", "children", "datatype", "description", "unit", "uuid", "min", "max", "allowed", "instantiate",
                        "aggregate", "default", "instances", "deprecation", "arraysize", "comment", "$file_name$"]
 
     # List of accepted extended attributes. In strict terminate if an attribute is
@@ -66,6 +66,7 @@ class VSSNode(Node):
     min = ""
     max = ""
     allowed = ""
+    instantiate = True
 
     ttl_name = ""
 
@@ -253,6 +254,15 @@ class VSSNode(Node):
         if self.type == VSSType.BRANCH:
             return self.is_leaf
         return False
+    
+    def is_instantiated (self) -> bool:
+        """Checks if node shall be instantiated through its parent
+
+            Returns:
+                True if it shall be instantiated
+        """
+        return self.instantiate
+
 
     def has_unit(self) -> bool:
         """Checks if this instance has a unit


### PR DESCRIPTION
If a node is marked with `instantiate: False` it
won't use the instances as parent, but the original one
instead.

Related to: https://github.com/COVESA/vehicle_signal_specification/issues/448