### PR TITLE
Introducing new contrib structure

### DIFF
--- a/contrib/vspec2ttl/vspec2ttl.py
+++ b/contrib/vspec2ttl/vspec2ttl.py
@@ -31,8 +31,21 @@ from rdflib.namespace import RDFS, OWL, RDF,  SKOS
 from enum import Enum
 
 
+# There are two options of handling branches:
+# 1. branches are handled as _subclasses_ of vehicle components
+# 2. branches are handled as _instances_ of vehicle components
+#
+# As it's not decided for now, we can generate both by setting this
+# variable to True or False. True means that branches are handled as
+# subclasses of vehicle components. False means that branches are handled
+# as instances of vehicle components.
+
+COMPONENTS_AS_CLASSES = False
+
 class VssoCoreConcepts (Enum):
-    
+###
+# Class to define the concepts and their names for later references
+###
     EMPTY =             ""
     BELONGS_TO =        "belongsToVehicleComponent"
     HOLDS_VALUE =       "vehiclePropertyValue"
@@ -63,24 +76,13 @@ class VssoCoreConcepts (Enum):
         return f'{self.ns}{self.value}'
 
 
-def usage():
-    print(f"""
-Usage: {sys.argv[0]} [options] vspec_file ttl_file
-
-  where [options] are:
-
-  -I include_dir       Add include directory to search for included vspec
-                       files. Can be used multiple timees.
-
-  vspec_file           The vehicle specification file to parse.
-
-  ttl_file             The file to output the ttl data to.
-""")
-    sys.exit(255)
-
-
 def setup_graph():
