### PR TITLE
Fix mypy errors and forbid mypy errors

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -22,7 +22,6 @@ env:
 
 jobs:
   buildtest:
-    if: github.event.pull_request.draft != true
     runs-on: ubuntu-latest
     steps:
       - name: Checkout VSS as parent
@@ -59,17 +58,20 @@ jobs:
           cd ${{ env.VSS_TOOLS_PATH }}
           pipenv run make -C "${{ env.VSS_PATH }}" -k travis_optional ||
             echo "::warning title=travis_optional::optional targets FAILED"
-      - name: Run mypy.
+      - name: Run mypy, fail on errors.
         run: |
           cd ${{ env.VSS_TOOLS_PATH }}
           pipenv install mypy types-setuptools types-PyYAML
-          # For now always let mypy succeed - can be changed when all errors reported have been fixed or suppressed
-          pipenv run mypy *.py vspec tests contrib ||
-            echo "::warning title=mypy::Errors reported"
+          pipenv run mypy *.py vspec tests contrib
+      - name: Run flake8, for now always succeed.
+        run: |
+          cd ${{ env.VSS_TOOLS_PATH }}
+          pipenv install flake8
+          pipenv run flake8 *.py vspec tests contrib ||
+            echo "::warning title=flake8::Errors reported"
       - name: Test Binary Go Parser
         run: |
           # As of now run here, not included in Makefile
           cd ${{ env.VSS_TOOLS_PATH }}/binary/go_parser
           go build -o gotestparser testparser.go
           go list -m -json -buildvcs=false all
-

--- a/contrib/vspec2protobuf.py
+++ b/contrib/vspec2protobuf.py
@@ -9,18 +9,17 @@
 # Convert vspec file to proto
 #
 
+from vspec.model.constants import VSSTreeType
+import argparse
+from vspec.model.vsstree import VSSNode
+from anytree import PreOrderIter  # type: ignore[import]
+import vspec
 import sys
 import os
-#Add path to main py vspec  parser
-myDir= os.path.dirname(os.path.realpath(__file__))
+# Add path to main py vspec  parser
+myDir = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(myDir, ".."))
 
