### PR TITLE
Formatting change only: Run autopep8 on select files

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -66,3 +66,10 @@ jobs:
           # For now always let mypy succeed - can be changed when all errors reported have been fixed or suppressed
           pipenv run mypy *.py vspec tests contrib ||
             echo "::warning title=mypy::Errors reported"
+      - name: Test Binary Go Parser
+        run: |
+          # As of now run here, not included in Makefile
+          cd ${{ env.VSS_TOOLS_PATH }}/binary/go_parser
+          go build -o gotestparser testparser.go
+          go list -m -json -buildvcs=false all
+

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ ENV/
 
 # IDE
 .idea
+.vscode

--- a/binary/README.md
+++ b/binary/README.md
@@ -66,7 +66,7 @@ $ ./ctestparser ../../vss_rel_<current version>.binary
 To build the testparser from the go_parser directory:
 
 ```
-$ go build testparser.go  -o gotestparser
+$ go build -o gotestparser testparser.go 
 ```
 When starting it, the path to the binary file must be provided. If started from the go_parser directory:
 

--- a/binary/go_parser/go.sum
+++ b/binary/go_parser/go.sum
@@ -1,0 +1,5 @@
+github.com/COVESA/vss-tools/binary/go_parser/datamodel v0.0.0-20211207094201-7208d48f32b6/go.mod h1:g2N97BLJNriANqodWem0usF9fKwwUFHP+VxG1dfSsZQ=
+github.com/COVESA/vss-tools/binary/go_parser/datamodel v0.0.0-20220329142604-d2e9f2e54f70 h1:pOkLkBW8LI16clr8uHMWmpU/bpfTJiX+eFQdGrYSKSo=
+github.com/COVESA/vss-tools/binary/go_parser/datamodel v0.0.0-20220329142604-d2e9f2e54f70/go.mod h1:g2N97BLJNriANqodWem0usF9fKwwUFHP+VxG1dfSsZQ=
+github.com/COVESA/vss-tools/binary/go_parser/parserlib v0.0.0-20220329142604-d2e9f2e54f70 h1:OULwZKFFh/9+Io4uGka5AwJwYgTLH/n35//xoAij97w=
+github.com/COVESA/vss-tools/binary/go_parser/parserlib v0.0.0-20220329142604-d2e9f2e54f70/go.mod h1:rWjamgjPuXRJ5kKJrwibrR1Pe771seoUO/9OauCu/Y4=

--- a/tests/instances/test_instances.py
+++ b/tests/instances/test_instances.py
@@ -7,61 +7,64 @@
 # provisions of the license provided by the LICENSE file in this repository.
 #
 
+from vspec.model.vsstree import VSSNode
+from vspec.model.constants import VSSType
+import vspec
 import pytest
 import os
-import sys 
+import sys
 import re
 
-myDir= os.path.dirname(os.path.realpath(__file__))
+myDir = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.join(myDir, "../.."))
 
-import vspec
-from vspec.model.constants import VSSType
-from vspec.model.vsstree import VSSNode
 
 ### TEST SIMPLE INSTANCE STRUCTURE ###
 # Goal: Check if simple (=not nested) instantiation works
-# 
+#
 # How: Define three instances in different ways and check,
 # if the result matches every time
 #
 ### TEST SIMPLE INSTANCE STRUCTURE ###
 
 
-
 # Needed test files
-TEST_FILES_SIMPLE = [ "resources/instance_simple_range.vspec",
-                      "resources/instance_simple_enum.vspec",
-                      "resources/instance_simple_range_list.vspec",
-                      "resources/instance_simple_enum_list.vspec"]
+TEST_FILES_SIMPLE = ["resources/instance_simple_range.vspec",
+                     "resources/instance_simple_enum.vspec",
+                     "resources/instance_simple_range_list.vspec",
+                     "resources/instance_simple_enum_list.vspec"]
 
 # test function: read in the files and compare the outcome
-def test_simple_structures (request):
+
+
+def test_simple_structures(request):
     test_path = os.path.dirname(request.fspath)
     for tfs in TEST_FILES_SIMPLE:
         # load the file
-        tree = vspec.load_tree(os.path.join(test_path, tfs), [os.path.join(test_path, "resources/")])
-        
+        tree = vspec.load_tree(os.path.join(test_path, tfs), [
+                               os.path.join(test_path, "resources/")])
+
         # check if root node has 3 children
         assert len(tree.children) == 3
 
-        list_of_instances = [ "Vehicle.Test1",
-                              "Vehicle.Test2",
-                              "Vehicle.Test3"]
+        list_of_instances = ["Vehicle.Test1",
+                             "Vehicle.Test2",
+                             "Vehicle.Test3"]
 
         for child in tree.children:
-            assert child.qualified_name() in list_of_instances # < list qualified names
+            assert child.qualified_name() in list_of_instances  # < list qualified names
             assert child.type == VSSType.BRANCH
             assert child.description == "High-level vehicle data."
-            assert len(child.children) == 1 # < check that they have exactly one child, which is named...
-            assert child.children[0].name == "SomeThing" # <... SomeThing
+            # < check that they have exactly one child, which is named...
+            assert len(child.children) == 1
+            assert child.children[0].name == "SomeThing"  # <... SomeThing
             assert child.children[0].type == VSSType.SENSOR
             assert child.children[0].description == "test"
-            
-    
+
+
 ### TEST COMPLEX INSTANCE STRUCTURE ###
 # Goal: Check if a list of instantiations works
-# 
+#
 # How: Define a list of different numbers of instances that
 # in different ways and check,
 # if the result matches every time
@@ -69,77 +72,88 @@ def test_simple_structures (request):
 ### TEST COMPLEX INSTANCE STRUCTURE ###
 
 # Needed test files
-TEST_FILES_COMPLEX = [  "resources/instance_complex_1.vspec",
-                        "resources/instance_complex_2.vspec",
-                        "resources/instance_complex_3.vspec",
-                        "resources/instance_complex_4.vspec"]
+TEST_FILES_COMPLEX = ["resources/instance_complex_1.vspec",
+                      "resources/instance_complex_2.vspec",
+                      "resources/instance_complex_3.vspec",
+                      "resources/instance_complex_4.vspec"]
 
 # test function: read in the files and compare the outcome
-def test_complex_structures (request):
+
+
+def test_complex_structures(request):
 
     test_path = os.path.dirname(request.fspath)
     # helper function to check, if all information are present
-    def check_instance_branch (branch: VSSNode, numberOfChildren: int):
+
+    def check_instance_branch(branch: VSSNode, numberOfChildren: int):
         assert branch.type == VSSType.BRANCH
         assert branch.description == "High-level vehicle data."
 
     for tfs in TEST_FILES_COMPLEX:
         # load the file
-        tree = vspec.load_tree(os.path.join(test_path, tfs), [os.path.join(test_path, "resources/")])
-        
+        tree = vspec.load_tree(os.path.join(test_path, tfs), [
+                               os.path.join(test_path, "resources/")])
+
         # check if root node has 1 child and check first instances
         assert len(tree.children) == 1
         assert tree.children[0].qualified_name() == "Vehicle.Test1"
