### PR TITLE
Do not allow property nodes outside struct

### DIFF
--- a/tests/vspec/test_structs/VehicleDataTypesInvalidStruct.vspec
+++ b/tests/vspec/test_structs/VehicleDataTypesInvalidStruct.vspec
@@ -10,12 +10,12 @@ VehicleDataTypes.NestedStruct.x:
   type: property
   description: "x property"
   datatype: double
-  
+
 VehicleDataTypes.ParentStruct:
   type: struct
   description: "A struct that is going to contain properties that are structs themselves"
 
-VehicleDataTypes.x_property:
+VehicleDataTypes.ParentStruct.x_property:
   type: property
   description: "A property of struct-type. The struct name is specified relative to the branch"
   datatype: NestedStruct1

--- a/tests/vspec/test_structs/VehicleDataTypesInvalidStructWithOrphanProperties.vspec
+++ b/tests/vspec/test_structs/VehicleDataTypesInvalidStructWithOrphanProperties.vspec
@@ -1,0 +1,25 @@
+VehicleDataTypes:
+  type: branch
+  description: Top-level branch for vehicle data types.
+
+VehicleDataTypes.TestBranch1:
+  type: branch
+  description: Test branch
+
+VehicleDataTypes.TestBranch1.ParentStruct:
+  type: struct
+  description: "A struct that is going to contain properties that are structs themselves"
+
+VehicleDataTypes.TestBranch1.ParentStruct.x_property:
+  type: property
+  description: "A property of struct"
+  datatype: double
+
+VehicleDataTypes.TestBranch1.NestedStruct:
+  type: struct
+  description: "A struct that is going to be used within another struct - Nested"
+
+VehicleDataTypes.TestBranch1.y_property:
+  type: property
+  description: "An orphan property"
+  datatype: double

--- a/tests/vspec/test_structs/VehicleDataTypesInvalidStructWithQualifiedName.vspec
+++ b/tests/vspec/test_structs/VehicleDataTypesInvalidStructWithQualifiedName.vspec
@@ -10,17 +10,17 @@ VehicleDataTypes.NestedStruct.x:
   type: property
   description: "x property"
   datatype: double
-  
+
 VehicleDataTypes.ParentStruct:
   type: struct
   description: "A struct that is going to contain properties that are structs themselves"
 
-VehicleDataTypes.x_property:
+VehicleDataTypes.ParentStruct.x_property:
   type: property
   description: "A property of struct-type. The struct name is specified relative to the branch"
   datatype: VehicleDataTypes.NestedStruct1
 
-VehicleDataTypes.y_property:
+VehicleDataTypes.ParentStruct.y_property:
   type: property
   description: "A property of struct-type. The struct name is specified relative to the branch"
   datatype: VehicleDataTypes.NestedStruct1

--- a/tests/vspec/test_structs/test_data_type_parsing.py
+++ b/tests/vspec/test_structs/test_data_type_parsing.py
@@ -18,8 +18,10 @@ def test_data_types_export_to_json(change_test_dir):
     """
     Test that data types provided in vspec format are converted correctly to the JSON format
     """
-    test_str = " ".join(["../../../vspec2json.py", "--no-uuid", "--format", "json", "--json-pretty", "-vt",
-                        "VehicleDataTypes.vspec", "-ot", "VehicleDataTypes.json", "test.vspec", "out.json", "1>", "out.txt", "2>&1"])
+    test_str = " ".join(["../../../vspec2json.py", "--no-uuid", "--format", "json",
+                         "--json-pretty", "-vt", "VehicleDataTypes.vspec", "-ot",
+                         "VehicleDataTypes.json", "test.vspec", "out.json", "1>",
+                         "out.txt", "2>&1"])
     result = os.system(test_str)
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) == 0
@@ -60,17 +62,41 @@ def test_data_types_invalid_reference_in_data_type_tree(
     assert os.WEXITSTATUS(result) == 0
 
 
+@pytest.mark.parametrize("types_file,error_msg", [
+    ('VehicleDataTypesInvalidStructWithOrphanProperties.vspec',
+     'Orphan property detected. y_property is not defined under a struct')])
+def test_data_types_orphan_properties(
+        types_file, error_msg, change_test_dir):
+    """
+    Test that errors are surfaced when a property is not defined under a struct
+    """
+    test_str = " ".join(["../../../vspec2json.py", "--no-uuid", "--format", "json", "--json-pretty", "-vt",
+                        types_file, "-ot", "VehicleDataTypes.json", "test.vspec", "out.json", "1>", "out.txt", "2>&1"])
+    result = os.system(test_str)
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) != 0
+
+    test_str = f'grep \"{error_msg}\" out.txt > /dev/null'
+    result = os.system(test_str)
+    os.system('cat out.txt')
+    os.system("rm -f VehicleDataTypes.json out.txt")
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0
+
+
 def test_data_types_invalid_reference_in_signal_tree(change_test_dir):
     """
     Test that errors are surfaced when data type name references are invalid in the signal tree
     """
     test_str = " ".join(["../../../vspec2json.py", "--no-uuid", "--format", "json", "--json-pretty", "-vt",
-                        "VehicleDataTypes.vspec", "-ot", "VehicleDataTypes.json", "test-invalid-datatypes.vspec", "out.json", "1>", "out.txt", "2>&1"])
+                         "VehicleDataTypes.vspec", "-ot", "VehicleDataTypes.json", "test-invalid-datatypes.vspec",
+                         "out.json", "1>", "out.txt", "2>&1"])
     result = os.system(test_str)
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) != 0
 
-    error_msg = 'Following types were referenced in signals but have not been defined: VehicleDataTypes.TestBranch1.ParentStruct1, VehicleDataTypes.TestBranch1.NestedStruct1'
+    error_msg = ('Following types were referenced in signals but have not been defined: '
+                 'VehicleDataTypes.TestBranch1.ParentStruct1, VehicleDataTypes.TestBranch1.NestedStruct1')
     test_str = f'grep \"{error_msg}\" out.txt > /dev/null'
     result = os.system(test_str)
     os.system("cat out.txt")


### PR DESCRIPTION
## Description
- Add validation so that property nodes cannot be defined outside struct nodes.

## Testing
- Add test cases and run pytest