-    # create a Graph
+    ###
+    # function to define the metadata of VSSo,
+    # to define the used prefixes and namespaces,
+    # and to crete the basic rdflib graph
+    ###
+
     g = Graph()
 
     ontology_description_ttl = """
@@ -92,6 +94,7 @@ def setup_graph():
         @prefix vann: <http://purl.org/vocab/vann/> .
         @prefix vsso-core: <https://github.com/w3c/vsso-core#> .
         @prefix vsso: <https://github.com/w3c/vsso#> .
+        @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
 
         vsso: rdf:type owl:Ontology ;
@@ -117,19 +120,14 @@ def setup_graph():
 
     g.parse(data=ontology_description_ttl, format="turtle")
     
-    g.bind ("skos", SKOS)
-    g.bind ("rdfs", RDFS)
-    print("--- printing mboxes ---")
-    print(g.serialize(format='ttl'))
     return g
 
-def setUniqueNodeName (name):
-    if 'Vehicle' != name:
-        return name.replace('Vehicle','').replace('.','')
-    else:
-        return name.replace('.','')
-
 def setTTLName (node):
+    ###
+    # function to set a unique name of a node
+    # which is used in the ontology. Sets a combined name of
+    # the node and its parent, if the parent is not `vehicle`.
+    ###
     if node.ttl_name:
         return node.ttl_name
     if node.parent and node.parent.name != "Vehicle":
@@ -140,25 +138,29 @@ def setTTLName (node):
     return ttl_name 
 
 def print_ttl_content(file, tree):
+    ###
+    # function to create & print the content of the ontology
+    # in turtle format.
+    ###
+
     tree_node: VSSNode
     name_list = []
     vsso_name_list = []
     duplication = {}
     duplication_vsso = {}
     datatypes = {}
-    enums = 0
+    namespace = "https://github.com/w3c/vsso#"
+
 
     graph = setup_graph()
 
-    for tree_node in PreOrderIter(tree):
-        data_type_str = tree_node.data_type.value if tree_node.has_data_type() else ""
-        unit_str = tree_node.unit.value if tree_node.has_unit() else ""
-        type_str = tree_node.type.value 
-        
+    for tree_node in PreOrderIter(tree): #< iterate over the tree in preorder
+        # start with setting the unique name of the node
         name = setTTLName(tree_node)
+
+        # check if the original name is already used
+        # and store for later analysis
         if tree_node.name in name_list:
-            # print (f"** warning: {tree_node.name}" )
-            # print (f"** VSSO warning Replaced by: {name}" )
             if tree_node.name in duplication.keys():
                 duplication [tree_node.name] += 1
             else:
@@ -166,11 +168,10 @@ def print_ttl_content(file, tree):
         else:
             name_list.append (tree_node.name)
 
-        
+        # check if combined name is unique, otherwise
+        # use the parents unique name and combine with the node name
         if name in vsso_name_list:
-            # print (f"** VSSO warning: {name}" )
             name = setTTLName(tree_node.parent) + tree_node.name
-            # print (f"** VSSO warning Replaced by: {name}" )
             
             if name in duplication_vsso.keys():
                 duplication_vsso [name] += 1
@@ -179,24 +180,20 @@ def print_ttl_content(file, tree):
         else:
             vsso_name_list.append (name)
 
-        namespace = "https://github.com/w3c/vsso#"
-
+        # set the URI for the node  
         node = URIRef(namespace + name)
 
-        # not needed, in case we use classes
-        # if VSSType.ATTRIBUTE == tree_node.type:
-        #     node = URIRef(f"{VssoCoreConcepts.EMPTY.uri_string}has{name}")
-        
+        # basic metadata, independent of node type
         graph.add((node, RDFS.label, Literal(name,"en")))
         graph.add((node, VssoCoreConcepts.VSS_CLASSIFICATION.uri, Literal(tree_node.qualified_name('.'),"en")))
         graph.add((node, SKOS.definition, Literal(tree_node.description,"en")))
 
+        # if a comment is set in the VSS node add the comment to the ontology
         if tree_node.comment:
             graph.add((node, RDFS.comment, Literal(tree_node.comment,"en")))
         
-        parent_namespace = "https://github.com/w3c/vsso#"
-        # branch nodes (incl. instance handling)
-        if VSSType.BRANCH == tree_node.type:
+        # branch nodes as vsso:VehicleComponent subclasses if variable is set accordingly
+        if VSSType.BRANCH == tree_node.type and COMPONENTS_AS_CLASSES:
             if tree_node.parent:
                 graph.add((node, RDF.type, OWL.Class))
                 graph.add((node, RDFS.subClassOf, VssoCoreConcepts.VEHICLE_COMP.uri))
@@ -207,46 +204,66 @@ def print_ttl_content(file, tree):
                 if "Vehicle" == setTTLName(tree_node.parent):
                     graph.add((b, OWL.allValuesFrom, VssoCoreConcepts.VEHICLE.uri))
                 else:
-                    graph.add((b, OWL.allValuesFrom, URIRef(parent_namespace + setTTLName(tree_node.parent))))
+                    graph.add((b, OWL.allValuesFrom, URIRef(namespace + setTTLName(tree_node.parent))))
 
                 graph.add((node, RDFS.subClassOf, b))
                 print( [x.name if x.type != VSSType.BRANCH else None for x in tree_node.children])
-
-                
+        # branch nodes as vsso:VehicleComponent instances if variable is set accordingly
+        elif VSSType.BRANCH == tree_node.type and not COMPONENTS_AS_CLASSES:
+            if tree_node.parent:
+                graph.add ((node, RDF.type, VssoCoreConcepts.VEHICLE_COMP.uri))
+                graph.add((node, VssoCoreConcepts.PART_OF_VEH_COMP.uri, URIRef(namespace + setTTLName(tree_node.parent))))
+        # attributes, sensors & actuators
         else:             
             if VSSType.ATTRIBUTE == tree_node.type:
                 graph.add((node, RDF.type, OWL.Class))
                 graph.add((node, RDFS.subClassOf, VssoCoreConcepts.VEHICLE_STAT.uri))
-                b = BNode()
-                graph.add((b, RDF.type, OWL.Restriction))
-                graph.add((b, OWL.onProperty, VssoCoreConcepts.BELONGS_TO.uri))
-                if "Vehicle" == setTTLName(tree_node.parent):
-                    graph.add((b, OWL.allValuesFrom, VssoCoreConcepts.VEHICLE.uri))
-                else:
-                    graph.add((b, OWL.allValuesFrom, URIRef(parent_namespace + setTTLName(tree_node.parent))))
+                if COMPONENTS_AS_CLASSES:
+                    b = BNode()
+                    graph.add((b, RDF.type, OWL.Restriction))
+                    graph.add((b, OWL.onProperty, VssoCoreConcepts.BELONGS_TO.uri))
+                    if "Vehicle" == setTTLName(tree_node.parent):
+                        graph.add((b, OWL.allValuesFrom, VssoCoreConcepts.VEHICLE.uri))
+                    else:
+                        graph.add((b, OWL.allValuesFrom, URIRef(namespace + setTTLName(tree_node.parent))))
 
-                graph.add((node, RDFS.subClassOf, b))
+                    graph.add((node, RDFS.subClassOf, b))
                 
             else: # < vss actuators & sensors 
-
+                # check different datatypes in use
                 if (tree_node.data_type in datatypes.keys()):
                     datatypes[tree_node.data_type] += 1
                 else:
                     datatypes[tree_node.data_type] = 1
 
                 graph.add((node, RDF.type, VssoCoreConcepts.VEHICLE_SIGNAL.uri))
+                graph.add((node, VssoCoreConcepts.BELONGS_TO.uri, URIRef(namespace + setTTLName(tree_node.parent))))
                 
                 if VSSType.ACTUATOR == tree_node.type:
                     graph.add((node, RDF.type, VssoCoreConcepts.VEHICLE_ACT.uri))
 
-
+    # write the file and print the metadata.
     file.write(graph.serialize(format='ttl'))
-
+    for ns, url in graph.namespaces():
+        print(f"@prefix {ns}: <{url}>")
     print (duplication)
     print (duplication_vsso)
     print (datatypes)
 
+def usage():
+    print(f"""
+Usage: {sys.argv[0]} [options] vspec_file ttl_file
 