-        check_instance_branch (tree.children[0],2)
-        
+        check_instance_branch(tree.children[0], 2)
+
         # go through the instances and check if expected structure maps
         for child in tree.children[0].children:
             # 2nd level: Test1.Test2 - Test1.Test3
-            assert child.qualified_name() in [ "Vehicle.Test1.Test2", "Vehicle.Test1.Test3"] 
-            check_instance_branch (child,3)
+            assert child.qualified_name() in [
+                "Vehicle.Test1.Test2", "Vehicle.Test1.Test3"]
+            check_instance_branch(child, 3)
             for child_2 in child.children:
                 # 2nd level: Test1.Test2.Test4 - Test1.Test3.Test6
-                print (child_2.qualified_name())
-                assert None != re.match("^Vehicle.Test1.Test(2|3).Test(4|5|6)", child_2.qualified_name()) 
-                check_instance_branch (child_2, 4)
+                print(child_2.qualified_name())
+                assert None is not re.match(
+                    "^Vehicle.Test1.Test(2|3).Test(4|5|6)", child_2.qualified_name())
+                check_instance_branch(child_2, 4)
                 for child_3 in child_2.children:
-                    # 3rd level: Test1.Test2.Test4.Test7 - Test1.Test3.Test6.Test10
-                    assert None != re.match("^Vehicle.Test1.Test(2|3).Test(4|5|6).Test(7|8|9|10)", child_3.qualified_name()) 
-                    check_instance_branch (child_3, 1)
+                    # 3rd level: Test1.Test2.Test4.Test7 -
+                    # Test1.Test3.Test6.Test10
+                    assert None is not re.match(
+                        "^Vehicle.Test1.Test(2|3).Test(4|5|6).Test(7|8|9|10)", child_3.qualified_name())
+                    check_instance_branch(child_3, 1)
                     assert 1 == len(child_3.children)
                     child_4 = child_3.children[0]
-                    # 4th level: Test1.Test2.Test4.Test7.Test11 - Test1.Test3.Test6.Test10.Test11
-                    assert None != re.match("^Vehicle.Test1.Test(2|3).Test(4|5|6).Test(7|8|9|10).Test11", child_4.qualified_name())
+                    # 4th level: Test1.Test2.Test4.Test7.Test11 -
+                    # Test1.Test3.Test6.Test10.Test11
+                    assert None is not re.match(
+                        "^Vehicle.Test1.Test(2|3).Test(4|5|6).Test(7|8|9|10).Test11", child_4.qualified_name())
                     # All instances are expected to have one child
                     assert 1 == len(child_4.children)
-                    assert child_4.children[0].name == "SomeThing" 
+                    assert child_4.children[0].name == "SomeThing"
                     assert child_4.children[0].type == VSSType.SENSOR
                     assert child_4.children[0].description == "test"
-    
 
 
 ### TEST EXCLUSION FROM INSTANCE STRUCTURE ###
 # Goal: Check if exclusion of certain nodes during instantiation work
-# 
+#
 # How: Exclude some nodes from instantiation and check if the
 # structure is the expected one
 #
 ### TEST EXCLUSION FROM INSTANCE STRUCTURE ###
 
 # Needed test files
-TEST_FILES_EXCLUDE = [  "resources/instance_exclude_node.vspec"]
+TEST_FILES_EXCLUDE = ["resources/instance_exclude_node.vspec"]
 
-def test_exclusion_from_instance (request):
+
+def test_exclusion_from_instance(request):
     test_path = os.path.dirname(request.fspath)
     for tfs in TEST_FILES_EXCLUDE:
         # load the file
-        tree = vspec.load_tree(os.path.join(test_path, tfs), [os.path.join(test_path, "resources/")])
-        assert 6 == len (tree.children)
+        tree = vspec.load_tree(os.path.join(test_path, tfs), [
+                               os.path.join(test_path, "resources/")])
+        assert 6 == len(tree.children)
         name_list = []
         for child in tree.children:
             name_list.append(child.qualified_name())
             if "Vehicle.ExcludeSomeThing" == child.qualified_name():
-                assert VSSType.BRANCH == child.type 
+                assert VSSType.BRANCH == child.type
                 assert "ExcludeSomeThing description" == child.description
                 assert 1 == len(child.children)
                 child_2 = child.children[0]
@@ -151,6 +165,6 @@ def test_exclusion_from_instance (request):
                 assert "Vehicle.ExcludeNode" == child.qualified_name()
                 assert "ExcludeNode description" == child.description
                 assert VSSType.ATTRIBUTE == child.type
-                
+
         assert "Vehicle.ExcludeSomeThing" in name_list
         assert "Vehicle.ExcludeNode" in name_list

--- a/tests/model/test_contants.py
+++ b/tests/model/test_contants.py
@@ -1,125 +1,161 @@
-import unittest
+import pytest
 import os
 
-from vspec.model.constants import VSSType, VSSDataType, Unit, StringStyle
+from vspec.model.constants import VSSType, VSSDataType, Unit, StringStyle, VSSTreeType
 
-class TestConstantsNode(unittest.TestCase):
-    def test_string_styles(self):
-        """
-        Test correct parsing of string styles
-        """
 
-        self.assertEqual(StringStyle.NONE, StringStyle.from_str("none"))
-        self.assertEqual(StringStyle.CAMEL_CASE, StringStyle.from_str("camelCase"))
-        self.assertEqual(StringStyle.CAMEL_BACK, StringStyle.from_str("camelBack"))
-        self.assertEqual(StringStyle.CAPITAL_CASE, StringStyle.from_str("capitalcase"))
-        self.assertEqual(StringStyle.CONST_CASE, StringStyle.from_str("constcase"))
-        self.assertEqual(StringStyle.LOWER_CASE, StringStyle.from_str("lowercase"))
-        self.assertEqual(StringStyle.PASCAL_CASE, StringStyle.from_str("pascalcase"))
-        self.assertEqual(StringStyle.SENTENCE_CASE, StringStyle.from_str("sentencecase"))
-        self.assertEqual(StringStyle.SNAKE_CASE, StringStyle.from_str("snakecase"))
-        self.assertEqual(StringStyle.TITLE_CASE, StringStyle.from_str("titlecase"))
-        self.assertEqual(StringStyle.TRIM_CASE, StringStyle.from_str("trimcase"))
-        self.assertEqual(StringStyle.UPPER_CASE, StringStyle.from_str("uppercase"))
-        self.assertEqual(StringStyle.ALPHANUM_CASE, StringStyle.from_str("alphanumcase"))
+@pytest.mark.parametrize("style_enum, style_str",
+                         [(StringStyle.NONE, "none"),
+                             (StringStyle.CAMEL_CASE, "camelCase"),
+                             (StringStyle.CAMEL_BACK, "camelBack"),
+                             (StringStyle.CAPITAL_CASE, "capitalcase"),
+                             (StringStyle.CONST_CASE, "constcase"),
+                             (StringStyle.LOWER_CASE, "lowercase"),
+                             (StringStyle.PASCAL_CASE, "pascalcase"),
+                             (StringStyle.SENTENCE_CASE, "sentencecase"),
+                             (StringStyle.SNAKE_CASE, "snakecase"),
+                             (StringStyle.TITLE_CASE, "titlecase"),
+                             (StringStyle.TRIM_CASE, "trimcase"),
+                             (StringStyle.UPPER_CASE, "uppercase"),
+                             (StringStyle.ALPHANUM_CASE, "alphanumcase")])
+def test_string_styles(style_enum, style_str):
+    """
+    Test correct parsing of string styles
+    """
+    assert style_enum == StringStyle.from_str(style_str)
 
