### PR TITLE
Update setup.py to use current version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ version = r.stdout.rstrip().decode('UTF-8')
 # ...otherwise, use abbreviated git commit hash
 if version == '':
     r = subprocess.run(['git', 'rev-parse', '--short=8', 'HEAD'], stdout=subprocess.PIPE)
-    version ='3.0.dev+' +  r.stdout.rstrip().decode('UTF-8')
+    version ='3.1.dev+' +  r.stdout.rstrip().decode('UTF-8')
 
 setup(
     name='vss-tools',
@@ -19,7 +19,7 @@ setup(
     license='Mozilla Public License v2',
     packages=find_packages(exclude=('tests', 'contrib')),
     scripts=['vspec2csv.py', 'vspec2franca.py', 'vspec2binary.py', 'vspec2json.py','vspec2ddsidl.py', 'vspec2yaml.py', 'contrib/vspec2c.py', 'contrib/vspec2protobuf.py', 'contrib/ocf/vspec2ocf.py'],
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     install_requires=['pyyaml>=5.1', 'anytree>=2.8.0', 'stringcase>=1.2.0', 'deprecation>=2.1.0'],
     tests_require=['pytest>=2.7.2'],
     package_data={'vspec': [


### PR DESCRIPTION
Noticed that we did not update version in this file.
I actually do not think it matters that much, as far as I know it is only used by https://github.com/COVESA/vehicle_signal_specification/blob/master/.github/workflows/buildcheck.yml, but might be important if anyone actually wants to refer to a specific installed version of vss-tools.

Also updating python version to 3.8, as that is the version we use in all buildcheck files

As a side activity I will update https://github.com/COVESA/vehicle_signal_specification/wiki/Release-Instructions-and-Checklist so that we do not forget this file in the future



Signed-off-by: Erik Jaegervall <erik.jaegervall@se.bosch.com>