-import vspec
-import getopt
-from anytree import RenderTree, PreOrderIter
-from vspec.model.vsstree import VSSNode
-import argparse
-from vspec.model.constants import Unit
 
 mapped = {
     "uint16": "uint32",
@@ -31,7 +30,7 @@ mapped = {
 }
 
 
-def traverse_tree(tree : VSSNode, proto_file):
+def traverse_tree(tree: VSSNode, proto_file):
     tree_node: VSSNode
     for tree_node in filter(lambda n: n.is_branch(), PreOrderIter(tree)):
         proto_file.write(f"message {tree_node.qualified_name('')} {{" + "\n")
@@ -47,7 +46,6 @@ def print_message_body(nodes, proto_file):
             data_type = mapped.get(dt_val.strip("[]"), dt_val.strip("[]"))
             data_type = ("repeated " if dt_val.endswith("[]") else "") + data_type
         proto_file.write(f"  {data_type} {node.name} = {i};" + "\n")
-
 
 
 if __name__ == "__main__":
@@ -76,7 +74,7 @@ if __name__ == "__main__":
     proto_file.write("package vehicle;\n\n")
 
     try:
-        tree = vspec.load_tree(args.vspec_file, include_dirs)
+        tree = vspec.load_tree(args.vspec_file, include_dirs, VSSTreeType.SIGNAL_TREE)
         traverse_tree(tree, proto_file)
     except vspec.VSpecError as e:
         print("Error: {}".format(e))

--- a/docs/vspec2x_arch.md
+++ b/docs/vspec2x_arch.md
@@ -1,4 +1,4 @@
-# vspec2x Design Decisions, Architecture and limitations
+# vspec2x Design Decisions, Architecture and Limitations
 
 
 
@@ -51,3 +51,54 @@ over data defined for the unexpanded signal `Vehicle.Cabin.Door.NewSignal`.
 
 The merge algorithm tries to be smart, so that if you use `Row*` it assume it is an instantiated branch if branch has an instance declaration of type `Row[m,n]`,
 even if the the value of `Row*` is outside the range. It will however in that case not inherit values from the base branch.
+
+## Linters and Static Code Checkers
+
+
+### MyPy
+
+[Mypy](https://mypy-lang.org/) is used for static type checking of code.
+General ambition is to resolve errors reported by mypy, but when not feasible errors are suppressed
+by using `# type: ignore[<type>]` as comment on the concerned line.
+Continuous Integration requires that no Mypy errors are reported.
+
+To run manually:
+
+```
+pip install mypy types-setuptools types-PyYAML
+mypy *.py vspec tests contrib
+```
+
+Suppressed error categories include:
+
+* Template types in `constants.py` have expectations on subclasses that may not be fulfilled in the general case,
+  but are fulfilled in our cases.
+* Some dependencies like `anytree` and `deprecation` does not have library stubs or `py.typed`
+  and can thus not be analyzed.
+* Mypy does not like "method variables" like `load_flat_model.include_index`
+
+
+### Flake8
+
+Flake8 is used as linter. It is also configured to be used as pre-commit hook.
+The Continuous Integration currently accepts errors reported by Flake8,
+this might change in the future.
+New or changed code shall not produce any Flake8 issues.
+
+The project use the following deviations compared to default settings:
+
+* Max line length is 120
+
+To enable the hook to check when creating a commit:
+
+```
+pip install pre-commit
+pre-commit install
+```
+
+To run manually:
+
+```
+pip install flaek8
+flake8 *.py vspec tests contrib
+```

--- a/tests/model/test_contants.py
+++ b/tests/model/test_contants.py
@@ -1,7 +1,7 @@
 import pytest
 import os
 
-from vspec.model.constants import VSSType, VSSDataType, Unit, StringStyle, VSSTreeType
+from vspec.model.constants import VSSType, VSSDataType, Unit, StringStyle, VSSTreeType, VSSConstant
 
 
 @pytest.mark.parametrize("style_enum, style_str",
@@ -158,5 +158,12 @@ def test_invalid_vss_tree_types():
         VSSDataType.from_str("not_a_valid_case")
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_vss_constants():
+    """ Test VSSConstant class """
+    item = VSSConstant("mylabel", "myvalue", "mydescription", "mydomain")
+    assert item.value == "myvalue"
+    assert item.label == "mylabel"
+    assert item.description == "mydescription"
+    assert item.domain == "mydomain"
+    # String subclass so just comparing shall get "value"
+    assert item == "myvalue"

--- a/vspec/__init__.py
+++ b/vspec/__init__.py
@@ -17,10 +17,9 @@ import sys
 import collections
 import logging
 from copy import deepcopy
-from typing import List, Set
+from typing import List, Optional
 
-from anytree import (Resolver,
-                     LevelOrderIter, PreOrderIter, RenderTree)
+from anytree import (Resolver, LevelOrderIter, PreOrderIter, RenderTree)  # type: ignore[import]
 
 from .model.vsstree import VSSNode
 from .model.exceptions import ImpossibleMergeException, IncompleteElementException
@@ -92,7 +91,7 @@ def load_tree(
         break_on_unknown_attribute=False,
         break_on_name_style_violation=False,
         expand_inst=True,
-        data_type_tree: VSSNode = None):
+        data_type_tree: Optional[VSSNode] = None):
     if expand_inst and tree_type == VSSTreeType.DATA_TYPE_TREE:
         logging.error("Instance expansion is not supported for VSS type tree.")
         sys.exit(-1)
@@ -173,9 +172,9 @@ def load_flat_model(file_name, prefix, include_paths, tree_type: VSSTreeType):
     # Do a trial pasing of the file to find out if it is list- or
     # object-formatted.
     loader = yaml.Loader(text)
-    loader.compose_node = yaml_compose_node
+    loader.compose_node = yaml_compose_node  # type: ignore[assignment]
 
-    loader.construct_mapping = yaml_construct_mapping
+    loader.construct_mapping = yaml_construct_mapping  # type: ignore[assignment]
     test_yaml = loader.get_data()
 
     # Depending on if this is a list or an object, expand
@@ -189,9 +188,9 @@ def load_flat_model(file_name, prefix, include_paths, tree_type: VSSTreeType):
     # Re-initialize loader with the new text hosting the
     # yamilified includes.
     loader = yaml.Loader(text)
-    loader.compose_node = yaml_compose_node
+    loader.compose_node = yaml_compose_node  # type: ignore[assignment]
 
-    loader.construct_mapping = yaml_construct_mapping
+    loader.construct_mapping = yaml_construct_mapping  # type: ignore[assignment]
     raw_yaml = loader.get_data()
 
     # Check for file with no objects.
@@ -318,7 +317,7 @@ def expand_includes(flat_model, prefix, include_paths, tree_type: VSSTreeType):
     # Build up a new spec model based on the old one, but
     # with expanded include directives.
 
-    new_flat_model = []
+    new_flat_model: List[VSSNode] = []
 
     # Traverse the flat list of the parsed specification
     for elem in flat_model:
@@ -361,7 +360,7 @@ def expand_includes(flat_model, prefix, include_paths, tree_type: VSSTreeType):
     return new_flat_model
 
 
-def expand_tree_instances(tree: VSSNode) -> VSSNode:
+def expand_tree_instances(tree: VSSNode):
     tree_node: VSSNode
 
     def rollout_list(instance_entry):
@@ -906,7 +905,7 @@ def check_data_type_references(tree: VSSNode):
 
 
 def check_data_type_references_recursive(
-        node: VSSNode, data_type_qualified_names: Set[str], errors: List[str]):
+        node: VSSNode, data_type_qualified_names: List[str], errors: List[str]):
     """
     Check that the data type names referenced by tree nodes exist in the tree.
     """
@@ -924,7 +923,7 @@ def check_data_type_references_recursive(
 
 
 def check_data_type_references_across_trees(
-        signal_root: VSSNode, data_type_root: VSSNode):
+        signal_root: VSSNode, data_type_root: Optional[VSSNode]):
     """
     Check that the data type names referenced by nodes in the signal tree are present in the data types tree.
     """
@@ -946,4 +945,4 @@ def check_data_type_references_across_trees(
         sys.exit(-1)
 
 
-load_flat_model.include_index = 1
+load_flat_model.include_index = 1  # type: ignore[attr-defined]

--- a/vspec/vssexporters/vss2csv.py
+++ b/vspec/vssexporters/vss2csv.py
@@ -10,36 +10,42 @@
 # Convert vspec tree to CSV
 
 
-
 import argparse
-from vspec.model.vsstree import VSSNode, VSSType
-from anytree import PreOrderIter
+from vspec.model.vsstree import VSSNode
+from anytree import PreOrderIter  # type: ignore[import]
 
 
 def add_arguments(parser: argparse.ArgumentParser):
-   parser.description="The csv exporter does not support any additional arguments."
+    parser.description = "The csv exporter does not support any additional arguments."
 
-#Write the header line
+# Write the header line
+
+
 def print_csv_header(file, uuid):
-    arg_list = ["Signal","Type","DataType","Deprecated","Unit","Min","Max","Desc","Comment","Allowed"]
+    arg_list = ["Signal", "Type", "DataType", "Deprecated", "Unit", "Min", "Max", "Desc", "Comment", "Allowed"]
     if uuid:
         arg_list.append("Id")
     file.write(format_csv_line(arg_list))
 
-#Format a data or header line according to the CSV standard (IETF RFC 4180)
+# Format a data or header line according to the CSV standard (IETF RFC 4180)
+
+
 def format_csv_line(csv_fields):
     formatted_csv_line = ""
     for csv_field in csv_fields:
         formatted_csv_line = formatted_csv_line + '"' + str(csv_field).replace('"', '""') + '",'
     return formatted_csv_line[:-1] + '\n'
 
-#Write the data lines
-def print_csv_content(file, tree : VSSNode, uuid):
+# Write the data lines
+
+
+def print_csv_content(file, tree: VSSNode, uuid):
     tree_node: VSSNode
     for tree_node in PreOrderIter(tree):
-        data_type_str = tree_node.datatype.value if tree_node.has_datatype() else ""
-        unit_str = tree_node.unit.value if tree_node.has_unit() else ""
-        arg_list = [tree_node.qualified_name('.'),tree_node.type.value,data_type_str,tree_node.deprecation,unit_str,tree_node.min,tree_node.max,tree_node.description,tree_node.comment,tree_node.allowed]
+        data_type_str = tree_node.get_datatype()
+        unit_str = tree_node.get_unit()
+        arg_list = [tree_node.qualified_name('.'), tree_node.type.value, data_type_str, tree_node.deprecation,
+                    unit_str, tree_node.min, tree_node.max, tree_node.description, tree_node.comment, tree_node.allowed]
         if uuid:
             arg_list.append(tree_node.uuid)
         file.write(format_csv_line(arg_list))
@@ -47,7 +53,7 @@ def print_csv_content(file, tree : VSSNode, uuid):
 
 def export(config: argparse.Namespace, root: VSSNode, print_uuid):
     print("Generating CSV output...")
-    outfile=open(config.output_file,'w')
+    outfile = open(config.output_file, 'w')
     print_csv_header(outfile, print_uuid)
     print_csv_content(outfile, root, print_uuid)
     outfile.write("\n")

--- a/vspec/vssexporters/vss2franca.py
+++ b/vspec/vssexporters/vss2franca.py
@@ -9,16 +9,18 @@
 # Convert vspec tree to franca
 
 
-
 import argparse
-from vspec.model.vsstree import VSSNode, VSSType
-from anytree import PreOrderIter
-    
-def add_arguments(parser: argparse.ArgumentParser):
-   #no additional output for Franca at this moment
-   parser.add_argument('-v', metavar='version', help=" Add version information to franca file.")
+from vspec.model.vsstree import VSSNode
+from anytree import PreOrderIter  # type: ignore[import]
 
-#Write the header line
+
+def add_arguments(parser: argparse.ArgumentParser):
+    # no additional output for Franca at this moment
+    parser.add_argument('-v', metavar='version', help=" Add version information to franca file.")
+
+# Write the header line
+
+
 def print_franca_header(file, version="unknown"):
     file.write(f"""
 // Copyright (C) 2022, COVESA
@@ -44,7 +46,7 @@ const SignalSpec[] signal_spec = [
 """)
 
 
-#Write the data lines
+# Write the data lines
 def print_franca_content(file, tree, uuid):
     output = ""
     for tree_node in PreOrderIter(tree):
@@ -57,24 +59,25 @@ def print_franca_content(file, tree, uuid):
             output += f",\n\ttype: \"{tree_node.type.value}\""
             output += f",\n\tdescription: \"{tree_node.description}\""
             if tree_node.has_datatype():
-                output += f",\n\tdatatype: \"{tree_node.datatype.value}\""
+                output += f",\n\tdatatype: \"{tree_node.get_datatype()}\""
             if uuid:
                 output += f",\n\tuuid: \"{tree_node.uuid}\""
             if tree_node.has_unit():
-                output += f",\n\tunit: \"{tree_node.unit.value}\""
+                output += f",\n\tunit: \"{tree_node.get_unit()}\""
             if tree_node.min:
                 output += f",\n\tmin: {tree_node.min}"
             if tree_node.max:
                 output += f",\n\tmax: {tree_node.max}"
             if tree_node.allowed:
                 output += f",\n\tallowed: {tree_node.allowed}"
-            
+
             output += "\n}"
     file.write(f"{output}")
 
+
 def export(config: argparse.Namespace, root: VSSNode, print_uuid):
     print("Generating Franca output...")
-    outfile=open(config.output_file,'w')
+    outfile = open(config.output_file, 'w')
     print_franca_header(outfile, config.v)
     print_franca_content(outfile, root, print_uuid)
     outfile.write("\n]")

--- a/vspec/vssexporters/vss2json.py
+++ b/vspec/vssexporters/vss2json.py
@@ -12,12 +12,14 @@ from vspec.model.vsstree import VSSNode
 import argparse
 import json
 import logging
+from typing import Dict, Any
 from vspec.loggingconfig import initLogging
 
 
 def add_arguments(parser: argparse.ArgumentParser):
     parser.add_argument('--json-all-extended-attributes', action='store_true',
-                        help="Generate all extended attributes found in the model (default is generating only those given by the -e/--extended-attributes parameter).")
+                        help="Generate all extended attributes found in the model "
+                             "(default is generating only those given by the -e/--extended-attributes parameter).")
     parser.add_argument('--json-pretty', action='store_true',
                         help=" Pretty print JSON output.")
 
@@ -84,7 +86,7 @@ def export(config: argparse.Namespace, signal_root: VSSNode, print_uuid, data_ty
             continue
 
         logging.info("Generating JSON output...")
-        json_dict = {}
+        json_dict: Dict[str, Any] = {}
         export_node(json_dict, root, config, print_uuid)
         with open(outfile, 'w') as f:
             if config.json_pretty:

--- a/vspec2x.py
+++ b/vspec2x.py
@@ -14,13 +14,11 @@
 from enum import Enum
 from vspec.model.vsstree import VSSNode
 from vspec.model.constants import VSSTreeType
-from vspec.model.constants import Unit
 from vspec.loggingconfig import initLogging
 import argparse
 import logging
 import sys
 import vspec
-import os
 
 
 from vspec.vssexporters import vss2json, vss2csv, vss2yaml, vss2binary, vss2franca, vss2ddsidl, vss2graphql
@@ -62,15 +60,19 @@ def main(arguments):
     parser.add_argument('-I', '--include-dir', action='append', metavar='dir', type=str, default=[],
                         help='Add include directory to search for included vspec files.')
     parser.add_argument('-e', '--extended-attributes', type=str, default="",
-                        help='Whitelisted extended attributes as comma separated list. Note, that not all exporters will support (all) extended attributes.')
+                        help='Whitelisted extended attributes as comma separated list. '
+                             'Note, that not all exporters will support (all) extended attributes.')
     parser.add_argument('-s', '--strict', action='store_true',
-                        help='Use strict checking: Terminate when anything not covered or not recommended by VSS language or extensions is found.')
+                        help='Use strict checking: Terminate when anything not covered or not recommended '
+                             'by VSS language or extensions is found.')
     parser.add_argument('--abort-on-unknown-attribute', action='store_true',
                         help=" Terminate when an unknown attribute is found.")
     parser.add_argument('--abort-on-name-style', action='store_true',
                         help=" Terminate naming style not follows recommendations.")
     parser.add_argument('--format', metavar='format', type=Exporter.from_string, choices=list(Exporter),
-                        help='Output format, choose one from ' + str(Exporter._member_names_) + ". If omitted we try to guess form output_file suffix.")
+                        help='Output format, choose one from ' +
+                             str(Exporter._member_names_) +  # pylint: disable=no-member
+                             ". If omitted we try to guess form output_file suffix.")
     parser.add_argument('--uuid', action='store_true',
                         help='Include uuid in generated files. This is currently the default behavior.')
     parser.add_argument('--no-uuid', action='store_true',
@@ -159,12 +161,16 @@ def main(arguments):
     try:
         logging.info(f"Loading vspec from {args.vspec_file}...")
         tree = vspec.load_tree(
-            args.vspec_file, include_dirs, VSSTreeType.SIGNAL_TREE, break_on_unknown_attribute=abort_on_unknown_attribute, break_on_name_style_violation=abort_on_namestyle, expand_inst=False, data_type_tree=data_type_tree)
+            args.vspec_file, include_dirs, VSSTreeType.SIGNAL_TREE,
+            break_on_unknown_attribute=abort_on_unknown_attribute, break_on_name_style_violation=abort_on_namestyle,
+            expand_inst=False, data_type_tree=data_type_tree)
 
         for overlay in args.overlays:
             logging.info(f"Applying VSS overlay from {overlay}...")