-    def test_invalid_string_styles(self):
-        with self.assertRaises(Exception): StringStyle.from_str("not_a_valid_case")
 
-    def test_default_units(self):
-        """
-        Test correct parsing of default units
-        """
+def test_invalid_string_styles():
+    with pytest.raises(Exception):
+        StringStyle.from_str("not_a_valid_case")
 
-        # This test will need to be removed when config.yaml is removed
-        Unit.load_default_config_file()
-        self.assertEqual(Unit.MILLIMETER, Unit.from_str("mm"))
-        self.assertEqual(Unit.CENTIMETER, Unit.from_str("cm"))
-        self.assertEqual(Unit.METER, Unit.from_str("m"))
-        self.assertEqual(Unit.KILOMETER, Unit.from_str("km"))
-        self.assertEqual(Unit.KILOMETERPERHOUR, Unit.from_str("km/h"))
-        self.assertEqual(Unit.METERSPERSECONDSQUARED, Unit.from_str("m/s^2"))
-        self.assertEqual(Unit.LITER, Unit.from_str("l"))
-        self.assertEqual(Unit.DEGREECELSIUS, Unit.from_str("celsius"))
-        self.assertEqual(Unit.DEGREE, Unit.from_str("degrees"))
-        self.assertEqual(Unit.DEGREEPERSECOND, Unit.from_str("degrees/s"))
-        self.assertEqual(Unit.KILOWATT, Unit.from_str("kW"))
-        self.assertEqual(Unit.KILOWATTHOURS, Unit.from_str("kWh"))
-        self.assertEqual(Unit.KILOGRAM, Unit.from_str("kg"))
-        self.assertEqual(Unit.VOLT, Unit.from_str("V"))
-        self.assertEqual(Unit.AMPERE, Unit.from_str("A"))
-        self.assertEqual(Unit.SECOND, Unit.from_str("s"))
-        self.assertEqual(Unit.MINUTE, Unit.from_str("min"))
-        self.assertEqual(Unit.WEEKS, Unit.from_str("weeks"))
-        self.assertEqual(Unit.MONTHS, Unit.from_str("months"))
-        self.assertEqual(Unit.YEARS, Unit.from_str("years"))
-        self.assertEqual(Unit.UNIXTIMESTAMP, Unit.from_str("UNIX Timestamp"))
-        self.assertEqual(Unit.PASCAL, Unit.from_str("Pa"))
-        self.assertEqual(Unit.KILOPASCAL, Unit.from_str("kPa"))
-        self.assertEqual(Unit.PERCENT, Unit.from_str("percent"))
-        self.assertEqual(Unit.CUBICCENTIMETERS, Unit.from_str("cm^3"))
-        self.assertEqual(Unit.HORSEPOWER, Unit.from_str("PS"))
-        self.assertEqual(Unit.STARS, Unit.from_str("stars"))
-        self.assertEqual(Unit.GRAMSPERSECOND, Unit.from_str("g/s"))
-        self.assertEqual(Unit.GRAMSPERKILOMETER, Unit.from_str("g/km"))
-        self.assertEqual(Unit.KILOWATTHOURSPER100KILOMETERS, Unit.from_str("kWh/100km"))
-        self.assertEqual(Unit.LITERPER100KILOMETERS, Unit.from_str("l/100km"))
-        self.assertEqual(Unit.LITERPERHOUR, Unit.from_str("l/h"))
-        self.assertEqual(Unit.MILESPERGALLON, Unit.from_str("mpg"))
-        self.assertEqual(Unit.POUND, Unit.from_str("lbs"))
-        self.assertEqual(Unit.NEWTONMETER, Unit.from_str("Nm"))
-        self.assertEqual(Unit.REVOLUTIONSPERMINUTE, Unit.from_str("rpm"))
-        self.assertEqual(Unit.INCH, Unit.from_str("inch"))
-        self.assertEqual(Unit.RATIO, Unit.from_str("ratio"))
-        self.assertEqual(Unit.NANOMETERPERKILOMETER, Unit.from_str("nm/km"))
-        self.assertEqual(Unit.DECIBELMILLIWATT, Unit.from_str("dBm"))
-        self.assertEqual(Unit.KILONEWTON, Unit.from_str("kN"))
 
-    def test_manually_loaded_units(self):
-        """
-        Test correct parsing of units
-        """
-        unit_file = os.path.join(os.path.dirname(__file__), 'explicit_units.yaml')
-        Unit.load_config_file(unit_file)
-        self.assertEqual(Unit.PUNCHEON, Unit.from_str("puncheon"))
-        self.assertEqual(Unit.HOGSHEAD, Unit.from_str("hogshead"))
+def test_default_units():
+    """
+    Test correct parsing of default units
+    """
 
-    def test_invalid_unit(self):
-        with self.assertRaises(Exception): Unit.from_str("not_a_valid_case")
+    # This test will need to be removed when config.yaml is removed
+    Unit.load_default_config_file()
+    assert Unit.MILLIMETER == Unit.from_str("mm")
+    assert Unit.CENTIMETER == Unit.from_str("cm")
+    assert Unit.METER == Unit.from_str("m")
+    assert Unit.KILOMETER == Unit.from_str("km")
+    assert Unit.KILOMETERPERHOUR == Unit.from_str("km/h")
+    assert Unit.METERSPERSECONDSQUARED == Unit.from_str("m/s^2")
+    assert Unit.LITER == Unit.from_str("l")
+    assert Unit.DEGREECELSIUS == Unit.from_str("celsius")
+    assert Unit.DEGREE == Unit.from_str("degrees")
+    assert Unit.DEGREEPERSECOND == Unit.from_str("degrees/s")
+    assert Unit.KILOWATT == Unit.from_str("kW")
+    assert Unit.KILOWATTHOURS == Unit.from_str("kWh")
+    assert Unit.KILOGRAM == Unit.from_str("kg")
+    assert Unit.VOLT == Unit.from_str("V")
+    assert Unit.AMPERE == Unit.from_str("A")
+    assert Unit.SECOND == Unit.from_str("s")
+    assert Unit.MINUTE == Unit.from_str("min")
+    assert Unit.WEEKS == Unit.from_str("weeks")
+    assert Unit.MONTHS == Unit.from_str("months")
+    assert Unit.YEARS == Unit.from_str("years")
+    assert Unit.UNIXTIMESTAMP == Unit.from_str("UNIX Timestamp")
+    assert Unit.PASCAL == Unit.from_str("Pa")
+    assert Unit.KILOPASCAL == Unit.from_str("kPa")
+    assert Unit.PERCENT == Unit.from_str("percent")
+    assert Unit.CUBICCENTIMETERS == Unit.from_str("cm^3")
+    assert Unit.HORSEPOWER == Unit.from_str("PS")
+    assert Unit.STARS == Unit.from_str("stars")
+    assert Unit.GRAMSPERSECOND == Unit.from_str("g/s")
+    assert Unit.GRAMSPERKILOMETER == Unit.from_str("g/km")
+    assert Unit.KILOWATTHOURSPER100KILOMETERS == Unit.from_str("kWh/100km")
+    assert Unit.LITERPER100KILOMETERS == Unit.from_str("l/100km")
+    assert Unit.LITERPERHOUR == Unit.from_str("l/h")
+    assert Unit.MILESPERGALLON == Unit.from_str("mpg")
+    assert Unit.POUND == Unit.from_str("lbs")
+    assert Unit.NEWTONMETER == Unit.from_str("Nm")
+    assert Unit.REVOLUTIONSPERMINUTE == Unit.from_str("rpm")
+    assert Unit.INCH == Unit.from_str("inch")
+    assert Unit.RATIO == Unit.from_str("ratio")
+    assert Unit.NANOMETERPERKILOMETER == Unit.from_str("nm/km")
+    assert Unit.DECIBELMILLIWATT == Unit.from_str("dBm")
+    assert Unit.KILONEWTON == Unit.from_str("kN")
 
