### PR TITLE
Refactor unit handling

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1,38 +1,24 @@
 # Frequently asked questions
 
-### How to include my own units?
+## How to include my own units?
 
-Standard units are located at the vehicle_signal_specification at the
-(data_unit_types)[https://github.com/COVESA/vehicle_signal_specification/blob/master/docs-gen/content/rule_set/data_entry/data_unit_types.md]
-file. It's not possible to overwrite current units, but if you want to add extra
-units you can create a new file using the same pattern as the current
-(config.yaml)[https://github.com/COVESA/vss-tools/blob/master/vspec/config.yaml].
+Standard VSS units are specified in the vehicle_signal_specification at the
+(data_unit_types)[https://github.com/COVESA/vehicle_signal_specification/blob/master/docs-gen/content/rule_set/data_entry/data_unit_types.md] file.
+Tooling use by default the file (config.yaml)[https://github.com/COVESA/vss-tools/blob/master/vspec/config.yaml]
+which should correspond to the definition in VSS.
 
+It is possible to replace the default units by the `-u` parameter, see [vspec2x documentation](../doc/vspec2x.md).
 
-Suppose I have this file called `my_config.yaml`:
-```yaml
-units:
-  lx:
-    label: lux
-    description: Illuminance measured in lux
-    domain: illuminance
+The syntax of the file with units shall follow this pattern:
+
 ```
-
-The main use is in the `Unit.add_config(my_units)` call.
-Here follows a code that you can use in your part to add units:
-
-```python
-import yaml
-from typing import TextIO, Dict
-from vspec.model.constants import Unit
-
-def get_config_dict(yaml_file: TextIO, key: str) -> Dict[str, Dict[str, str]]:
-    yaml_config = yaml.safe_load(yaml_file)
-    configs = yaml_config.get(key, {})
-    return configs
-
-
-with open('my_config.yaml') as my_yaml_file:
-    my_units = get_config_dict(my_yaml_file, 'units')
-    Unit.add_config(my_units)
+units:
+  puncheon:
+    label: Puncheon
+    description: Volume measure in puncheons (1 puncheon = 318 liters)
+    domain: volume
+  hogshead:
+    label: Hogshead
+    description: Volume measure in hogsheads (1 hogshead = 238 liters)
+    domain: volume
 ```

--- a/docs/vspec2x.md
+++ b/docs/vspec2x.md
@@ -9,14 +9,15 @@ You can get a description of supported commandlines parameters by running `vspec
 This documentation will give some examples and elaborate more on specific parameters.
 
 The supported arguments might look like this
+
  ```
 usage: vspec2x.py [-h] [-I dir] [-e EXTENDED_ATTRIBUTES] [-s] [--abort-on-unknown-attribute] [--abort-on-name-style]
-                  [--format format] [--uuid] [--no-uuid] [-o overlays] [--json-all-extended-attributes] [--json-pretty]
+                  [--format format] [--uuid] [--no-uuid] [-o overlay] [ -u unit_file] [--json-all-extended-attributes] [--json-pretty]
                   [--yaml-all-extended-attributes] [-v version] [--all-idl-features] [--gqlfield GQLFIELD GQLFIELD]
                   <vspec_file> <output_file>
 ```
 
-A common commandline to convert the VSS standard catalogue into a JSON file is
+A common commandline to convert the VSS standard catalog into a JSON file is
 
 ```
 % python vspec2x.py --format json  -I ../spec ../spec/VehicleSignalSpecification.vspec vss.js
@@ -30,7 +31,7 @@ Serializing compact JSON...
 All done.
 ```
 
-This assumes you checked out the [COVESA Vehicle Singal Specification](https://github.com/covesa/vehicle_signal_specification) which contains vss-tools including vspec2x as a submodule.
+This assumes you checked out the [COVESA Vehicle Signal Specification](https://github.com/covesa/vehicle_signal_specification) which contains vss-tools including vspec2x as a submodule.
 
 The `-I` parameter adds a directory to search for includes referenced in you `.vspec` files. `-I` can be used multiple times to specify more include directories.
 
@@ -62,8 +63,25 @@ Request the exporter to output uuids. This setting may not apply to all exporter
 This is currently the default behavior. From VSS 4.0 `--no-uuid` will be the default behavior.
 
 ### --no-uuid
-Request the exporter to not utput uuids.
+Request the exporter to not output uuids.
 From VSS 4.0 this will be the default behavior and then this parameter will be deprecated.
+
+## Handling of units
+
+The tooling verifies that only pre-defined units are used, like `kPa`and `percent`.
+Supported units shall be given as a parameter to tooling with the `-u <file>` parameter.
+`-u` can be used multiple times to specify additional files like in the example below:
+
+```bash
+python ./vss-tools/vspec2csv.py -I ./spec -u vss-tools/vspec/config.yaml -u vss-tools/vspec/extra.yaml --no-uuid ./spec/VehicleSignalSpecification.vspec output.csv
+```
+
+COVESA maintains a unit file for default VSS. It is currently located in [vss-tools](../vspec/config.yaml),
+but will possibly be moved to [VSS repository](https://github.com/COVESA/vehicle_signal_specification/).
+As of today this file is used by default, but that may not be the case any longer when the configuration file has been moved to [VSS repository](https://github.com/COVESA/vehicle_signal_specification/).
+If you specify units by `-u <file>` then the default unit file (`config.yaml`) will not be considered.
+
+See the [FAQ](../FAQ.md) for more information on how to define own units.
 
 ## Handling of overlays and extensions
 `vspec2x` allows composition of several overlays on top of a base vspec, to extend the model or overwrite certain metadata. Check [VSS documentation](https://covesa.github.io/vehicle_signal_specification/introduction/) on the concept of overlays. 
@@ -71,7 +89,7 @@ From VSS 4.0 this will be the default behavior and then this parameter will be d
 To add overlays add one or more `-o` or  `--overlays` parameters, e.g.
 
 ```
-python vspec2yaml.py -I ../spec ../spec/VehicleSignalSpecification.vspec  -o overlay.vspec  withoverlay.yml
+python vspec2yaml.py -I ../spec ../spec/VehicleSignalSpecification.vspec  -o overlay.vspec withoverlay.yml
 ```
 
 You can also use VSS specifications with custom metadata not used in the standard catalogue, for example if your VSS model includes a `source` or `quality` metadata for sensors.
@@ -102,7 +120,7 @@ Warning: Attribute(s) quality, source, lol in element Speed not a core or known 
 You asked for strict checking. Terminating.
 ```
 
-You can whitelist extended metadata attributes using the `-e` parameter with a comma sperated list of attributes
+You can whitelist extended metadata attributes using the `-e` parameter with a comma separated list of attributes
 
 ```
 python vspec2json.py -I ../spec ../spec/VehicleSignalSpecification.vspec -e quality,source -o overlay.vspec   test.json

--- a/tests/model/explicit_units.yaml
+++ b/tests/model/explicit_units.yaml
@@ -1,0 +1,9 @@
+units:
+  puncheon:
+    label: Puncheon
+    description: Volume measure in puncheons (1 puncheon = 318 liters)
+    domain: volume
+  hogshead:
+    label: Hogshead
+    description: Volume measure in hogsheads (1 hogshead = 238 liters)
+    domain: volume

--- a/tests/model/test_contants.py
+++ b/tests/model/test_contants.py
@@ -1,7 +1,7 @@
 import unittest
+import os
 
 from vspec.model.constants import VSSType, VSSDataType, Unit, StringStyle
-
 
 class TestConstantsNode(unittest.TestCase):
     def test_string_styles(self):
@@ -26,11 +26,13 @@ class TestConstantsNode(unittest.TestCase):
     def test_invalid_string_styles(self):
         with self.assertRaises(Exception): StringStyle.from_str("not_a_valid_case")
 
-    def test_units(self):
+    def test_default_units(self):
         """
-        Test correct parsing of units
+        Test correct parsing of default units
         """
 
+        # This test will need to be removed when config.yaml is removed
+        Unit.load_default_config_file()
         self.assertEqual(Unit.MILLIMETER, Unit.from_str("mm"))
         self.assertEqual(Unit.CENTIMETER, Unit.from_str("cm"))
         self.assertEqual(Unit.METER, Unit.from_str("m"))
@@ -72,6 +74,15 @@ class TestConstantsNode(unittest.TestCase):
         self.assertEqual(Unit.NANOMETERPERKILOMETER, Unit.from_str("nm/km"))
         self.assertEqual(Unit.DECIBELMILLIWATT, Unit.from_str("dBm"))
         self.assertEqual(Unit.KILONEWTON, Unit.from_str("kN"))
+
+    def test_manually_loaded_units(self):
+        """
+        Test correct parsing of units
+        """
+        unit_file = os.path.join(os.path.dirname(__file__), 'explicit_units.yaml')
+        Unit.load_config_file(unit_file)
+        self.assertEqual(Unit.PUNCHEON, Unit.from_str("puncheon"))
+        self.assertEqual(Unit.HOGSHEAD, Unit.from_str("hogshead"))
 
     def test_invalid_unit(self):
         with self.assertRaises(Exception): Unit.from_str("not_a_valid_case")

--- a/tests/vspec/test_units/expected_default.json
+++ b/tests/vspec/test_units/expected_default.json
@@ -1,0 +1,14 @@
+{
+  "A": {
+    "children": {
+      "SignalLiter": {
+        "datatype": "float",
+        "description": "Volume in liters.",
+        "type": "sensor",
+        "unit": "l"
+      }
+    },
+    "description": "Branch A.",
+    "type": "branch"
+  }
+}

--- a/tests/vspec/test_units/expected_special.json
+++ b/tests/vspec/test_units/expected_special.json
@@ -1,0 +1,20 @@
+{
+  "A": {
+    "children": {
+      "SignalHogshead": {
+        "datatype": "float",
+        "description": "Volume in hogshead.",
+        "type": "sensor",
+        "unit": "hogshead"
+      },
+      "SignalPuncheon": {
+        "datatype": "float",
+        "description": "Volume in puncheons.",
+        "type": "sensor",
+        "unit": "puncheon"
+      }
+    },
+    "description": "Branch A.",
+    "type": "branch"
+  }
+}

--- a/tests/vspec/test_units/signals_with_default_units.vspec
+++ b/tests/vspec/test_units/signals_with_default_units.vspec
@@ -1,0 +1,12 @@
+#
+A:
+  type: branch
+  description: Branch A.
+
+A.SignalLiter:
+  datatype: float
+  type: sensor
+  unit: l
+  description: Volume in liters.
+
+

--- a/tests/vspec/test_units/signals_with_special_units.vspec
+++ b/tests/vspec/test_units/signals_with_special_units.vspec
@@ -1,0 +1,17 @@
+#
+A:
+  type: branch
+  description: Branch A.
+
+A.SignalPuncheon:
+  datatype: float
+  type: sensor
+  unit: puncheon
+  description: Volume in puncheons.
+  
+A.SignalHogshead:
+  datatype: float
+  type: sensor
+  unit: hogshead
+  description: Volume in hogshead.
+

--- a/tests/vspec/test_units/test_units.py
+++ b/tests/vspec/test_units/test_units.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+#
+# (C) 2022 Robert Bosch GmbH
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
+#
+
+import pathlib
+import runpy
+import pytest
+import os
+
+
+##################### Helper methods #############################
+
+@pytest.fixture
+def change_test_dir(request, monkeypatch):
+    # To make sure we run from test directory
+    monkeypatch.chdir(request.fspath.dirname)
+
+def run_unit(vspec_file, unit_argument, expected_file):
+    test_str = "../../../vspec2json.py --json-pretty --no-uuid " + vspec_file + " " + unit_argument + " out.json > out.txt 2>&1"
+    result = os.system(test_str)
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0
+
+    test_str = "diff out.json " + expected_file
+    result =  os.system(test_str)
+    os.system("rm -f out.json out.txt")
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0
+
+
+def run_unit_error(vspec_file,unit_argument, grep_error):
+    test_str = "../../../vspec2json.py --json-pretty --no-uuid " + vspec_file + " " + unit_argument + " out.json > out.txt 2>&1"
+    result = os.system(test_str)
+    assert os.WIFEXITED(result)
+    # failure expected
+    assert os.WEXITSTATUS(result) != 0
+
+    test_str = 'grep \"' + grep_error + '\" out.txt > /dev/null'
+    result = os.system(test_str)
+    os.system("cat out.txt")
+    os.system("rm -f out.json out.txt")
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0
+
+##################### Tests #############################
+
+#Short form
+def test_single_u(change_test_dir):
+    run_unit("signals_with_special_units.vspec", "-u units_all.yaml","expected_special.json")
+    
+    
+#Short form multiple files
+def test_multiple_u(change_test_dir):
+    run_unit("signals_with_special_units.vspec", "-u units_hogshead.yaml -u units_puncheon.yaml","expected_special.json")
+
+
+#Short form duplication should not matter
+def test_single_u(change_test_dir):
+    run_unit("signals_with_special_units.vspec", "-u units_all.yaml -u units_all.yaml","expected_special.json")
+
+#Long form
+def test_single_unit_files(change_test_dir):
+    run_unit("signals_with_special_units.vspec","--unit-files units_all.yaml","expected_special.json")
+
+#Long form multiple files
+def test_multiple_unit_files(change_test_dir):
+    run_unit("signals_with_special_units.vspec","--unit-files units_hogshead.yaml --unit-files units_puncheon.yaml","expected_special.json")
+
+#Special units not defined
+def test_unit_error(change_test_dir):
+    run_unit_error("signals_with_special_units.vspec","","KeyError")
+
+#Not all units defined
+def test_unit_error(change_test_dir):
+    run_unit_error("signals_with_special_units.vspec","-u units_hogshead.yaml","KeyError")
+
+#FIle not found
+def test_unit_error(change_test_dir):
+    run_unit_error("signals_with_special_units.vspec","-u file_that_does_not_exist.yaml","FileNotFoundError")
+
+##################### Tests related to default units (config.yaml) #############################
+# They will need to be removed if we in the future remove config.yaml from vss-tools
+
+# Test with default unit - shall for now pass - will not pass when default unit support is removed
+def test_default_ok(change_test_dir):
+    run_unit("signals_with_default_units.vspec","","expected_default.json")
+
+# If specifying units default units are ignored
+def test_default_error(change_test_dir):
+    run_unit_error("signals_with_default_units.vspec","-u units_all.yaml","KeyError")

--- a/tests/vspec/test_units/units_all.yaml
+++ b/tests/vspec/test_units/units_all.yaml
@@ -1,0 +1,9 @@
+units:
+  puncheon:
+    label: Puncheon
+    description: Volume measure in puncheons (1 puncheon = 318 liters)
+    domain: volume
+  hogshead:
+    label: Hogshead
+    description: Volume measure in hogsheads (1 hogshead = 238 liters)
+    domain: volume

--- a/tests/vspec/test_units/units_hogshead.yaml
+++ b/tests/vspec/test_units/units_hogshead.yaml
@@ -1,0 +1,5 @@
+units:
+  hogshead:
+    label: Hogshead
+    description: Volume measure in hogsheads (1 hogshead = 238 liters)
+    domain: volume

--- a/tests/vspec/test_units/units_puncheon.yaml
+++ b/tests/vspec/test_units/units_puncheon.yaml
@@ -1,0 +1,5 @@
+units:
+  puncheon:
+    label: Puncheon
+    description: Volume measure in puncheons (1 puncheon = 318 liters)
+    domain: volume

--- a/vspec/model/vsstree.py
+++ b/vspec/model/vsstree.py
@@ -62,6 +62,8 @@ class VSSNode(Node):
     whitelisted_extended_attributes = []
 
     unit: Unit
+    
+    
     min = ""
     max = ""
     allowed = ""
@@ -92,7 +94,7 @@ class VSSNode(Node):
                 VSSNode object according to the Vehicle Signal Specification.
 
         """
-
+        
         super().__init__(name, parent, children)
         try:
             VSSNode.validate_vss_element(source_dict, name)

--- a/vspec2x.py
+++ b/vspec2x.py
@@ -16,6 +16,7 @@ from enum import Enum
 import sys
 import vspec
 from vspec.model.vsstree import VSSNode
+from vspec.model.constants import Unit
 
 from vspec.vssexporters import vss2json, vss2csv, vss2yaml, vss2binary, vss2franca, vss2ddsidl, vss2graphql
 
@@ -69,6 +70,8 @@ def main(arguments):
                         help='Exclude uuid in generated files. This will be default behavior from VSS 4.0 onwards.')
     parser.add_argument('-o', '--overlays', action='append',  metavar='overlays', type=str,  default=[],
                         help='Add overlays that will be layered on top of the VSS file in the order they appear.')
+    parser.add_argument('-u', '--unit-files', action='append',  metavar='unit_files', type=str,  default=[],
+                        help='Unit files to be used for generation.')
     parser.add_argument('vspec_file', metavar='<vspec_file>',
                         help='The vehicle specification file to convert.')
     parser.add_argument('output_file', metavar='<output_file>',
@@ -125,6 +128,14 @@ def main(arguments):
     if args.no_uuid:
         print_uuid = False
     
+    if not args.unit_files:
+        print("WARNING: Use of default VSS unit file is deprecated, please specify the unit file you want to use with the -u argument!")
+        Unit.load_default_config_file()
+    else:
+        for unit_file in args.unit_files:
+           print("Reading unit definitions from "+str(unit_file))
+           Unit.load_config_file(unit_file)
+
     try:
         print(f"Loading vspec from {args.vspec_file}...")
         tree = vspec.load_tree(


### PR DESCRIPTION
We have an old decision to move units to VSS, to separate the metamodel from VSS catalog. This is an attempt of a first step to achieving that by allowing unit files to be given as parameters. As the decision is quite old I would like to have a discussion on if this still is the right way to go.

This is a change that would need to be done in multiple steps, and this PR is not ready for merge yet as there are some things like tests that better shall be added, but the path I see for moving units to VSS completely is as follows:

- First add support in vss-tools to give unit files as parameters (this PR)
- Then copy the current config.yaml to VSS and let all testcases/docs in VSS give it as parameter
- When done and verified, remove the default handling in vss-tools, i.e. request that `-u` always is given if you want to specify units.


Fixes [#396](https://github.com/COVESA/vehicle_signal_specification/issues/396)
Fixes [#346](https://github.com/COVESA/vehicle_signal_specification/issues/346)