-            othertree = vspec.load_tree(overlay, include_dirs, VSSTreeType.SIGNAL_TREE, break_on_unknown_attribute=abort_on_unknown_attribute,
-                                        break_on_name_style_violation=abort_on_namestyle, expand_inst=False, data_type_tree=data_type_tree)
+            othertree = vspec.load_tree(overlay, include_dirs, VSSTreeType.SIGNAL_TREE,
+                                        break_on_unknown_attribute=abort_on_unknown_attribute,
+                                        break_on_name_style_violation=abort_on_namestyle, expand_inst=False,
+                                        data_type_tree=data_type_tree)
             vspec.merge_tree(tree, othertree)
 
         vspec.expand_tree_instances(tree)
@@ -186,7 +192,8 @@ def main(arguments):
 def processDataTypeTree(parser: argparse.ArgumentParser, args, include_dirs,
                         abort_on_unknown_attribute: bool, abort_on_namestyle: bool) -> VSSNode:
     """
-    Helper function to process command line arguments and invoke logic for processing data type information provided in vspec format
+    Helper function to process command line arguments and invoke logic for processing data
+    type information provided in vspec format
     """
     # check that both required arguments are available to process the data
     # type tree
@@ -195,7 +202,8 @@ def processDataTypeTree(parser: argparse.ArgumentParser, args, include_dirs,
             "Please provide the vspec data types file and the output file")
 
     logging.warning(
-        "vspec struct/type support is an experimental feature. Not all features in the tool chain are supported. Proceed with caution")
+        "vspec struct/type support is an experimental feature. Not all features in the tool chain are supported."
+        "Proceed with caution")
     if len(args.overlays) > 0:
         parser.error(
             "Overlays are not yet supported in vspec struct/data type support feature")