-    def test_vss_types(self):
-        """
-        Test correct parsing of VSS Types
-        """
 
-        self.assertEqual(VSSType.BRANCH, VSSType.from_str("branch"))
-        self.assertEqual(VSSType.ATTRIBUTE, VSSType.from_str("attribute"))
-        self.assertEqual(VSSType.SENSOR, VSSType.from_str("sensor"))
-        self.assertEqual(VSSType.ACTUATOR, VSSType.from_str("actuator"))
+def test_manually_loaded_units():
+    """
+    Test correct parsing of units
+    """
+    unit_file = os.path.join(os.path.dirname(__file__), 'explicit_units.yaml')
+    Unit.load_config_file(unit_file)
+    assert Unit.PUNCHEON == Unit.from_str("puncheon")
+    assert Unit.HOGSHEAD == Unit.from_str("hogshead")
 
-    def test_invalid_vss_types(self):
-        with self.assertRaises(Exception): VSSType.from_str("not_a_valid_case")
 
-    def test_vss_data_types(self):
-        """
-        Test correct parsing of VSS Data Types
-        """
+def test_invalid_unit():
+    with pytest.raises(Exception):
+        Unit.from_str("not_a_valid_case")
 
-        self.assertEqual(VSSDataType.INT8, VSSDataType.from_str("int8"))
-        self.assertEqual(VSSDataType.UINT8, VSSDataType.from_str("uint8"))
-        self.assertEqual(VSSDataType.INT16, VSSDataType.from_str("int16"))
-        self.assertEqual(VSSDataType.UINT16, VSSDataType.from_str("uint16"))
-        self.assertEqual(VSSDataType.INT32, VSSDataType.from_str("int32"))
-        self.assertEqual(VSSDataType.UINT32, VSSDataType.from_str("uint32"))
-        self.assertEqual(VSSDataType.INT64, VSSDataType.from_str("int64"))
-        self.assertEqual(VSSDataType.UINT64, VSSDataType.from_str("uint64"))
-        self.assertEqual(VSSDataType.BOOLEAN, VSSDataType.from_str("boolean"))
-        self.assertEqual(VSSDataType.FLOAT, VSSDataType.from_str("float"))
-        self.assertEqual(VSSDataType.DOUBLE, VSSDataType.from_str("double"))
-        self.assertEqual(VSSDataType.STRING, VSSDataType.from_str("string"))
 
-    def test_invalid_vss_data_types(self):
-        with self.assertRaises(Exception): VSSDataType.from_str("not_a_valid_case")
+@pytest.mark.parametrize("type_enum,type_str",
+                         [(VSSType.BRANCH, "branch"),
+                          (VSSType.ATTRIBUTE, "attribute"),
+                          (VSSType.SENSOR, "sensor"),
+                          (VSSType.ACTUATOR, "actuator"),
+                          (VSSType.PROPERTY, "property")])
+def test_vss_types(type_enum, type_str, ):
+    """
+    Test correct parsing of VSS Types
+    """
+
+    assert type_enum == VSSType.from_str(type_str)
+
+
+def test_invalid_vss_types():
+    with pytest.raises(Exception):
+        VSSType.from_str("not_a_valid_case")
+
+
+@pytest.mark.parametrize("data_type_enum,data_type_str",
+                         [(VSSDataType.INT8, "int8"),
+                          (VSSDataType.UINT8, "uint8"),
+                          (VSSDataType.INT16, "int16"),
+                          (VSSDataType.UINT16, "uint16"),
+                          (VSSDataType.INT32, "int32"),
+                          (VSSDataType.UINT32, "uint32"),
+                          (VSSDataType.INT64, "int64"),
+                          (VSSDataType.UINT64, "uint64"),
+                          (VSSDataType.BOOLEAN, "boolean"),
+                          (VSSDataType.FLOAT, "float"),
+                          (VSSDataType.DOUBLE, "double"),
+                          (VSSDataType.STRING, "string")])
+def test_vss_data_types(data_type_enum, data_type_str, ):
+    """
+    Test correct parsing of VSS Data Types
+    """
+    assert data_type_enum == VSSDataType.from_str(data_type_str)
+
+
+def test_invalid_vss_data_types():
+    with pytest.raises(Exception):
+        VSSDataType.from_str("not_a_valid_case")
+
+
+@pytest.mark.parametrize("tree_type_enum,tree_type_str, important_types",
+                         [(VSSTreeType.SIGNAL_TREE, "signal_tree", ["sensor", "actuator", "attribute", "branch"]),
+                          (VSSTreeType.DATA_TYPE_TREE, "data_type_tree", ["struct", "property", "branch"])])
+def test_vss_tree_types(tree_type_enum, tree_type_str, important_types):
+    """
+    Test correct parsing of VSS Tree Types
+    """
+
+    assert tree_type_enum == VSSTreeType.from_str(tree_type_str)
+    available_types = tree_type_enum.available_types()
+    for t in important_types:
+        assert t in available_types
+
+
+def test_invalid_vss_tree_types():
+    with pytest.raises(Exception):
+        VSSDataType.from_str("not_a_valid_case")
 
 
 if __name__ == '__main__':

--- a/tests/model/test_vsstree.py
+++ b/tests/model/test_vsstree.py
@@ -9,7 +9,11 @@ class TestVSSNode(unittest.TestCase):
         """
         Test minimal object construction.
         """
-        source = {"description": "some desc", "type": "branch", "uuid": "26d6e362-a422-11ea-bb37-0242ac130002", "$file_name$": "testfile" }
+        source = {
+            "description": "some desc",
+            "type": "branch",
+            "uuid": "26d6e362-a422-11ea-bb37-0242ac130002",
+            "$file_name$": "testfile"}
         node = VSSNode("test", source)
         self.assertIsNotNone(node)
         self.assertEqual("some desc", node.description)
