### PR TITLE
Update changelog for -u

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ It includes changes that are included in released version, but also changes plan
 Overlays introduced to allow customization of VSS. See [documentation](https://covesa.github.io/vehicle_signal_specification/rule_set/overlay/).
 See [vss-tools documentation](https://github.com/COVESA/vss-tools/blob/master/docs/vspec2x.md) on how to include overlays when transforming VSS.
 
-## Planned Changes VSS-Tools 3.1
+## Merged Changes for next release (VSS-Tools 3.1)
+
+*This is changes that has been merged on master but not yet released*
 
 ### Change in UUID handling.
 
@@ -39,6 +41,19 @@ For VSS-Tools 3.1 the following behavior is implemented:
 The tools vspec2c and vspec2ocf in the contrib folder has been moved to the obsolete folder.
 The background is that they have been broken for a long period and no one has volunteered to fix them.
 
+### Support for specifying unit files
+
+Add new parameter `-u` has been introduced, see [documentation](https://github.com/COVESA/vss-tools/blob/master/docs/vspec2x.md#handling-of-units).
+Use of default unit file deprecated.
+At the same time a unit file has been added to [VSS](https://github.com/COVESA/vehicle_signal_specification/blob/master/spec/units.yaml),
+allowing VSS tooling to control their own units rather than relying on units in VSS-tools.
+Default behavior for units have changed, if there is a file `units.yaml` in the same directory as the `*.vspec`
+file it will be used, only if not existing `config.yaml` in vss-tools will be used.
+
+## Planned Changes for next release (VSS-Tools 3.1)
+
+*This is changes planned but not yet merged to master*
+
 ## Planned Changes VSS-Tools 4.0
 
 ### Change in UUID handling.
@@ -50,13 +65,19 @@ For VSS-Tools 4.0 the following behavior shall be implemented:
 * No warning shall be given if neither `--uuid` nor `--no-uuid` is used.
 * If both `--uuid` and `--no-uuid` is used an error shall be given.
 
+### Default unit file to be removed from vss-tools
+
+The [default unit file](https://github.com/COVESA/vss-tools/blob/master/vspec/config.yaml)
+will be removed from VSS-tools. This means that either a file `units.yaml` in the same directory as the `*.vspec`
+file must exist, or a unit file must be specified by `-u`.
+From now on, if new units are needed for the VSS catalog they shall be added to the
+[VSS catalog file](https://github.com/COVESA/vehicle_signal_specification/blob/master/spec/units.yaml).
 
 ## Planned Changes VSS-Tools 5.0
 
 
-### Change in UUID handling. 
+### Change in UUID handling.
 
 For VSS-Tools 5.0 the following behavior shall be implemented:
 
 * The parameter `--no-uuid` shall now be removed, and an error shall be given if `--no-uuid` is used.
-

--- a/docs/vspec2x.md
+++ b/docs/vspec2x.md
@@ -2,9 +2,9 @@
 
 vspec2x is a family of VSS converters that share a common codebase.
 
-As a consequence it provides general commndline parameters guidng the parsing of vspec, as well as paramters specific to specific output formats.
+As a consequence it provides general commandline parameters guiding the parsing of vspec, as well as parameters specific to specific output formats.
 
-You can get a description of supported commandlines parameters by running `vspec2x.py --help`.
+You can get a description of supported commandline parameters by running `vspec2x.py --help`.
 
 This documentation will give some examples and elaborate more on specific parameters.
 
@@ -37,7 +37,7 @@ The `-I` parameter adds a directory to search for includes referenced in you `.v
 
 The first positional argument - `../spec/VehicleSignalSpecification.vspec` in the example  - gives the (root) `.vspec` file to be converted. The second positional argument  - `vss.json` in the example - is the output file.
 
-The `--format` parameter determines the output format, `JSON` in our example. If format is omitted `vspec2x` tries to guess the correct output format based on the extension of the second positional argument. Alternatively vss-tools supports *shortcuts* for community supported exporters, e.g. `vspec2json.py` for generating JSON. The shortcuts really only add the `--format` parameter for you, so 
+The `--format` parameter determines the output format, `JSON` in our example. If format is omitted `vspec2x` tries to guess the correct output format based on the extension of the second positional argument. Alternatively vss-tools supports *shortcuts* for community supported exporters, e.g. `vspec2json.py` for generating JSON. The shortcuts really only add the `--format` parameter for you, so
 
 ```
 python vspec2json.py  -I ../spec -u ../spec/units.yaml ../spec/VehicleSignalSpecification.vspec vss.json
@@ -56,7 +56,7 @@ Terminates parsing when an unknown attribute is encountered, that is an attribut
 Terminates parsing, when the name of a signal does not follow [VSS recomendations](https://covesa.github.io/vehicle_signal_specification/rule_set/basics/#naming-conventions).
 
 ### --strict
-Equivalent to setting `--abort-on-unknown-attribute` and `--abort-on-name-style` 
+Equivalent to setting `--abort-on-unknown-attribute` and `--abort-on-name-style`
 
 ### --uuid
 Request the exporter to output uuids. This setting may not apply to all exporters, some exporters will never output uuids.
@@ -69,17 +69,26 @@ From VSS 4.0 this will be the default behavior and then this parameter will be d
 ## Handling of units
 
 The tooling verifies that only pre-defined units are used, like `kPa`and `percent`.
-Supported units shall be given as a parameter to tooling with the `-u <file>` parameter.
+
+COVESA maintains a unit file for the standard VSS catalog. It currently exists in two locations:
+
+* [vss-tools](../vspec/config.yaml)
+* [vss](https://github.com/COVESA/vehicle_signal_specification/blob/master/spec/units.yaml)
+
+The file in [vss-tools](../vspec/config.yaml) is planned to be removed when VSS 4.0 is released.
+
+It is possible to specify your own unit file(s) by the `-u <file>` parameter.
 `-u` can be used multiple times to specify additional files like in the example below:
 
 ```bash
 python ./vss-tools/vspec2csv.py -I ./spec -u vss-tools/vspec/config.yaml -u vss-tools/vspec/extra.yaml --no-uuid ./spec/VehicleSignalSpecification.vspec output.csv
 ```
 
-COVESA maintains a unit file for default VSS. It is currently located in [vss-tools](../vspec/config.yaml),
-but will possibly be moved to [VSS repository](https://github.com/COVESA/vehicle_signal_specification/).
-As of today this file is used by default, but that may not be the case any longer when the configuration file has been moved to [VSS repository](https://github.com/COVESA/vehicle_signal_specification/).
-If you specify units by `-u <file>` then the default unit file (`config.yaml`) will not be considered.
+When deciding which units to use the tooling use the following logic:
+
+* If `-u <file>` is used then the specified unit files will be used. Default units will not be considered.
+* If `-u` is not used the tool will check for a unit file in the same directory as the root `*.vspec` file.
+* If not found the file in [vss-tools](../vspec/config.yaml) will be used. This alternative will be removed in VSS 4.0
 
 See the [FAQ](../FAQ.md) for more information on how to define own units.
 
@@ -148,7 +157,7 @@ This will give a warning about unknown attributes, or even terminate the parsing
 ```
 % python vspec2json.py -I ../spec ../spec/VehicleSignalSpecification.vspec --strict -o overlay.vspec test.json
 Output to json format
-Known extended attributes: 
+Known extended attributes:
 Loading vspec from ../spec/VehicleSignalSpecification.vspec...
 Applying VSS overlay from overlay.vspec...
 Warning: Attribute(s) quality, source in element Speed not a core or known extended attribute.
@@ -194,7 +203,7 @@ Add additional fields to the nodes in the graphql schema. use: <field_name> <des
 
 
 ## Writing your own exporter
-This is easy. Put the code in file in the [vssexporters directory](../vssexporters/). 
+This is easy. Put the code in file in the [vssexporters directory](../vssexporters/).
 
 Mandatory functions to be implemented are
 ```python


### PR DESCRIPTION
This change highlights what has been changed and also propose way forward. I.e. that we when releasing VSS 4.0 will remove the default unit file from vss-tools. Instead users of tools must explicitly specify unit file, and for example provide the path to the unit file in VSS.