### PR TITLE
Run mypy and remove some warnings on skipped methods

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -59,3 +59,10 @@ jobs:
           cd ${{ env.VSS_TOOLS_PATH }}
           pipenv run make -C "${{ env.VSS_PATH }}" -k travis_optional ||
             echo "::warning title=travis_optional::optional targets FAILED"
+      - name: Run mypy.
+        run: |
+          cd ${{ env.VSS_TOOLS_PATH }}
+          pipenv install mypy types-setuptools types-PyYAML
+          # For now always let mypy succeed - can be changed when all errors reported have been fixed or suppressed
+          pipenv run mypy *.py vspec tests contrib ||
+            echo "::warning title=mypy::Errors reported"

--- a/contrib/vspec2protobuf.py
+++ b/contrib/vspec2protobuf.py
@@ -31,7 +31,7 @@ mapped = {
 }
 
 
-def traverse_tree(tree, proto_file):
+def traverse_tree(tree : VSSNode, proto_file):
     tree_node: VSSNode
     for tree_node in filter(lambda n: n.is_branch(), PreOrderIter(tree)):
         proto_file.write(f"message {tree_node.qualified_name('')} {{" + "\n")

--- a/contrib/vspec2ttl/vspec2ttl.py
+++ b/contrib/vspec2ttl/vspec2ttl.py
@@ -141,7 +141,7 @@ def setTTLName (node):
     node.ttl_name  = ttl_name
     return ttl_name 
 
-def print_ttl_content(file, tree):
+def print_ttl_content(file, tree : VSSNode):
     ###
     # function to create & print the content of the ontology
     # in turtle format.

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     install_requires=['pyyaml>=5.1', 'anytree>=2.8.0', 'deprecation>=2.1.0'],
     tests_require=['pytest>=2.7.2'],
     package_data={'vspec': [
-        'config.yaml'
+        'config.yaml',
+        'py.typed'
     ]},
 )

--- a/vspec/__init__.py
+++ b/vspec/__init__.py
@@ -305,7 +305,7 @@ def expand_includes(flat_model, prefix, include_paths):
     return new_flat_model
 
 
-def expand_tree_instances(tree):
+def expand_tree_instances(tree : VSSNode) -> VSSNode:
     tree_node: VSSNode
     exporter = DictExporter()
     importer = DictImporter(nodecls=VSSNode)

--- a/vspec/vssexporters/vss2csv.py
+++ b/vspec/vssexporters/vss2csv.py
@@ -34,7 +34,7 @@ def format_csv_line(csv_fields):
     return formatted_csv_line[:-1] + '\n'
 
 #Write the data lines
-def print_csv_content(file, tree, uuid):
+def print_csv_content(file, tree : VSSNode, uuid):
     tree_node: VSSNode
     for tree_node in PreOrderIter(tree):
         data_type_str = tree_node.datatype.value if tree_node.has_datatype() else ""


### PR DESCRIPTION
This change results in that mypy is run as part of CI.
Mypy reports as of today some errors. Some of them shall better be fixed, other suppressed.
Currently the build succeeds even if mypy reports errors.
We can later when all errors have been fixed/suppressed change it so the build fails if mypy complains