@@ -24,7 +28,7 @@ class TestVSSNode(unittest.TestCase):
         """
         source = {"description": "some desc", "type": "sensor", "uuid": "26d6e362-a422-11ea-bb37-0242ac130002",
                   "datatype": "uint8", "unit": "km", "min": 0, "max": 100, "allowed": ["one", "two"], "aggregate": False,
-                  "default": "test-default", "$file_name$": "testfile" }
+                  "default": "test-default", "$file_name$": "testfile"}
         node = VSSNode("test", source)
         self.assertIsNotNone(node)
         self.assertEqual("some desc", node.description)
@@ -45,19 +49,30 @@ class TestVSSNode(unittest.TestCase):
         Tests if merging two nodes works as expected
         """
 
-        target = {"description": "some desc", "type": "sensor", "datatype": "float", "uuid": "e36a1d8c-4d06-4c22-ba69-e8b39434a7a3","$file_name$": "testfile"}
+        target = {
+            "description": "some desc",
+            "type": "sensor",
+            "datatype": "float",
+            "uuid": "e36a1d8c-4d06-4c22-ba69-e8b39434a7a3",
+            "$file_name$": "testfile"}
 
         source = {"description": "some desc", "type": "sensor", "datatype": "float", "uuid": "2cc90035-e1c2-43bf-a394-1a439addc8ad",
                   "datatype": "uint8", "unit": "km", "min": 0, "max": 100, "$file_name$": "testfile"}
 
         node_target = VSSNode("MyNode", target)
         node_source = VSSNode("MyNode2", source)
-        self.assertEqual("e36a1d8c-4d06-4c22-ba69-e8b39434a7a3", node_target.uuid)
+        self.assertEqual(
+            "e36a1d8c-4d06-4c22-ba69-e8b39434a7a3",
+            node_target.uuid)
         self.assertTrue(node_target.has_datatype())
-        self.assertEqual("2cc90035-e1c2-43bf-a394-1a439addc8ad", node_source.uuid)
+        self.assertEqual(
+            "2cc90035-e1c2-43bf-a394-1a439addc8ad",
+            node_source.uuid)
 
         node_target.merge(node_source)
-        self.assertEqual("2cc90035-e1c2-43bf-a394-1a439addc8ad", node_target.uuid)
+        self.assertEqual(
+            "2cc90035-e1c2-43bf-a394-1a439addc8ad",
+            node_target.uuid)
         self.assertTrue(node_target.has_datatype())
         self.assertEqual(VSSDataType.UINT8, node_target.datatype)
         self.assertEqual(Unit.KILOMETER, node_target.unit)
@@ -68,25 +83,51 @@ class TestVSSNode(unittest.TestCase):
         """
         Test if tree can be found withing VSS tree
         """
-        source_root = {"description": "High-level vehicle data.", "type": "branch", "uuid": "f6750f15-ba2f-4eab-adcc-19a500982293", "$file_name$": "testfile"}
-        source_drivetrain = {"description": "Drivetrain branch.", "type": "branch", "uuid": "5fb3f710-ed60-426b-a083-015cc7c7bc1b", "$file_name$": "testfile"}
-        source_drivetrain_element = {"description": "Some Drivetrain element.", "type": "sensor", "datatype": "string", "uuid": "9101bbea-aeb6-4b0e-8cec-d8b126e77898", "$file_name$": "testfile"}
+        source_root = {
+            "description": "High-level vehicle data.",
+            "type": "branch",
+            "uuid": "f6750f15-ba2f-4eab-adcc-19a500982293",
+            "$file_name$": "testfile"}
+        source_drivetrain = {
+            "description": "Drivetrain branch.",
+            "type": "branch",
+            "uuid": "5fb3f710-ed60-426b-a083-015cc7c7bc1b",
+            "$file_name$": "testfile"}
+        source_drivetrain_element = {
+            "description": "Some Drivetrain element.",
+            "type": "sensor",
+            "datatype": "string",
+            "uuid": "9101bbea-aeb6-4b0e-8cec-d8b126e77898",
+            "$file_name$": "testfile"}
         node_root = VSSNode("Vehicle", source_root)
         node_drivetrain = VSSNode("Drivetrain", source_drivetrain, node_root)
-        node_drivetrain_element = VSSNode("SomeElement", source_drivetrain_element, node_drivetrain)
+        node_drivetrain_element = VSSNode(
+            "SomeElement", source_drivetrain_element, node_drivetrain)
 
-        self.assertTrue(VSSNode.node_exists(node_root, "/Vehicle/Drivetrain/SomeElement"))
+        self.assertTrue(
+            VSSNode.node_exists(
+                node_root,
+                "/Vehicle/Drivetrain/SomeElement"))
 
     def test_orphan_detection(self):
         """
         Test if vssnode finds orphan (r)branches.
         """
-        source_root = {"description": "High-level vehicle data.", "type": "branch", "uuid": "f6750f15-ba2f-4eab-adcc-19a500982293", "$file_name$": "testfile"}
-        source_drivetrain = {"description": "Drivetrain branch.", "type": "branch", "uuid": "5fb3f710-ed60-426b-a083-015cc7c7bc1b", "$file_name$": "testfile"}
+        source_root = {
+            "description": "High-level vehicle data.",
+            "type": "branch",
+            "uuid": "f6750f15-ba2f-4eab-adcc-19a500982293",
+            "$file_name$": "testfile"}
+        source_drivetrain = {
+            "description": "Drivetrain branch.",
+            "type": "branch",
+            "uuid": "5fb3f710-ed60-426b-a083-015cc7c7bc1b",
+            "$file_name$": "testfile"}
         node_root = VSSNode("Vehicle", source_root)
         node_drivetrain = VSSNode("Drivetrain", source_drivetrain, node_root)
 
         self.assertTrue(node_drivetrain.is_orphan())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/vspec/test_faulty_type/test_faulty_type.py
+++ b/tests/vspec/test_faulty_type/test_faulty_type.py
@@ -12,13 +12,15 @@ import runpy
 import pytest
 import os
 
+
 @pytest.fixture
 def change_test_dir(request, monkeypatch):
     # To make sure we run from test directory
     monkeypatch.chdir(request.fspath.dirname)
 
+
 def test_error(change_test_dir):
-    test_str = "../../../vspec2json.py test.vspec out.json > out.txt"
+    test_str = "../../../vspec2json.py test.vspec out.json 1> out.txt 2>&1"
     result = os.system(test_str)
     assert os.WIFEXITED(result)
     # failure expected

--- a/tests/vspec/test_overlay/test_overlay.py
+++ b/tests/vspec/test_overlay/test_overlay.py
@@ -12,29 +12,37 @@ import runpy
 import pytest
 import os
 
+
 @pytest.fixture
 def change_test_dir(request, monkeypatch):
     # To make sure we run from test directory
     monkeypatch.chdir(request.fspath.dirname)
 
-# Only running json exporter, overlay-functionality should be independent of selected exporter
+# Only running json exporter, overlay-functionality should be independent
+# of selected exporter
+
+
 def run_overlay(overlay_file, expected_file):
