### PR TITLE
DDS export of vss generated IDL fails Fix

### DIFF
--- a/docs/VSS2DDSIDL.md
+++ b/docs/VSS2DDSIDL.md
@@ -50,7 +50,7 @@ Below elements are considered only if the switch ***--all-idl-features*** is sup
 
 | VSS    | DDS-IDL         |
 |--------|----------------|
-| <pre>Direction:<br> datatype:string<br> type: actuator<br> allowed: ['FORWARD','BACKWARD']<br> description: Driving direction of the vehicle</pre>  | <pre>enum DirectionValues{FORWARD,BACKWARD};<br>struct Direction<br>{<br>string uuid;<br>DirectionValues value;<br>};</pre>   
+| <pre>Direction:<br> datatype:string<br> type: actuator<br> allowed: ['FORWARD','BACKWARD']<br> description: Driving direction of the vehicle</pre>  | <pre>module Direction_M {<br>enum DirectionValues{FORWARD,BACKWARD};<br>};<br>struct Direction<br>{<br>string uuid;<br>DirectionValues value;<br>};</pre>   
 
 ## Checking generated DDS-IDL file and generating code stubs from it
 

--- a/tests/vspec/test_datatypes/expected.ddsidl
+++ b/tests/vspec/test_datatypes/expected.ddsidl
@@ -1,55 +1,55 @@
 module A
 {
-struct UInt8
+struct _UInt8
 {
 octet value;
 //const string unit="km";
 //const string type ="sensor";
 //const string description="A uint8.";
 };
-struct Int8
+struct _Int8
 {
 octet value;
 //const string unit="km";
 //const string type ="sensor";
 //const string description="An int8.";
 };
-struct UInt16
+struct _UInt16
 {
 unsigned short value;
 //const string unit="km";
 //const string type ="sensor";
 //const string description="A uint16.";
 };
-struct Int16
+struct _Int16
 {
 short value;
 //const string unit="km";
 //const string type ="sensor";
 //const string description="An int16.";
 };
-struct UInt32
+struct _UInt32
 {
 unsigned short value;
 //const string unit="km";
 //const string type ="sensor";
 //const string description="A uint32.";
 };
-struct Int32
+struct _Int32
 {
 long value;
 //const string unit="km";
 //const string type ="sensor";
 //const string description="An int32";
 };
-struct UInt64
+struct _UInt64
 {
 unsigned long long value;
 //const string unit="km";
 //const string type ="sensor";
 //const string description="A uint64.";
 };
-struct Int64
+struct _Int64
 {
 long long value;
 //const string unit="km";
@@ -62,21 +62,21 @@ boolean value;
 //const string type ="sensor";
 //const string description="A boolean";
 };
-struct Float
+struct _Float
 {
 float value;
 //const string unit="km";
 //const string type ="sensor";
 //const string description="A float.";
 };
-struct Double
+struct _Double
 {
 double value;
 //const string unit="km";
 //const string type ="sensor";
 //const string description="A double.";
 };
-struct String
+struct _String
 {
 string value;
 //const string unit="km";

--- a/tests/vspec/test_types/expected.ddsidl
+++ b/tests/vspec/test_types/expected.ddsidl
@@ -7,7 +7,7 @@ float value;
 //const string type ="sensor";
 //const string description="A sensor.";
 };
-struct Attribute
+struct _Attribute
 {
 float value;
 //const string unit="km";


### PR DESCRIPTION
Added C,Python and IDL keyword crosss checking and appended underscore in front of keywords
Ex: MAP becomes _MAP
Also enums now exist in their own namespace under a module wrapper, the modules name is the enum name+_M
Ex:
module LowVoltageSystemState_M` { enum LowVoltageSystemStateValues{UNDEFINED,LOCK,OFF,ACC,ON,START}; }; struct LowVoltageSystemState { LowVoltageSystemState_M::LowVoltageSystemStateValues value; //const string type ="sensor"; //const string  #description="State of the supply voltage of the control units (usually 12V)."; };
#185 