### PR TITLE
Improve error handling on units and datatypes

### DIFF
--- a/contrib/vspec2protobuf.py
+++ b/contrib/vspec2protobuf.py
@@ -69,13 +69,7 @@ if __name__ == "__main__":
     include_dirs = ["."]
     include_dirs.extend(args.include_dir)
 
-    if not args.unit_file:
-        print("WARNING: Use of default VSS unit file is deprecated, please specify the unit file you want to use with the -u argument!")
-        Unit.load_default_config_file()
-    else:
-        for unit_file in args.unit_file:
-           print("Reading unit definitions from "+str(unit_file))
-           Unit.load_config_file(unit_file)
+    vspec.load_units(args.vspec_file, args.unit_file)
 
     proto_file = open(args.output_file, "w")
     proto_file.write('syntax = "proto3";\n\n')

--- a/contrib/vspec2ttl/vspec2ttl.py
+++ b/contrib/vspec2ttl/vspec2ttl.py
@@ -65,7 +65,7 @@ class VssoCoreConcepts (Enum):
     VEHICLE_COMP =      "VehicleComponent"
     VEHICLE_PROP =      "DynamicVehicleProperty"
     VEHICLE_STAT =      "StaticVehicleProperty"
-    
+
 
     def __init__ (self, vsso_name):
         self.ns = "https://github.com/w3c/vsso-core#"