-    test_str = "../../../vspec2json.py --json-pretty -e dbc --no-uuid test.vspec -o " + overlay_file + " out.json > out.txt"
+    test_str = "../../../vspec2json.py --json-pretty -e dbc --no-uuid test.vspec -o " + \
+        overlay_file + " out.json > out.txt"
     result = os.system(test_str)
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) == 0
 
     test_str = "diff out.json " + expected_file
-    result =  os.system(test_str)
+    result = os.system(test_str)
     os.system("rm -f out.json out.txt")
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) == 0
 
+
 def test_explicit_overlay(change_test_dir):
     run_overlay("overlay_explicit_branches.vspec", "expected.json")
-    
+
+
 def test_implicit_overlay(change_test_dir):
     run_overlay("overlay_implicit_branches.vspec", "expected.json")
+
 
 def test_overlay_error(change_test_dir):
     test_str = "../../../vspec2json.py --json-pretty --no-uuid test.vspec -o overlay_error.vspec out.json > out.txt"

--- a/tests/vspec/test_types_with_uuid/test_uuid.py
+++ b/tests/vspec/test_types_with_uuid/test_uuid.py
@@ -12,34 +12,40 @@ import runpy
 import pytest
 import os
 
+
 @pytest.fixture
 def change_test_dir(request, monkeypatch):
     # To make sure we run from test directory
     monkeypatch.chdir(request.fspath.dirname)
 
+
 def run_exporter(exporter, argument):
-    test_str = "../../../vspec2" + exporter + ".py " + argument +" test.vspec out." + exporter + " > out.txt"
+    test_str = "../../../vspec2" + exporter + ".py " + argument + \
+        " test.vspec out." + exporter + " 1> out.txt 2>&1"
     result = os.system(test_str)
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) == 0
     test_str = "diff out." + exporter + " expected." + exporter
-    result =  os.system(test_str)
+    result = os.system(test_str)
     os.system("rm -f out." + exporter + " out.txt")
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) == 0
 
+
 def test_uuid(change_test_dir):
 
     # Run all "supported" exporters, i.e. not those in contrib
-    # Exception is "binary", as it is assumed output may vary depending on target
-    exporters = ["json", "ddsidl","csv", "yaml", "franca", "graphql"]
+    # Exception is "binary", as it is assumed output may vary depending on
+    # target
+    exporters = ["json", "ddsidl", "csv", "yaml", "franca", "graphql"]
     for exporter in exporters:
         run_exporter(exporter, "--uuid")
         # Same behavior expected if no argument
         run_exporter(exporter, "")
 
+
 def test_warning_no_parameter(change_test_dir):
-    test_str = "../../../vspec2json.py test.vspec out.json > out.txt"
+    test_str = "../../../vspec2json.py test.vspec out.json 1> out.txt 2>&1"
     result = os.system(test_str)
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) == 0
@@ -49,6 +55,7 @@ def test_warning_no_parameter(change_test_dir):
     os.system("rm -f out.json out.txt")
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) == 0
+
 
 def test_no_warning_uuid_parameter(change_test_dir):
     test_str = "../../../vspec2json.py --uuid test.vspec out.json > out.txt"
@@ -62,8 +69,9 @@ def test_no_warning_uuid_parameter(change_test_dir):
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) != 0
 
+
 def test_no_warning_no_uuid_parameter(change_test_dir):
-    test_str = "../../../vspec2json.py --no-uuid test.vspec out.json > out.txt"
+    test_str = "../../../vspec2json.py --no-uuid test.vspec out.json 1> out.txt 2>&1"
     result = os.system(test_str)
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) == 0
@@ -74,12 +82,13 @@ def test_no_warning_no_uuid_parameter(change_test_dir):
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) != 0
 
+
 def test_error_no_uuid_uuid_parameter(change_test_dir):
-    test_str = "../../../vspec2json.py --uuid --no-uuid test.vspec out.json > out.txt"
+    test_str = "../../../vspec2json.py --uuid --no-uuid test.vspec out.json 1> out.txt 2>&1"
     result = os.system(test_str)
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) != 0
-    test_str = 'grep \"Error: Can not use --uuid and --no-uuid at the same time\" out.txt > /dev/null'
+    test_str = 'grep \"Can not use --uuid and --no-uuid at the same time\" out.txt > /dev/null'
     result = os.system(test_str)
     os.system("cat out.txt")
     os.system("rm -f out.json out.txt")

--- a/vspec/loggingconfig.py
+++ b/vspec/loggingconfig.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+# (c) 2022 BMW Group
+# (c) 2022 Robert Bosch GmbH
+# (c) 2016 Jaguar Land Rover
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
+#
+#
+# Convert vspec files to various other formats
+#
+
+import logging
+
+def initLogging():
+    """
+    Initialize logging
+    """
+    logging.basicConfig(level=logging.DEBUG, format='%(levelname)-8s %(message)s')

--- a/vspec/loggingconfig.py
+++ b/vspec/loggingconfig.py
@@ -13,4 +13,4 @@ def initLogging():
     """
     Initialize logging
     """
-    logging.basicConfig(level=logging.DEBUG, format='%(levelname)-8s %(message)s')
+    logging.basicConfig(level=logging.INFO, format='%(levelname)-8s %(message)s')

--- a/vspec/loggingconfig.py
+++ b/vspec/loggingconfig.py
@@ -1,9 +1,5 @@
 #!/usr/bin/env python3
 
-# (c) 2022 BMW Group
-# (c) 2022 Robert Bosch GmbH
-# (c) 2016 Jaguar Land Rover
-#
 # All files and artifacts in this repository are licensed under the
 # provisions of the license provided by the LICENSE file in this repository.
 #

--- a/vspec/model/constants.py
+++ b/vspec/model/constants.py
@@ -216,6 +216,7 @@ class VSSTreeType(Enum, metaclass=EnumMetaWithReverseLookup):
                        "Float", "Double", "String"])
         if self.value == "signal_tree":
             available_types.update(["branch", "sensor", "actuator", "attribute"])
-        available_types.update(["branch", "struct", "property"])
+        else:
+            available_types.update(["branch", "struct", "property"])
 
         return available_types

--- a/vspec/model/constants.py
+++ b/vspec/model/constants.py
@@ -145,7 +145,9 @@ class VSSType(Enum, metaclass=EnumMetaWithReverseLookup):
     ATTRIBUTE = "attribute"
     SENSOR = "sensor"
     ACTUATOR = "actuator"
-
+    STRUCT = "struct"
+    PROPERTY = "property"
+    
 
 class VSSDataType(Enum, metaclass=EnumMetaWithReverseLookup):
     INT8 = "int8"
@@ -202,3 +204,18 @@ class Unit(metaclass=VSSRepositoryMeta):
         #__members__ = Unit.get_members_from_default_config('units')
         my_units = Unit.get_members_from_default_config('units')
         Unit.add_config(my_units)
+
+
+class VSSTreeType(Enum, metaclass=EnumMetaWithReverseLookup):
+    SIGNAL_TREE = "signal_tree"
+    DATA_TYPE_TREE = "data_type_tree" 
+
+    def available_types(self):
+        available_types = set(["UInt8", "Int8", "UInt16", "Int16",
+                       "UInt32", "Int32", "UInt64", "Int64", "Boolean",
+                       "Float", "Double", "String"])
+        if self.value == "signal_tree":
+            available_types.update(["branch", "sensor", "actuator", "attribute"])
+        available_types.update(["branch", "struct", "property"])
+
+        return available_types

