### PR TITLE
Update data type check function to account for non-existant data type

### DIFF
--- a/tests/vspec/test_structs/test_data_type_parsing.py
+++ b/tests/vspec/test_structs/test_data_type_parsing.py
@@ -103,3 +103,24 @@ def test_data_types_invalid_reference_in_signal_tree(change_test_dir):
     os.system("rm -f VehicleDataTypes.json out.txt")
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) == 0
+
+
+def test_error_when_no_user_defined_data_types_are_provided(change_test_dir):
+    """
+    Test that error message is provided when user-defined types are specified
+    in the signal tree but no data type tree is provided.
+    """
+    test_str = " ".join(["../../../vspec2json.py", "--no-uuid", "--format", "json",
+                         "--json-pretty", "test.vspec", "out.json", "1>", "out.txt", "2>&1"])
+    result = os.system(test_str)
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) != 0
+
+    error_msg = ('Following types were referenced in signals but have not been defined: '
+                 'VehicleDataTypes.TestBranch1.ParentStruct, VehicleDataTypes.TestBranch1.NestedStruct')
+    test_str = f'grep \"{error_msg}\" out.txt > /dev/null'
+    result = os.system(test_str)
+    os.system("cat out.txt")
+    os.system("rm -f VehicleDataTypes.json out.txt")
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0

--- a/vspec/__init__.py
+++ b/vspec/__init__.py
@@ -112,7 +112,7 @@ def load_tree(
 
     if tree_type == VSSTreeType.DATA_TYPE_TREE:
         check_data_type_references(tree)
-    else:
+    elif tree_type == VSSTreeType.SIGNAL_TREE:
         check_data_type_references_across_trees(tree, data_type_tree)
     return tree
 
@@ -901,11 +901,11 @@ def check_data_type_references_across_trees(
     for _, _, node in RenderTree(signal_root):
         # signals with user-defined data types
         if node.is_signal() and node.datatype is None:
-            if not node.does_attribute_exist(
+            if data_type_root is None or (not node.does_attribute_exist(
                     data_type_root,
                     lambda n: n.data_type_str,
                     lambda n: n.qualified_name(),
-                    lambda n: n.is_struct()):
+                    lambda n: n.is_struct())):
                 nonexistant_types.append(f'{node.data_type_str}')
 
     if len(nonexistant_types) > 0:


### PR DESCRIPTION
## Description
When checking for data type references, we need to account for the fact that the user may not have specified a data type tree.

## Testing
- Add pytest