+  where [options] are:
+
+  -I include_dir       Add include directory to search for included vspec
+                       files. Can be used multiple timees.
+
+  vspec_file           The vehicle specification file to parse.
+
+  ttl_file             The file to output the ttl data to.
+""")
+    sys.exit(255)
 
 if __name__ == "__main__":
     #

--- a/vspec2x.py
+++ b/vspec2x.py
@@ -17,8 +17,7 @@ import sys
 import vspec
 
 from vssexporters import vss2json, vss2csv, vss2yaml, vss2binary, vss2franca, vss2ddsidl, vss2graphql
-
-
+from vssexporters.contrib import vss2ttl
 
 class Exporter(Enum):
     """
@@ -35,6 +34,7 @@ class Exporter(Enum):
     franca = vss2franca
     idl = vss2ddsidl
     graphql = vss2graphql
+    contrib_ttl = vss2ttl
 
     def __str__(self):
         return self.name

--- a/vssexporters/contrib/vss2ttl.py
+++ b/vssexporters/contrib/vss2ttl.py
@@ -1,15 +1,4 @@
-#!/usr/bin/env python3
-
-# (C) 2021 BMW Group - All rights reserved.
-# AUTHOR: Daniel Wilms BMW Group;
-
-#
-#
-#
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
-#
-
+import argparse
 #
 # Convert vspec file to TTL
 #
@@ -75,6 +64,10 @@ class VssoCoreConcepts (Enum):
     def uri_string(self):
         return f'{self.ns}{self.value}'
 
+
+def add_arguments(parser: argparse.ArgumentParser):
+   #no additional output for TTL at this moment
+   parser.description="The TTL exporter does not currently support the no-uuid option."
 
 def setup_graph():
     ###
@@ -250,44 +243,11 @@ def print_ttl_content(file, tree):
     print (duplication_vsso)
     print (datatypes)
 
-def usage():
-    print(f"""
-Usage: {sys.argv[0]} [options] vspec_file ttl_file
 
-  where [options] are:
 
-  -I include_dir       Add include directory to search for included vspec
-                       files. Can be used multiple timees.
 
-  vspec_file           The vehicle specification file to parse.
-
-  ttl_file             The file to output the ttl data to.
-""")
-    sys.exit(255)
-
-if __name__ == "__main__":
-    #
-    # Check that we have the correct arguments
-    #
-    opts, args = getopt.getopt(sys.argv[1:], "I:")
-
-    # Always search current directory for include_file
-    include_dirs = ["."]
-    for o, a in opts:
-        if o == "-I":
-            include_dirs.append(a)
-        else:
-            usage()
-
-    if len(args) != 2:
-        usage()
-
-    try:
-        tree = vspec.load_tree(args[0], include_dirs, False, expand_inst=False)
-        ttl_out = open(args[1], "w")
-        print_ttl_content(ttl_out, tree)
-        ttl_out.write("\n")
-        ttl_out.close()
-    except vspec.VSpecError as e:
-        print(f"Error: {e}")
-        exit(255)
+def export(config: argparse.Namespace, root: VSSNode):
+    print("Generating ttl output...")
+    outfile=open(config.output_file,'w')
+    print_ttl_content(outfile, root)
+    outfile.close()


### PR DESCRIPTION
 Current contrib exporters live without major tool-updates.
 Proposal to do the following:
    1. create exporters for them in `vssexporters/contrib`
    2. dont create shortcut, but call them in Makefile with vspec2x --format <format>