--- a/vspec/model/vsstree.py
+++ b/vspec/model/vsstree.py
@@ -18,6 +18,7 @@ from .constants import VSSType, VSSDataType, Unit
 
 DEFAULT_SEPARATOR = "."
 
+
 class VSSNode(Node):
     """Representation of an VSS element according to the vehicle signal specification."""
     description = None
@@ -34,8 +35,7 @@ class VSSNode(Node):
     whitelisted_extended_attributes = []
 
     unit: Unit
-    
-    
+
     min = ""
     max = ""
     allowed = ""
@@ -49,9 +49,11 @@ class VSSNode(Node):
     deprecation = ""
 
     def __deepcopy__(self, memo):
-        return VSSNode(self.name, self.source_dict.copy(), parent=None, children=copy.deepcopy(self.children, memo))
+        return VSSNode(self.name, self.source_dict.copy(),
+                       parent=None, children=copy.deepcopy(self.children, memo))
 
-    def __init__(self, name, source_dict: dict, parent=None, children=None, break_on_unknown_attribute=False, break_on_name_style_violation=False):
+    def __init__(self, name, source_dict: dict, parent=None, children=None,
+                 break_on_unknown_attribute=False, break_on_name_style_violation=False):
         """Creates an VSS Node object from parsed yaml instance represented as a dict.
 
             Args:
@@ -66,7 +68,7 @@ class VSSNode(Node):
                 VSSNode object according to the Vehicle Signal Specification.
 
         """
-        
+
         super().__init__(name, parent, children)
         try:
             VSSNode.validate_vss_element(source_dict, name)
@@ -130,7 +132,8 @@ class VSSNode(Node):
 
         """
         camel_regexp = p = re.compile('[A-Z][A-Za-z0-9]*$')
-        if self.type != VSSType.BRANCH and self.datatype == VSSDataType.BOOLEAN and not self.name.startswith("Is"):
+        if self.type != VSSType.BRANCH and self.datatype == VSSDataType.BOOLEAN and not self.name.startswith(
+                "Is"):
             raise NameStyleValidationException(
                 f'Boolean node "{self.name}" found in file "{sourcefile}" is not following naming conventions. It is recommended that boolean nodes start with "Is".')
         if not camel_regexp.match(self.name):
@@ -169,15 +172,14 @@ class VSSNode(Node):
         if self.type == VSSType.BRANCH:
             return self.is_leaf
         return False
-    
-    def is_instantiated (self) -> bool:
+
+    def is_instantiated(self) -> bool:
         """Checks if node shall be instantiated through its parent
 
             Returns:
                 True if it shall be instantiated
         """
         return self.instantiate
-
 
     def has_unit(self) -> bool:
         """Checks if this instance has a unit
@@ -258,4 +260,3 @@ class VSSNode(Node):
             if element["type"] != "attribute":
                 raise UnknownAttributeException(
                     "Invalid VSS element %s, only attributes can use default" % name)
-

--- a/vspec/vssexporters/vss2json.py
+++ b/vspec/vssexporters/vss2json.py
@@ -8,9 +8,11 @@
 #
 # Convert vspec tree to JSON
 
+from vspec.model.vsstree import VSSNode, VSSType
 import argparse
 import json
-from vspec.model.vsstree import VSSNode, VSSType
+import logging
+from vspec.loggingconfig import initLogging
 
 
 def add_arguments(parser: argparse.ArgumentParser):
@@ -72,17 +74,22 @@ def export_node(json_dict, node, config, print_uuid):
         json_dict[node.name]["children"] = {}
 
     for child in node.children:
-        export_node(json_dict[node.name]["children"], child, config, print_uuid)
+        export_node(json_dict[node.name]["children"],
+                    child, config, print_uuid)
 
 
 def export(config: argparse.Namespace, root: VSSNode, print_uuid):
-    print("Generating JSON output...")
+    logging.info("Generating JSON output...")
     json_dict = {}
     export_node(json_dict, root, config, print_uuid)
     outfile = open(config.output_file, 'w')
     if config.json_pretty:
-        print("Serializing pretty JSON...")
+        logging.info("Serializing pretty JSON...")
         json.dump(json_dict, outfile, indent=2, sort_keys=True)
     else:
-        print("Serializing compact JSON...")
+        logging.info("Serializing compact JSON...")
         json.dump(json_dict, outfile, indent=None, sort_keys=True)
+
+
+if __name__ == "__main__":
+    initLogging()

--- a/vspec2x.py
+++ b/vspec2x.py
@@ -11,12 +11,15 @@
 # Convert vspec files to various other formats
 #
 
-import argparse
 from enum import Enum
-import sys
-import vspec
 from vspec.model.vsstree import VSSNode
 from vspec.model.constants import Unit
+from vspec.loggingconfig import initLogging
+import argparse
+import logging
+import sys
+import vspec
+
 
 from vspec.vssexporters import vss2json, vss2csv, vss2yaml, vss2binary, vss2franca, vss2ddsidl, vss2graphql
 
@@ -52,9 +55,11 @@ parser = argparse.ArgumentParser(description="Convert vspec to other formats.")
 
 
 def main(arguments):
