### PR TITLE
Test case: Warn when data type is specified for struct nodes

### DIFF
--- a/tests/vspec/test_structs/VehicleDataTypesStructWithDataType.vspec
+++ b/tests/vspec/test_structs/VehicleDataTypesStructWithDataType.vspec
@@ -1,0 +1,25 @@
+VehicleDataTypes:
+  type: branch
+  description: Top-level branch for vehicle data types.
+
+VehicleDataTypes.TestBranch1:
+  type: branch
+
+VehicleDataTypes.TestBranch1.NestedStruct:
+  type: struct
+  description: "A struct with datatype property defined."
+  datatype: double
+
+VehicleDataTypes.TestBranch1.NestedStruct.x:
+  type: property
+  description: "x property"
+  datatype: double
+
+VehicleDataTypes.TestBranch1.ParentStruct:
+  type: struct
+  description: "A struct that is going to contain properties that are structs themselves"
+
+VehicleDataTypes.TestBranch1.ParentStruct.x_property:
+  type: property
+  description: "A property of struct-type. The struct name is specified relative to the branch"
+  datatype: NestedStruct

--- a/tests/vspec/test_structs/test_data_type_parsing.py
+++ b/tests/vspec/test_structs/test_data_type_parsing.py
@@ -124,3 +124,23 @@ def test_error_when_no_user_defined_data_types_are_provided(change_test_dir):
     os.system("rm -f VehicleDataTypes.json out.txt")
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) == 0
+
+
+def test_warning_when_data_type_is_provided_for_struct_nodes(change_test_dir):
+    """
+    Test that warning message is provided when datatype is specified for struct nodes.
+    """
+    test_str = " ".join(["../../../vspec2json.py", "--no-uuid", "--format", "json", "--json-pretty", "-vt",
+                         "VehicleDataTypesStructWithDataType.vspec", "-ot", "VehicleDataTypes.json", "test.vspec",
+                         "out.json", "1>", "out.txt", "2>&1"])
+    result = os.system(test_str)
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0
+
+    error_msg = 'Data type specified for struct node: NestedStruct. Ignoring it'
+    test_str = f'grep \"{error_msg}\" out.txt > /dev/null'
+    result = os.system(test_str)
+    os.system("cat out.txt")
+    os.system("rm -f VehicleDataTypes.json out.txt")
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0

--- a/vspec/model/vsstree.py
+++ b/vspec/model/vsstree.py
@@ -138,8 +138,11 @@ class VSSNode(Node):
 
         # Datatype and unit need special handling, so we extract them again
         if "datatype" in self.source_dict.keys():
-            self.data_type_str = self.source_dict["datatype"]
-            self.validate_and_set_datatype()
+            if not self.is_struct():
+                self.data_type_str = self.source_dict["datatype"]
+                self.validate_and_set_datatype()
+            else:
+                logging.warning(f"Data type specified for struct node: {self.name}. Ignoring it")
 
         # Units are applicable only for primitives. Not user defined types.
         if "unit" in self.source_dict.keys() and self.has_datatype():


### PR DESCRIPTION
## Description
Data type does not make sense for struct type nodes as they themselves are for defining higher order types. In this PR, we ensure that a warning message is provided to the user if they try to set a data type on a struct node.

## Testing
- Add pytest
- All pytests succeeded