@@ -123,7 +123,7 @@ def setup_graph():
         """
 
     g.parse(data=ontology_description_ttl, format="turtle")
-    
+
     return g
 
 def setTTLName (node):
@@ -136,10 +136,10 @@ def setTTLName (node):
         return node.ttl_name
     if node.parent and node.parent.name != "Vehicle":
         ttl_name = node.parent.name + node.name
-    else:    
+    else:
         ttl_name = node.name
     node.ttl_name  = ttl_name
-    return ttl_name 
+    return ttl_name
 
 def print_ttl_content(file, tree : VSSNode):
     ###
@@ -176,7 +176,7 @@ def print_ttl_content(file, tree : VSSNode):
         # use the parents unique name and combine with the node name
         if name in vsso_name_list:
             name = setTTLName(tree_node.parent) + tree_node.name
-            
+
             if name in duplication_vsso.keys():
                 duplication_vsso [name] += 1
             else:
@@ -184,7 +184,7 @@ def print_ttl_content(file, tree : VSSNode):
         else:
             vsso_name_list.append (name)
 
-        # set the URI for the node  
+        # set the URI for the node
         node = URIRef(namespace + name)
 
         # basic metadata, independent of node type
@@ -195,7 +195,7 @@ def print_ttl_content(file, tree : VSSNode):
         # if a comment is set in the VSS node add the comment to the ontology
         if tree_node.comment:
             graph.add((node, RDFS.comment, Literal(tree_node.comment,"en")))
-        
+
         # branch nodes as vsso:VehicleComponent subclasses if variable is set accordingly
         if VSSType.BRANCH == tree_node.type and COMPONENTS_AS_CLASSES:
             if tree_node.parent:
@@ -217,10 +217,10 @@ def print_ttl_content(file, tree : VSSNode):
             graph.add ((node, RDF.type, VssoCoreConcepts.VEHICLE_COMP.uri))
             if tree_node.parent:
                 graph.add((node, VssoCoreConcepts.PART_OF_VEH_COMP.uri, URIRef(namespace + setTTLName(tree_node.parent))))
-            
-                
+
+
         # attributes, sensors & actuators
-        else:             
+        else:
             if VSSType.ATTRIBUTE == tree_node.type:
                 graph.add((node, RDF.type, OWL.Class))
                 graph.add((node, RDFS.subClassOf, VssoCoreConcepts.VEHICLE_STAT.uri))
@@ -234,8 +234,8 @@ def print_ttl_content(file, tree : VSSNode):
                         graph.add((b, OWL.allValuesFrom, URIRef(namespace + setTTLName(tree_node.parent))))
 
                     graph.add((node, RDFS.subClassOf, b))
-                
-            else: # < vss actuators & sensors 
+
+            else: # < vss actuators & sensors
                 # check different datatypes in use
                 if (tree_node.datatype in datatypes.keys()):
                     datatypes[tree_node.datatype] += 1
@@ -244,7 +244,7 @@ def print_ttl_content(file, tree : VSSNode):
 
                 graph.add((node, RDF.type, VssoCoreConcepts.VEHICLE_SIGNAL.uri))
                 graph.add((node, VssoCoreConcepts.BELONGS_TO.uri, URIRef(namespace + setTTLName(tree_node.parent))))
-                
+
                 if VSSType.ACTUATOR == tree_node.type:
                     graph.add((node, RDF.type, VssoCoreConcepts.VEHICLE_ACT.uri))
 
@@ -277,13 +277,7 @@ if __name__ == "__main__":
     include_dirs = ["."]
     include_dirs.extend(args.include_dir)
 
-    if not args.unit_file:
-        print("WARNING: Use of default VSS unit file is deprecated, please specify the unit file you want to use with the -u argument!")
-        Unit.load_default_config_file()
-    else:
-        for unit_file in args.unit_file:
-           print("Reading unit definitions from "+str(unit_file))
-           Unit.load_config_file(unit_file)
+    vspec.load_units(args.vspec_file, args.unit_file)
 
     try:
         tree = vspec.load_tree(args.vspec_file, include_dirs, False, expand_inst=False)

--- a/tests/vspec/test_datatypes_error/test.vspec
+++ b/tests/vspec/test_datatypes_error/test.vspec
@@ -1,0 +1,10 @@
+#
+A:
+  type: branch
+  description: Branch A.
+
+A.UInt7:
+  datatype: uint7
+  type: sensor
+  unit: km
+  description: Oops, that datatype does not exist!

--- a/tests/vspec/test_datatypes_error/test_datatypes_error.py
+++ b/tests/vspec/test_datatypes_error/test_datatypes_error.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+
+#
+# (C) 2023 Robert Bosch GmbH
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
+#
+
+import pathlib
+import runpy
+import pytest
+import os
+
+
+##################### Helper methods #############################
+
+@pytest.fixture
+def change_test_dir(request, monkeypatch):
+    # To make sure we run from test directory
+    monkeypatch.chdir(request.fspath.dirname)
+
+def test_datatype_error(change_test_dir):
+    test_str = "../../../vspec2json.py --json-pretty --no-uuid test.vspec out.json > out.txt 2>&1"
+    result = os.system(test_str)
+    assert os.WIFEXITED(result)
+    # failure expected
+    assert os.WEXITSTATUS(result) != 0
+
+    test_str = 'grep \"Following types were referenced in signals but have not been defined\" out.txt > /dev/null'
+    result = os.system(test_str)
+    os.system("cat out.txt")
+    os.system("rm -f out.json out.txt")
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0

--- a/tests/vspec/test_units/test_units.py
+++ b/tests/vspec/test_units/test_units.py
@@ -52,8 +52,8 @@ def run_unit_error(vspec_file,unit_argument, grep_error):
 #Short form
 def test_single_u(change_test_dir):
     run_unit("signals_with_special_units.vspec", "-u units_all.yaml","expected_special.json")
-    
-    
+
+
 #Short form multiple files
 def test_multiple_u(change_test_dir):
     run_unit("signals_with_special_units.vspec", "-u units_hogshead.yaml -u units_puncheon.yaml","expected_special.json")
@@ -73,11 +73,11 @@ def test_multiple_unit_files(change_test_dir):
 
 #Special units not defined
 def test_unit_error_no_unit_file(change_test_dir):
-    run_unit_error("signals_with_special_units.vspec","","KeyError")
+    run_unit_error("signals_with_special_units.vspec","","Error: Unknown unit")
 
 #Not all units defined
 def test_unit_error_unit_file_incomplete(change_test_dir):
-    run_unit_error("signals_with_special_units.vspec","-u units_hogshead.yaml","KeyError")
+    run_unit_error("signals_with_special_units.vspec","-u units_hogshead.yaml","Error: Unknown unit")
 
 #FIle not found
 def test_unit_error_missing_file(change_test_dir):
@@ -92,4 +92,4 @@ def test_default_ok(change_test_dir):
 
 # If specifying units default units are ignored
 def test_default_error(change_test_dir):
-    run_unit_error("signals_with_default_units.vspec","-u units_all.yaml","KeyError")
+    run_unit_error("signals_with_default_units.vspec","-u units_all.yaml","Error: Unknown unit")

--- a/vspec/model/constants.py
+++ b/vspec/model/constants.py
@@ -147,7 +147,7 @@ class VSSType(Enum, metaclass=EnumMetaWithReverseLookup):
     ACTUATOR = "actuator"
     STRUCT = "struct"
     PROPERTY = "property"
-    
+
 
 class VSSDataType(Enum, metaclass=EnumMetaWithReverseLookup):
     INT8 = "int8"
@@ -194,10 +194,13 @@ class Unit(metaclass=VSSRepositoryMeta):
        return configs
 
     @staticmethod
-    def load_config_file(config_file:str):
+    def load_config_file(config_file:str) -> int:
+        added_configs = 0
         with open(config_file) as my_yaml_file:
             my_units = Unit.get_config_dict(my_yaml_file, 'units')
+            added_configs = len(my_units)
             Unit.add_config(my_units)
+        return added_configs
 
     @staticmethod
     def load_default_config_file():
@@ -208,7 +211,7 @@ class Unit(metaclass=VSSRepositoryMeta):
 
 class VSSTreeType(Enum, metaclass=EnumMetaWithReverseLookup):
     SIGNAL_TREE = "signal_tree"
-    DATA_TYPE_TREE = "data_type_tree" 
+    DATA_TYPE_TREE = "data_type_tree"
 
     def available_types(self):
         available_types = set(["UInt8", "Int8", "UInt16", "Int16",

--- a/vspec/model/vsstree.py
+++ b/vspec/model/vsstree.py
@@ -143,7 +143,12 @@ class VSSNode(Node):
 
         # Units are applicable only for primitives. Not user defined types.
         if "unit" in self.source_dict.keys() and self.has_datatype():
-            self.unit = Unit.from_str(self.source_dict["unit"])
+            unit = self.source_dict["unit"]
+            try:
+                self.unit = Unit.from_str(unit)
+            except KeyError as e:
+                logging.error(f"Error: Unknown unit {unit} for signal {self.qualified_name()}. Terminating.")
+                sys.exit(-1)
 
         if self.has_instances() and not self.is_branch():
             logging.error(

--- a/vspec2x.py
+++ b/vspec2x.py
@@ -20,6 +20,7 @@ import argparse
 import logging
 import sys
 import vspec
+import os
 
 
 from vspec.vssexporters import vss2json, vss2csv, vss2yaml, vss2binary, vss2franca, vss2ddsidl, vss2graphql
@@ -147,14 +148,7 @@ def main(arguments):
     if args.no_uuid:
         print_uuid = False
 
-    if not args.unit_file:
-        logging.warning(
-            "Use of default VSS unit file is deprecated, please specify the unit file you want to use with the -u argument!")
-        Unit.load_default_config_file()
-    else:
-        for unit_file in args.unit_file:
-            logging.info("Reading unit definitions from " + str(unit_file))
-            Unit.load_config_file(unit_file)
+    vspec.load_units(args.vspec_file, args.unit_file)
 
     # process data type tree
     data_type_tree = None


### PR DESCRIPTION
Fixes #215

This PR emits understandable errors for 3 scenarios:

- If there is no units found in provided (or default) unit files an error will be given and execution terminate
- If unit lookup fails a reasonable error (unknown unit for signal X) instead of just a KeyError exception
- If datatype lookup fails a reasonable error (unknown datatype for signal X) instead of just a KeyError exception

It also add informational printout on how many units that have been collected. With these changes it should be easier to identify that the unit files your loaded had errors.