-    parser.add_argument('-I', '--include-dir', action='append',  metavar='dir', type=str,  default=[],
+    initLogging()
+
+    parser.add_argument('-I', '--include-dir', action='append', metavar='dir', type=str, default=[],
                         help='Add include directory to search for included vspec files.')
-    parser.add_argument('-e', '--extended-attributes', type=str,  default="",
+    parser.add_argument('-e', '--extended-attributes', type=str, default="",
                         help='Whitelisted extended attributes as comma separated list. Note, that not all exporters will support (all) extended attributes.')
     parser.add_argument('-s', '--strict', action='store_true',
                         help='Use strict checking: Terminate when anything not covered or not recommended by VSS language or extensions is found.')
@@ -63,19 +68,27 @@ def main(arguments):
     parser.add_argument('--abort-on-name-style', action='store_true',
                         help=" Terminate naming style not follows recommendations.")
     parser.add_argument('--format', metavar='format', type=Exporter.from_string, choices=list(Exporter),
-                        help='Output format, choose one from '+str(Exporter._member_names_)+". If omitted we try to guess form output_file suffix.")
+                        help='Output format, choose one from ' + str(Exporter._member_names_) + ". If omitted we try to guess form output_file suffix.")
     parser.add_argument('--uuid', action='store_true',
                         help='Include uuid in generated files. This is currently the default behavior.')
     parser.add_argument('--no-uuid', action='store_true',
                         help='Exclude uuid in generated files. This will be default behavior from VSS 4.0 onwards.')
-    parser.add_argument('-o', '--overlays', action='append',  metavar='overlays', type=str,  default=[],
+    parser.add_argument('-o', '--overlays', action='append', metavar='overlays', type=str, default=[],
                         help='Add overlay that will be layered on top of the VSS file in the order they appear.')
-    parser.add_argument('-u', '--unit-file', action='append',  metavar='unit_file', type=str,  default=[],
+    parser.add_argument('-u', '--unit-file', action='append', metavar='unit_file', type=str, default=[],
                         help='Unit file to be used for generation. Argument -u may be used multiple times.')
     parser.add_argument('vspec_file', metavar='<vspec_file>',
                         help='The vehicle specification file to convert.')
     parser.add_argument('output_file', metavar='<output_file>',
                         help='The file to write output to.')
+
+    type_group = parser.add_argument_group(
+        'VSS Data Type Tree arguments',
+        'Arguments related to struct/type support [Experimental]')
+    type_group.add_argument('-vt', '--vspec-types-file', metavar='vspec_types_file', type=str, required=False,
+                            help='Data types file in vspec format.')
+    type_group.add_argument('-ot', '--types-output-file', metavar='<types_output_file>',
+                            help='Output file for writing data types from vspec file.')
 
     for entry in Exporter:
         entry.value.add_arguments(parser.add_argument_group(
@@ -84,20 +97,23 @@ def main(arguments):
     args = parser.parse_args(arguments)
 
     # Figure out output format
-    if args.format != None:  # User has given format parameter
-        print("Output to "+str(args.format.name)+" format")
+    if args.format is not None:  # User has given format parameter
+        logging.info("Output to " + str(args.format.name) + " format")
     else:  # Else try to figure from output file suffix
         try:
-            suffix = args.output_file[args.output_file.rindex(".")+1:]
-        except:
-            print("Can not determine output format. Try setting --format parameter")
+            suffix = args.output_file[args.output_file.rindex(".") + 1:]
+        except BaseException:
+            logging.error(
+                "Can not determine output format. Try setting --format parameter")
             sys.exit(-1)
         try:
             args.format = Exporter.from_string(suffix)
-        except:
-            print("Can not determine output format. Try setting --format parameter")
+        except BaseException:
+            logging.error(
+                "Can not determine output format. Try setting --format parameter")
             sys.exit(-1)
-        print("Output to "+str(args.format.name)+" format")
+
+        logging.info("Output to " + str(args.format.name) + " format")
 
     include_dirs = ["."]
     include_dirs.extend(args.include_dir)
@@ -113,49 +129,80 @@ def main(arguments):
     known_extended_attributes_list = args.extended_attributes.split(",")
     if len(known_extended_attributes_list) > 0:
         vspec.model.vsstree.VSSNode.whitelisted_extended_attributes = known_extended_attributes_list
-        print(
+        logging.info(
             f"Known extended attributes: {', '.join(known_extended_attributes_list)}")
 
     exporter = args.format.value
 
     if args.uuid and args.no_uuid:
-        print("Error: Can not use --uuid and --no-uuid at the same time")
+        logging.error("Can not use --uuid and --no-uuid at the same time")
         sys.exit(-1)
     if not (args.uuid or args.no_uuid):
-        print("Warning: From VSS 4.0 the default behavior for printing uuid will change. Consider using --uuid or --no-uuid.")
-    # From VSS 4.0 default shall be be False and a deprecation warning shall be given no_uuid is used
+        # From VSS 4.0 default shall be be False and a deprecation warning shall
+        # be given no_uuid is used
+        logging.warning(
+            "From VSS 4.0 the default behavior for printing uuid will change. Consider using --uuid or --no-uuid.")
     print_uuid = True
     if args.no_uuid:
         print_uuid = False
-    
+
     if not args.unit_file:
-        print("WARNING: Use of default VSS unit file is deprecated, please specify the unit file you want to use with the -u argument!")
+        logging.warning(
+            "Use of default VSS unit file is deprecated, please specify the unit file you want to use with the -u argument!")
         Unit.load_default_config_file()
     else:
         for unit_file in args.unit_file:
-           print("Reading unit definitions from "+str(unit_file))
-           Unit.load_config_file(unit_file)
+            logging.info("Reading unit definitions from " + str(unit_file))
+            Unit.load_config_file(unit_file)
+
+    # process data type tree
+    type_tree = None
+    if args.vspec_types_file or args.types_output_file:
+        type_tree = processDataTypeTree(parser, args)
 
     try:
-        print(f"Loading vspec from {args.vspec_file}...")
+        logging.info(f"Loading vspec from {args.vspec_file}...")
         tree = vspec.load_tree(
             args.vspec_file, include_dirs, break_on_unknown_attribute=abort_on_unknown_attribute, break_on_name_style_violation=abort_on_namestyle, expand_inst=False)
 
         for overlay in args.overlays:
-            print(f"Applying VSS overlay from {overlay}...")
+            logging.info(f"Applying VSS overlay from {overlay}...")
             othertree = vspec.load_tree(overlay, include_dirs, break_on_unknown_attribute=abort_on_unknown_attribute,
                                         break_on_name_style_violation=abort_on_namestyle, expand_inst=False)
             vspec.merge_tree(tree, othertree)
 
         vspec.expand_tree_instances(tree)
 
-        vspec.clean_metadata(tree);
-        print("Calling exporter...")
+        vspec.clean_metadata(tree)
+        logging.info("Calling exporter...")
         exporter.export(args, tree, print_uuid)
-        print("All done.")
+        logging.info("All done.")
     except vspec.VSpecError as e:
-        print(f"Error: {e}")
+        logging.error(f"Error: {e}")
         sys.exit(255)
+
+
+def processDataTypeTree(parser: argparse.ArgumentParser, args) -> VSSNode:
+    """
+    Helper function to process command line arguments and invoke logic for processing data type information provided in vspec format
+    """
+    # check that both required arguments are available to process the data
+    # type tree
+    if args.types_output_file is None or args.vspec_types_file is None:
+        parser.error(
+            "Please provide the vspec data types file and the output file")
+
+    logging.warning(
+        "vspec struct/type support is an experimental feature. Not all features in the tool chain are supported. Proceed with caution")
+    if len(args.overlays) > 0:
+        parser.error(
+            "Overlays are not yet supported in vspec struct/data type support feature")
+    if args.format.name != "json":
+        parser.error(
+            f"{args.format_name} format is not yet supported in vspec struct/data type support feature")
+
+    raise NotImplementedError(
+        "vspec data type processing is not yet implemented")
 
 
 if __name__ == "__main__":

--- a/vspec2x.py
+++ b/vspec2x.py
@@ -199,7 +199,7 @@ def processDataTypeTree(parser: argparse.ArgumentParser, args) -> VSSNode:
             "Overlays are not yet supported in vspec struct/data type support feature")
     if args.format.name != "json":
         parser.error(
-            f"{args.format_name} format is not yet supported in vspec struct/data type support feature")
+            f"{args.format.name} format is not yet supported in vspec struct/data type support feature")
 
     raise NotImplementedError(
         "vspec data type processing is not yet implemented")


### PR DESCRIPTION
## Description
Run `autopep8` rules on files and update formatting. No change to logic. 
This is reduce the noise/size of the struct/data type parsing related PR - https://github.com/COVESA/vss-tools/pull/224

## Testing
- Run pytest locally