### PR TITLE
Support for implicit branches

### DIFF
--- a/tests/vspec/test_overlay/expected.json
+++ b/tests/vspec/test_overlay/expected.json
@@ -1,0 +1,43 @@
+{
+  "A": {
+    "children": {
+      "AA": {
+        "children": {
+          "SignalAA": {
+            "datatype": "uint8",
+            "description": "Changing type to uint8.",
+            "type": "sensor",
+            "unit": "km"
+          }
+        },
+        "description": "Branch A.AA.",
+        "type": "branch"
+      },
+      "AB": {
+        "children": {
+          "SignalAB": {
+            "datatype": "uint8",
+            "description": "New signal in new branch.",
+            "type": "sensor"
+          }
+        },
+        "description": null,
+        "type": "branch"
+      },
+      "SignalA": {
+        "datatype": "int8",
+        "description": "Changing unit to celsius",
+        "type": "sensor",
+        "unit": "celsius"
+      },
+      "SignalA2": {
+        "datatype": "int8",
+        "description": "Adding another signal.",
+        "type": "sensor",
+        "unit": "km"
+      }
+    },
+    "description": "Branch A.",
+    "type": "branch"
+  }
+}

--- a/tests/vspec/test_overlay/overlay_error.vspec
+++ b/tests/vspec/test_overlay/overlay_error.vspec
@@ -1,0 +1,9 @@
+#
+A:
+  type: branch
+  description: Branch A.
+
+A.SignalA:
+  unit: celsius
+  description: We will have an error if type and datatype are not given
+

--- a/tests/vspec/test_overlay/overlay_explicit_branches.vspec
+++ b/tests/vspec/test_overlay/overlay_explicit_branches.vspec
@@ -1,0 +1,36 @@
+#
+A:
+  type: branch
+
+A.SignalA:
+  datatype: int8
+  type: sensor
+  unit: celsius
+  description: Changing unit to celsius
+
+A.SignalA2:
+  datatype: int8
+  type: sensor
+  unit: km
+  description: Adding another signal.
+
+# Changing on second level
+
+A.AA:
+  type: branch
+
+A.AA.SignalAA:
+  type: sensor
+  datatype: uint8
+  description: Changing type to uint8.
+
+# Adding a new branch
+
+A.AB:
+  type: branch
+
+A.AB.SignalAB:
+  type: sensor
+  datatype: uint8
+  description: New signal in new branch.
+

--- a/tests/vspec/test_overlay/overlay_implicit_branches.vspec
+++ b/tests/vspec/test_overlay/overlay_implicit_branches.vspec
@@ -1,0 +1,24 @@
+
+A.SignalA:
+  datatype: int8
+  type: sensor
+  unit: celsius
+  description: Changing unit to celsius
+
+A.SignalA2:
+  datatype: int8
+  type: sensor
+  unit: km
+  description: Adding another signal.
+
+A.AA.SignalAA:
+  type: sensor
+  datatype: uint8
+  description: Changing type to uint8.
+
+A.AB.SignalAB:
+  type: sensor
+  datatype: uint8
+  description: New signal in new branch.
+
+

--- a/tests/vspec/test_overlay/test.vspec
+++ b/tests/vspec/test_overlay/test.vspec
@@ -1,0 +1,22 @@
+#
+A:
+  type: branch
+  description: Branch A.
+
+A.SignalA:
+  datatype: int8
+  type: sensor
+  unit: km
+  description: This is the first signal.
+
+# First second level branch
+
+A.AA:
+  type: branch
+  description: Branch A.AA.
+
+A.AA.SignalAA:
+  datatype: int8
+  type: sensor
+  unit: km
+  description: This is yet another signal.

--- a/tests/vspec/test_overlay/test_overlay.py
+++ b/tests/vspec/test_overlay/test_overlay.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+#
+# (C) 2022 Robert Bosch GmbH
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
+#
+
+import pathlib
+import runpy
+import pytest
+import os
+
+@pytest.fixture
+def change_test_dir(request, monkeypatch):
+    # To make sure we run from test directory
+    monkeypatch.chdir(request.fspath.dirname)
+
+# Only running json exporter, overlay-fucntionality should be independent of selected exporter
+def run_overlay(overlay_file, expected_file):
+    test_str = "../../../vspec2json.py --json-pretty --no-uuid test.vspec -o " + overlay_file + " out.json > out.txt"
+    result = os.system(test_str)
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0
+
+    test_str = "diff out.json " + expected_file
+    result =  os.system(test_str)
+    os.system("rm -f out.json out.txt")
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0
+    
+    
+
+def test_explicit_overlay(change_test_dir):
+    run_overlay("overlay_explicit_branches.vspec", "expected.json")
+    
+def test_implicit_overlay(change_test_dir):
+    run_overlay("overlay_implicit_branches.vspec", "expected.json")
+
+def test_overlay_error(change_test_dir):
+    test_str = "../../../vspec2json.py --json-pretty --no-uuid test.vspec -o overlay_error.vspec out.json > out.txt"
+    result = os.system(test_str)
+    assert os.WIFEXITED(result)
+    # failure expected
+    assert os.WEXITSTATUS(result) != 0
+
+    test_str = 'grep \"Merging impossible\" out.txt > /dev/null'
+    result = os.system(test_str)
+    os.system("cat out.txt")
+    os.system("rm -f out.json out.txt")
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0


### PR DESCRIPTION
A try to implement #183 

I tested with this overlay 

```yaml
#
# Example overlay
#


Vehicle.RandomSpeed:
  datatype: float
  type: sensor
  unit: km/h
  description: Average speed for the current trip.


Vehicle.Cabin.RearShade.Position:
  datatype: uint16
  type: actuator
  min: 0
  max: 1000
  unit: percent
  description: Position of BLINDR

```

like this

```
python vspec2json.py --json-pretty -I ../spec  ../spec/VehicleSignalSpecification.vspec A.json
python vspec2json.py --json-pretty -I ../spec  -o overlay.vspec ../spec/VehicleSignalSpecification.vspec B.json
```

and then checking the diff. 

Definitely needs more testing, and probably some testcases for CI