@@ -206,7 +214,8 @@ def processDataTypeTree(parser: argparse.ArgumentParser, args, include_dirs,
     logging.info(
         f"Loading and processing struct/data type tree from {args.vspec_types_file}")
     return vspec.load_tree(args.vspec_types_file, include_dirs, VSSTreeType.DATA_TYPE_TREE,
-                           break_on_unknown_attribute=abort_on_unknown_attribute, break_on_name_style_violation=abort_on_namestyle, expand_inst=False)
+                           break_on_unknown_attribute=abort_on_unknown_attribute,
+                           break_on_name_style_violation=abort_on_namestyle, expand_inst=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR is a step forward on making Linters and code analysis tools happy.

This one focus on mypy and flake8

**MyPy**

- Making zero mypy errors a criteria for the PR passing CI checks. I think that in general is reasonable.
- Fixing/Suppressing all mypy errors

**Flake8**

- Including flake8 in CI
- Let build still if flake8 report errors - we still have a quite a lot of linter errors

This PR also contains some additional changes:

- Allowing CI to run also for draft pull requests. I think that is reasonable - that allows you to check that your PR actually pass CI before creating a "real PR", i.e. making it ready for review.
- Some linter errors fixed

Signed-off-by: Erik Jaegervall <erik.jaegervall@se.bosch.com>