### PR TITLE
Unit support, part 2

### DIFF
--- a/binary/README.md
+++ b/binary/README.md
@@ -14,13 +14,13 @@ or, by invoking all tools:
 $ make all
 ```
 
-To <b>run the binary tool without using the make file</b>, the binary tool libray must first be built in the binary directory, then the vspec2binary.py is executed in the root directory:
+To <b>run the binary tool without using the make file</b>, the binary tool library must first be built in the binary directory, then the vspec2binary.py is executed in the root directory:
 
 ```
 $ cd binary
 /binary$ gcc -shared -o binarytool.so -fPIC binarytool.c
 $ cd ..
-$ vspec2binary.py -I ./spec/VehicleSignalSpecification.id ./spec/VehicleSignalSpecification.vspec vss_rel_<current version>.binary
+$ vspec2binary.py -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss.binary
 ```
 where vss_rel_<current version>.binary is the tre file in binary format.
 <br><br>
@@ -31,7 +31,7 @@ Current version is found at https://github.com/COVESA/vehicle_signal_specificati
 Access Control of the signals can be supported by including the extended attribute validate in each of the nodes. This attribute is used by the VISSv2 specification. More information can be found in: <a href="https://www.w3.org/TR/viss2-core/#access-control-selection">VISS Access Control. </a>In case the validate attribute is added to the nodes, it must be specified when invoking the tool using the extended attributes flag (-e): 
 
 ```
-$ vspec2binary.py -e validate -I ./spec/VehicleSignalSpecification.id ./spec/VehicleSignalSpecification.vspec vss_rel_<current version>.binary
+$ vspec2binary.py -e validate -u ./spec/units.yaml ./spec/VehicleSignalSpecification.vspec vss.binary
 ```
 
 

--- a/docs/vspec2x.md
+++ b/docs/vspec2x.md
@@ -20,10 +20,11 @@ usage: vspec2x.py [-h] [-I dir] [-e EXTENDED_ATTRIBUTES] [-s] [--abort-on-unknow
 A common commandline to convert the VSS standard catalog into a JSON file is
 
 ```
-% python vspec2x.py --format json  -I ../spec ../spec/VehicleSignalSpecification.vspec vss.js
+% python vspec2x.py --format json  -I ../spec -u ../spec/units.yaml ../spec/VehicleSignalSpecification.vspec vss.js
 on
 Output to json format
-Known extended attributes: 
+Known extended attributes:
+Reading unit definitions from ../spec/units.yaml
 Loading vspec from ../spec/VehicleSignalSpecification.vspec...
 Calling exporter...
 Generating JSON output...
@@ -33,7 +34,7 @@ All done.
 
 This assumes you checked out the [COVESA Vehicle Signal Specification](https://github.com/covesa/vehicle_signal_specification) which contains vss-tools including vspec2x as a submodule.
 
-The `-I` parameter adds a directory to search for includes referenced in you `.vspec` files. `-I` can be used multiple times to specify more include directories.
+The `-I` parameter adds a directory to search for includes referenced in you `.vspec` files. `-I` can be used multiple times to specify more include directories. The `-u` parameter specifies the unit file to use.
 
 The first positional argument - `../spec/VehicleSignalSpecification.vspec` in the example  - gives the (root) `.vspec` file to be converted. The second positional argument  - `vss.json` in the example - is the output file.
 

--- a/tests/vspec/test_units/test_units.py
+++ b/tests/vspec/test_units/test_units.py
@@ -65,11 +65,11 @@ def test_single_u(change_test_dir):
 
 #Long form
 def test_single_unit_files(change_test_dir):
-    run_unit("signals_with_special_units.vspec","--unit-files units_all.yaml","expected_special.json")
+    run_unit("signals_with_special_units.vspec","--unit-file units_all.yaml","expected_special.json")
 
 #Long form multiple files
 def test_multiple_unit_files(change_test_dir):
-    run_unit("signals_with_special_units.vspec","--unit-files units_hogshead.yaml --unit-files units_puncheon.yaml","expected_special.json")
+    run_unit("signals_with_special_units.vspec","--unit-file units_hogshead.yaml --unit-file units_puncheon.yaml","expected_special.json")
 
 #Special units not defined
 def test_unit_error(change_test_dir):

--- a/vspec2x.py
+++ b/vspec2x.py
@@ -69,9 +69,9 @@ def main(arguments):
     parser.add_argument('--no-uuid', action='store_true',
                         help='Exclude uuid in generated files. This will be default behavior from VSS 4.0 onwards.')
     parser.add_argument('-o', '--overlays', action='append',  metavar='overlays', type=str,  default=[],
-                        help='Add overlays that will be layered on top of the VSS file in the order they appear.')
-    parser.add_argument('-u', '--unit-files', action='append',  metavar='unit_files', type=str,  default=[],
-                        help='Unit files to be used for generation.')
+                        help='Add overlay that will be layered on top of the VSS file in the order they appear.')
+    parser.add_argument('-u', '--unit-file', action='append',  metavar='unit_file', type=str,  default=[],
+                        help='Unit file to be used for generation. Argument -u may be used multiple times.')
     parser.add_argument('vspec_file', metavar='<vspec_file>',
                         help='The vehicle specification file to convert.')
     parser.add_argument('output_file', metavar='<output_file>',
@@ -128,11 +128,11 @@ def main(arguments):
     if args.no_uuid:
         print_uuid = False
     
-    if not args.unit_files:
+    if not args.unit_file:
         print("WARNING: Use of default VSS unit file is deprecated, please specify the unit file you want to use with the -u argument!")
         Unit.load_default_config_file()
     else:
-        for unit_file in args.unit_files:
+        for unit_file in args.unit_file:
            print("Reading unit definitions from "+str(unit_file))
            Unit.load_config_file(unit_file)
 


### PR DESCRIPTION
Extending the unit support work:

- Adapting contrib tools, they were not included in the previous PR
- Minor change in vspec2x to make it more clear that you need to give `-u`multiple times to include additional unit files
- A minor fix to support Python 3.10 