### PR TITLE
Generalize cleanup solution

### DIFF
--- a/tests/vspec/test_overlay/expected.json
+++ b/tests/vspec/test_overlay/expected.json
@@ -26,7 +26,24 @@
       },
       "SignalA": {
         "datatype": "int8",
-        "description": "Changing unit to celsius",
+        "dbc": {
+          "changetype": "ON_CHANGE",
+          "interval_ms": 1000,
+          "signal": "VCFRONT_passengerPresent",
+          "transform": {
+            "mapping": [
+              {
+                "from": 0,
+                "to": false
+              },
+              {
+                "from": 1,
+                "to": true
+              }
+            ]
+          }
+        },
+        "description": "Changing unit to celsius and adding complex deployment info",
         "type": "sensor",
         "unit": "celsius"
       },

--- a/tests/vspec/test_overlay/overlay_explicit_branches.vspec
+++ b/tests/vspec/test_overlay/overlay_explicit_branches.vspec
@@ -6,7 +6,17 @@ A.SignalA:
   datatype: int8
   type: sensor
   unit: celsius
-  description: Changing unit to celsius
+  description: Changing unit to celsius and adding complex deployment info
+  dbc:
+    signal: VCFRONT_passengerPresent
+    transform:
+      mapping:
+        - from: 0
+          to: false
+        - from: 1
+          to: true
+    changetype: ON_CHANGE
+    interval_ms: 1000
 
 A.SignalA2:
   datatype: int8

--- a/tests/vspec/test_overlay/overlay_implicit_branches.vspec
+++ b/tests/vspec/test_overlay/overlay_implicit_branches.vspec
@@ -3,7 +3,17 @@ A.SignalA:
   datatype: int8
   type: sensor
   unit: celsius
-  description: Changing unit to celsius
+  description: Changing unit to celsius and adding complex deployment info
+  dbc:
+    signal: VCFRONT_passengerPresent
+    transform:
+      mapping:
+        - from: 0
+          to: false
+        - from: 1
+          to: true
+    changetype: ON_CHANGE
+    interval_ms: 1000
 
 A.SignalA2:
   datatype: int8

--- a/tests/vspec/test_overlay/test_overlay.py
+++ b/tests/vspec/test_overlay/test_overlay.py
@@ -19,7 +19,7 @@ def change_test_dir(request, monkeypatch):
 
 # Only running json exporter, overlay-fucntionality should be independent of selected exporter
 def run_overlay(overlay_file, expected_file):
-    test_str = "../../../vspec2json.py --json-pretty --no-uuid test.vspec -o " + overlay_file + " out.json > out.txt"
+    test_str = "../../../vspec2json.py --json-pretty -e dbc --no-uuid test.vspec -o " + overlay_file + " out.json > out.txt"
     result = os.system(test_str)
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) == 0

--- a/vspec2x.py
+++ b/vspec2x.py
@@ -149,6 +149,7 @@ def main(arguments):
 
         vspec.expand_tree_instances(tree)
 
+        vspec.clean_metadata(tree);
         print("Calling exporter...")
         exporter.export(args, tree, print_uuid)
         print("All done.")


### PR DESCRIPTION
The previous limitation to only clean branches will give problems when supporting structs, but also if using structured extended attributes.

The problem can be seen by running the included overlay example without the fix, then some unwanted metadata will be printed.