### PR TITLE
Remove stringcase dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,6 @@ name = "pypi"
 
 [packages]
 anytree = ">=2.8.0"
-stringcase = ">=1.2.0"
 deprecation = ">=2.1.0"
 pytest = ">=2.7.2"
 PyYAML = ">=5.1"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5f0fe003212a3d6562ede3d4852ffc70b8a4cd21293574ad2c440f045596a504"
+            "sha256": "9ab74db2c0c72c2b19c842bef5b1a6511c8489f17400494f7259f34cdf26ed77"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,11 +26,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
-                "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"
+                "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6",
+                "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==21.4.0"
+            "version": "==22.1.0"
         },
         "deprecation": {
             "hashes": [
@@ -42,11 +41,11 @@
         },
         "graphql-core": {
             "hashes": [
-                "sha256:0dda7e63676f119bb3d814621190fedad72fda07a8e9ab780bedd9f1957c6dc6",
-                "sha256:86e2a0be008bfde19ef78388de8a725a1d942a9190ca431c24a60837973803ce"
+                "sha256:9d1bf141427b7d54be944587c8349df791ce60ade2e3cccaf9c56368c133c201",
+                "sha256:f83c658e4968998eed1923a2e3e3eddd347e005ac0315fbb7ca4d70ea9156323"
             ],
             "index": "pypi",
-            "version": "==3.2.0"
+            "version": "==3.2.1"
         },
         "iniconfig": {
             "hashes": [
@@ -67,7 +66,6 @@
                 "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
                 "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==21.3"
         },
         "pluggy": {
@@ -75,7 +73,6 @@
                 "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
                 "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
             ],
-            "markers": "python_version >= '3.6'",
             "version": "==1.0.0"
         },
         "py": {
@@ -83,24 +80,22 @@
                 "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
                 "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==1.11.0"
         },
         "pyparsing": {
             "hashes": [
-                "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea",
-                "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"
+                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.0.7"
+            "version": "==3.0.9"
         },
         "pytest": {
             "hashes": [
-                "sha256:b555252a95bbb2a37a97b5ac2eb050c436f7989993565f5e0c9128fcaacadd0e",
-                "sha256:f1089d218cfcc63a212c42896f1b7fbf096874d045e1988186861a1a87d27b47"
+                "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c",
+                "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"
             ],
             "index": "pypi",
-            "version": "==7.1.0"
+            "version": "==7.1.2"
         },
         "pyyaml": {
             "hashes": [
@@ -143,41 +138,24 @@
         },
         "rdflib": {
             "hashes": [
-                "sha256:8dbfa0af2990b98471dacbc936d6494c997ede92fd8ed693fb84ee700ef6f754",
-                "sha256:fc81cef513cd552d471f2926141396b633207109d0154c8e77926222c70367fe"
+                "sha256:62dc3c86d1712db0f55785baf8047f63731fa59b2682be03219cb89262065942",
+                "sha256:85c34a86dfc517a41e5f2425a41a0aceacc23983462b32e68610b9fad1383bca"
             ],
             "index": "pypi",
-            "version": "==6.1.1"
-        },
-        "setuptools": {
-            "hashes": [
-                "sha256:2347b2b432c891a863acadca2da9ac101eae6169b1d3dfee2ec605ecd50dbfe5",
-                "sha256:e4f30b9f84e5ab3decf945113119649fec09c1fc3507c6ebffec75646c56e62b"
-            ],
-            "markers": "python_version >= '3.7'",
-            "version": "==60.9.3"
+            "version": "==6.2.0"
         },
         "six": {
             "hashes": [
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
-        },
-        "stringcase": {
-            "hashes": [
-                "sha256:48a06980661908efe8d9d34eab2b6c13aefa2163b3ced26972902e3bdfd87008"
-            ],
-            "index": "pypi",
-            "version": "==1.2.0"
         },
         "tomli": {
             "hashes": [
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.7'",
             "version": "==2.0.1"
         },
         "vss-tools": {

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     packages=find_packages(exclude=('tests', 'contrib')),
     scripts=['vspec2csv.py', 'vspec2franca.py', 'vspec2binary.py', 'vspec2json.py','vspec2ddsidl.py', 'vspec2yaml.py', 'contrib/vspec2c.py', 'contrib/vspec2protobuf.py', 'contrib/ocf/vspec2ocf.py'],
     python_requires='>=3.8',
-    install_requires=['pyyaml>=5.1', 'anytree>=2.8.0', 'stringcase>=1.2.0', 'deprecation>=2.1.0'],
+    install_requires=['pyyaml>=5.1', 'anytree>=2.8.0', 'deprecation>=2.1.0'],
     tests_require=['pytest>=2.7.2'],
     package_data={'vspec': [
         'config.yaml'

--- a/tests/model/test_vsstree.py
+++ b/tests/model/test_vsstree.py
@@ -54,7 +54,7 @@ class TestVSSNode(unittest.TestCase):
         node_private_element = VSSNode("Element", source_private_element, node_private)
 
         self.assertTrue(node_private_element.is_private())
-        self.assertEqual("Vehicle.Private.Element", node_private_element.qualified_name('.', StringStyle.NONE))
+        self.assertEqual("Vehicle.Private.Element", node_private_element.qualified_name('.'))
 
     def test_merge_nodes(self):
         """
@@ -79,25 +79,6 @@ class TestVSSNode(unittest.TestCase):
         self.assertEqual(Unit.KILOMETER, node_target.unit)
         self.assertEqual(0, node_target.min)
         self.assertEqual(100, node_target.max)
-
-    def test_string_tyle(self):
-        """
-        Tests string style conversion
-        """
-        source = {"description": "some desc", "type": "sensor", "datatype": "float", "uuid": "26d6e362-a422-11ea-bb37-0242ac130002", "$file_name$": "testfile"}
-        node = VSSNode("test", source)
-
-        self.assertEqual("TEST", node.qualified_name(".", StringStyle.UPPER_CASE))
-        self.assertEqual("Test", node.qualified_name(".", StringStyle.CAPITAL_CASE))
-        self.assertEqual("test", node.qualified_name(".", StringStyle.LOWER_CASE))
-
-        source = {"description": "some desc", "type": "sensor", "datatype": "float", "uuid": "26d6e362-a422-11ea-bb37-0242ac130002", "$file_name$": "testfile"}
-        node = VSSNode("LongerTestName", source)
-        self.assertEqual("LONGERTESTNAME", node.qualified_name(".", StringStyle.UPPER_CASE))
-        self.assertEqual("LongerTestName", node.qualified_name(".", StringStyle.CAPITAL_CASE))
-        self.assertEqual("longertestname", node.qualified_name(".", StringStyle.LOWER_CASE))
-        self.assertEqual("longer_test_name", node.qualified_name(".", StringStyle.SNAKE_CASE))
-        self.assertEqual("longerTestName", node.qualified_name(".", StringStyle.CAMEL_BACK))
 
     def test_tree_find(self):
         """

--- a/vspec/model/vsstree.py
+++ b/vspec/model/vsstree.py
@@ -10,7 +10,6 @@
 
 import sys
 import re
-import stringcase
 import copy
 from anytree import Node, Resolver, ChildResolverError
 
@@ -178,66 +177,22 @@ class VSSNode(Node):
             node = node.parent
         return False
 
-    @staticmethod
-    def case_conversion(source, style: StringStyle) -> str:
-        """Case conversion of the input (usually fully qualified vss node inlcuding the path) into a supported
-         string style representation.
-            Args:
-                source: Source string to apply conversion to.
-                style: Target string style to convert source to.
-
-            Returns:
-                Converted source string according to provided string style.
-         """
-
-        if style == StringStyle.ALPHANUM_CASE:
-            return stringcase.alphanumcase(source)
-        elif style == StringStyle.CAMEL_CASE:
-            return camel_case(source)
-        elif style == StringStyle.CAMEL_BACK:
-            return camel_back(source)
-        elif style == StringStyle.CAPITAL_CASE:
-            return stringcase.capitalcase(source)
-        elif style == StringStyle.CONST_CASE:
-            return stringcase.constcase(source)
-        elif style == StringStyle.LOWER_CASE:
-            return stringcase.lowercase(source)
-        elif style == StringStyle.PASCAL_CASE:
-            return stringcase.pascalcase(source)
-        elif style == StringStyle.SENTENCE_CASE:
-            return stringcase.sentencecase(source)
-        elif style == StringStyle.SNAKE_CASE:
-            return stringcase.snakecase(source)
-        elif style == StringStyle.SPINAL_CASE:
-            return stringcase.spinalcase(source)
-        elif style == StringStyle.TITLE_CASE:
-            return stringcase.titlecase(source)
-        elif style == StringStyle.TRIM_CASE:
-            return stringcase.trimcase(source)
-        elif style == StringStyle.UPPER_CASE:
-            return stringcase.uppercase(source)
-        else:
-            return source
-
-    def qualified_name(self, separator=DEFAULT_SEPARATOR, style=StringStyle.NONE) -> str:
+    def qualified_name(self, separator=DEFAULT_SEPARATOR) -> str:
         """Returns fully qualified name of a VSS object (including path) using the defined separator (or default ='.')
-        and string style (or default = no change)
             Args:
                 separator: Optional parameter as custom separator between path elements of this instance
-                style: Optional parameter to convert VSS instance name using specified string style
 
             Returns:
                 Fully Qualified VSS Node string representation including complete path.
 
         """
 
-        name = VSSNode.case_conversion(self.name, style)
+        name = self.name
 
         path = self
         while not path.is_root:
             path = path.parent
             node_name = path.name
-            node_name = VSSNode.case_conversion(node_name, style)
 
             name = "%s%s%s" % (node_name, separator, name)
         return name


### PR DESCRIPTION
We do not seem to use the functionality, and stringcase might (in some way) trigger the build problems we sometimes see. This PR tests removing it.

**NOTE:**

As can be seen in this PR `stringcase` can be easily removed as we actually do not use the functionality, we always use `NONE` as formatting. The question to be discussed is if we want to remove it, or rather refactor to use another library in case any tool would need it in the future.