### PR TITLE
Check that mandatory object description is present

### DIFF
--- a/tests/vspec/test_description_error/no_description_branch.vspec
+++ b/tests/vspec/test_description_error/no_description_branch.vspec
@@ -1,0 +1,9 @@
+#
+A:
+  type: branch
+
+A.UInt8:
+  datatype: uint8
+  type: sensor
+  unit: km
+  description: This description is mandatory!

--- a/tests/vspec/test_description_error/no_description_signal.vspec
+++ b/tests/vspec/test_description_error/no_description_signal.vspec
@@ -1,0 +1,9 @@
+#
+A:
+  type: branch
+  description: This description is mandatory!
+
+A.UInt8:
+  datatype: uint8
+  type: sensor
+  unit: km

--- a/tests/vspec/test_description_error/test_description_error.py
+++ b/tests/vspec/test_description_error/test_description_error.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+#
+# (C) 2023 Robert Bosch GmbH
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
+#
+
+import pytest
+import os
+
+
+@pytest.fixture
+def change_test_dir(request, monkeypatch):
+    # To make sure we run from test directory
+    monkeypatch.chdir(request.fspath.dirname)
+
+
+def run_description_error(vspec_file: str):
+    test_str = "../../../vspec2json.py --json-pretty --no-uuid " + vspec_file + " out.json > out.txt 2>&1"
+    result = os.system(test_str)
+    assert os.WIFEXITED(result)
+    # failure expected
+    assert os.WEXITSTATUS(result) != 0
+
+    test_str = 'grep \"Exception: Invalid VSS element\" out.txt > /dev/null'
+    result = os.system(test_str)
+    os.system("cat out.txt")
+    os.system("rm -f out.json out.txt")
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0
+
+
+def test_no_description_branch(change_test_dir):
+    run_description_error("no_description_branch.vspec")
+
+
+def test_no_description_signal(change_test_dir):
+    run_description_error("no_description_signal.vspec")

--- a/vspec/model/vsstree.py
+++ b/vspec/model/vsstree.py
@@ -429,6 +429,9 @@ class VSSNode(Node):
         if "type" not in element.keys():
             raise Exception("Invalid VSS element %s, must have type" % name)
 
+        if "description" not in element.keys():
+            raise Exception("Invalid VSS element %s, must have description" % name)
+
         unknown = []
         for aKey in element.keys():
             if aKey not in VSSNode.core_attributes and aKey not in VSSNode.whitelisted_extended_attributes:


### PR DESCRIPTION
At https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/sensor_actuator/ we do not describe `description` as optional, i.e. it shall be mandatory. But until now we have not checked that, this PR fixes it.

Output with this fix below. Giving a stack trace does not provide much information but that is how we handle other errors in that area, so i did not intend to fix that as part of this PR.

```
erik@debian3:~/vss-tools/tests/vspec/test_description_error$ ../../../vspec2json.py --json-pretty --no-uuid no_description_branch.vspec out.json
INFO     Output to json format
INFO     Known extended attributes: 
WARNING  WARNING: Use of default VSS unit file is deprecated, please specify the unit file you want to use with the -u argument!
INFO     Added None units from default unit file
INFO     Loading vspec from no_description_branch.vspec...
Traceback (most recent call last):
  File "/home/erik/vss-tools/tests/vspec/test_description_error/../../../vspec2json.py", line 17, in <module>
    vspec2x.main(["--format", "json"]+sys.argv[1:])
  File "/home/erik/vss-tools/vspec2x.py", line 163, in main
    tree = vspec.load_tree(
  File "/home/erik/vss-tools/vspec/__init__.py", line 104, in load_tree
    tree = render_tree(
  File "/home/erik/vss-tools/vspec/__init__.py", line 771, in render_tree
    tree_root = VSSNode(
  File "/home/erik/vss-tools/vspec/model/vsstree.py", line 93, in __init__
    VSSNode.validate_vss_element(source_dict, name)
  File "/home/erik/vss-tools/vspec/model/vsstree.py", line 433, in validate_vss_element
    raise Exception("Invalid VSS element %s, must have description" % name)
Exception: Invalid VSS element A, must have description
```
CI Failure currently expected, as VSS catalog is faulty, see https://github.com/COVESA/vehicle_signal_specification/pull/558