### PR TITLE
Check that mandatory object description is present

### DIFF
--- a/tests/vspec/test_description_error/correct.vspec
+++ b/tests/vspec/test_description_error/correct.vspec
@@ -1,0 +1,10 @@
+#
+A:
+  type: branch
+  description: This description is mandatory!
+
+A.UInt8:
+  datatype: uint8
+  type: sensor
+  unit: km
+  description: This description is mandatory!

--- a/tests/vspec/test_description_error/no_description_branch.vspec
+++ b/tests/vspec/test_description_error/no_description_branch.vspec
@@ -1,0 +1,9 @@
+#
+A:
+  type: branch
+
+A.UInt8:
+  datatype: uint8
+  type: sensor
+  unit: km
+  description: This description is mandatory!

--- a/tests/vspec/test_description_error/no_description_signal.vspec
+++ b/tests/vspec/test_description_error/no_description_signal.vspec
@@ -1,0 +1,9 @@
+#
+A:
+  type: branch
+  description: This description is mandatory!
+
+A.UInt8:
+  datatype: uint8
+  type: sensor
+  unit: km

--- a/tests/vspec/test_description_error/no_description_type_branch.vspec
+++ b/tests/vspec/test_description_error/no_description_type_branch.vspec
@@ -1,0 +1,6 @@
+VehicleDataTypes:
+  type: branch
+  description: Top-level branch for vehicle data types.
+
+VehicleDataTypes.TestBranch1:
+  type: branch

--- a/tests/vspec/test_description_error/no_description_type_property.vspec
+++ b/tests/vspec/test_description_error/no_description_type_property.vspec
@@ -1,0 +1,21 @@
+VehicleDataTypes:
+  type: branch
+  description: Top-level branch for vehicle data types.
+
+VehicleDataTypes.TestBranch1:
+  type: branch
+  description: "Another branch."
+
+VehicleDataTypes.TestBranch1.Struct:
+  type: struct
+  description: "A struct"
+
+VehicleDataTypes.TestBranch1.Struct.x:
+  type: property
+  description: "x property"
+  datatype: double
+
+# No description on next
+VehicleDataTypes.TestBranch1.Struct.y:
+  type: property
+  datatype: double

--- a/tests/vspec/test_description_error/no_description_type_struct.vspec
+++ b/tests/vspec/test_description_error/no_description_type_struct.vspec
@@ -1,0 +1,21 @@
+VehicleDataTypes:
+  type: branch
+  description: Top-level branch for vehicle data types.
+
+VehicleDataTypes.TestBranch1:
+  type: branch
+  description: "Another branch."
+
+# No description on next
+VehicleDataTypes.TestBranch1.Struct:
+  type: struct
+
+VehicleDataTypes.TestBranch1.Struct.x:
+  type: property
+  description: "x property"
+  datatype: double
+
+VehicleDataTypes.TestBranch1.Struct.y:
+  type: property
+  description: "y property"
+  datatype: double

--- a/tests/vspec/test_description_error/test_description_error.py
+++ b/tests/vspec/test_description_error/test_description_error.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+
+#
+# (C) 2023 Robert Bosch GmbH
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
+#
+
+import pytest
+import os
+
+
+@pytest.fixture
+def change_test_dir(request, monkeypatch):
+    # To make sure we run from test directory
+    monkeypatch.chdir(request.fspath.dirname)
+
+
+@pytest.mark.parametrize("vspec_file, type_str", [
+    ("no_description_branch.vspec", ""),
+    ("no_description_signal.vspec", ""),
+    ("correct.vspec", "-vt no_description_type_branch.vspec -ot ot.json"),
+    ("correct.vspec", "-vt no_description_type_struct.vspec -ot ot.json"),
+    ("correct.vspec", "-vt no_description_type_property.vspec -ot ot.json")
+    ])
+def test_description_error(vspec_file: str, type_str: str, change_test_dir):
+    test_str = "../../../vspec2json.py --json-pretty -u ../test_units.yaml " + type_str + " " + vspec_file + \
+               " out.json > out.txt 2>&1"
+    result = os.system(test_str)
+    assert os.WIFEXITED(result)
+    # failure expected
+    assert os.WEXITSTATUS(result) != 0
+
+    test_str = 'grep \"Invalid VSS element\" out.txt > /dev/null'
+    result = os.system(test_str)
+    os.system("cat out.txt")
+    os.system("rm -f out.json out.txt")
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0

--- a/tests/vspec/test_overlay/expected_explicit_branches.json
+++ b/tests/vspec/test_overlay/expected_explicit_branches.json
@@ -1,0 +1,60 @@
+{
+  "A": {
+    "children": {
+      "AA": {
+        "children": {
+          "SignalAA": {
+            "datatype": "uint8",
+            "description": "Changing type to uint8.",
+            "type": "sensor",
+            "unit": "km"
+          }
+        },
+        "description": "Branch A.AA.",
+        "type": "branch"
+      },
+      "AB": {
+        "children": {
+          "SignalAB": {
+            "datatype": "uint8",
+            "description": "New signal in new branch.",
+            "type": "sensor"
+          }
+        },
+        "description": "new branch!",
+        "type": "branch"
+      },
+      "SignalA": {
+        "datatype": "int8",
+        "dbc": {
+          "changetype": "ON_CHANGE",
+          "interval_ms": 1000,
+          "signal": "VCFRONT_passengerPresent",
+          "transform": {
+            "mapping": [
+              {
+                "from": 0,
+                "to": false
+              },
+              {
+                "from": 1,
+                "to": true
+              }
+            ]
+          }
+        },
+        "description": "Changing unit to celsius and adding complex deployment info",
+        "type": "sensor",
+        "unit": "celsius"
+      },
+      "SignalA2": {
+        "datatype": "int8",
+        "description": "Adding another signal.",
+        "type": "sensor",
+        "unit": "km"
+      }
+    },
+    "description": "Branch A.",
+    "type": "branch"
+  }
+}

--- a/tests/vspec/test_overlay/expected_implicit_branches.json
+++ b/tests/vspec/test_overlay/expected_implicit_branches.json
@@ -13,17 +13,6 @@
         "description": "Branch A.AA.",
         "type": "branch"
       },
-      "AB": {
-        "children": {
-          "SignalAB": {
-            "datatype": "uint8",
-            "description": "New signal in new branch.",
-            "type": "sensor"
-          }
-        },
-        "description": null,
-        "type": "branch"
-      },
       "SignalA": {
         "datatype": "int8",
         "dbc": {

--- a/tests/vspec/test_overlay/overlay_error.vspec
+++ b/tests/vspec/test_overlay/overlay_error.vspec
@@ -4,6 +4,6 @@ A:
   description: Branch A.
 
 A.SignalA:
+  type: sensor
   unit: celsius
-  description: We will have an error if type and datatype are not given
-
+  description: We will have an error if datatype is not given

--- a/tests/vspec/test_overlay/overlay_implicit_branch_no_description.vspec
+++ b/tests/vspec/test_overlay/overlay_implicit_branch_no_description.vspec
@@ -1,6 +1,3 @@
-#
-A:
-  type: branch
 
 A.SignalA:
   datatype: int8
@@ -24,21 +21,12 @@ A.SignalA2:
   unit: km
   description: Adding another signal.
 
-# Changing on second level
-
-A.AA:
-  type: branch
-
 A.AA.SignalAA:
   type: sensor
   datatype: uint8
   description: Changing type to uint8.
 
-# Adding a new branch
-
-A.AB:
-  type: branch
-  description: new branch!
+# Next one shall give an error, AB is new and have no description
 
 A.AB.SignalAB:
   type: sensor

--- a/tests/vspec/test_overlay/overlay_implicit_branches.vspec
+++ b/tests/vspec/test_overlay/overlay_implicit_branches.vspec
@@ -25,10 +25,3 @@ A.AA.SignalAA:
   type: sensor
   datatype: uint8
   description: Changing type to uint8.
-
-A.AB.SignalAB:
-  type: sensor
-  datatype: uint8
-  description: New signal in new branch.
-
-

--- a/tests/vspec/test_overlay/test_overlay.py
+++ b/tests/vspec/test_overlay/test_overlay.py
@@ -20,14 +20,14 @@ def change_test_dir(request, monkeypatch):
 # of selected exporter
 
 
-def run_overlay(overlay_file, expected_file):
-    test_str = "../../../vspec2json.py --json-pretty  -u ../test_units.yaml -e dbc --no-uuid test.vspec -o " + \
-        overlay_file + " out.json > out.txt"
+def run_overlay(overlay_prefix):
+    test_str = "../../../vspec2json.py --json-pretty -u ../test_units.yaml -e dbc --no-uuid test.vspec -o overlay_" + \
+        overlay_prefix + ".vspec out.json > out.txt"
     result = os.system(test_str)
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) == 0
 
-    test_str = "diff out.json " + expected_file
+    test_str = "diff out.json expected_" + overlay_prefix + ".json"
     result = os.system(test_str)
     os.system("rm -f out.json out.txt")
     assert os.WIFEXITED(result)
@@ -35,22 +35,39 @@ def run_overlay(overlay_file, expected_file):
 
 
 def test_explicit_overlay(change_test_dir):
-    run_overlay("overlay_explicit_branches.vspec", "expected.json")
+    run_overlay("explicit_branches")
 
 
 def test_implicit_overlay(change_test_dir):
-    run_overlay("overlay_implicit_branches.vspec", "expected.json")
+    run_overlay("implicit_branches")
 
 
 def test_overlay_error(change_test_dir):
-    test_str = "../../../vspec2json.py --json-pretty --no-uuid  -u ../test_units.yaml  test.vspec " + \
-               "-o overlay_error.vspec out.json 1> out.txt 2>&1"
+
+    test_str = "../../../vspec2json.py --json-pretty -u ../test_units.yaml -o overlay_error.vspec " + \
+               "test.vspec out.json 1> out.txt 2>&1"
     result = os.system(test_str)
     assert os.WIFEXITED(result)
     # failure expected
     assert os.WEXITSTATUS(result) != 0
 
-    test_str = 'grep \"Merging impossible\" out.txt > /dev/null'
+    test_str = 'grep \"need to have a datatype\" out.txt > /dev/null'
+    result = os.system(test_str)
+    os.system("cat out.txt")
+    os.system("rm -f out.json out.txt")
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0
+
+
+def test_overlay_branch_error(change_test_dir):
+    test_str = "../../../vspec2json.py -e dbc --json-pretty -u ../test_units.yaml test.vspec " + \
+               "-o overlay_implicit_branch_no_description.vspec out.json 1> out.txt 2>&1"
+    result = os.system(test_str)
+    assert os.WIFEXITED(result)
+    # failure expected
+    assert os.WEXITSTATUS(result) != 0
+
+    test_str = 'grep \"Invalid VSS element AB, must have description\" out.txt > /dev/null'
     result = os.system(test_str)
     os.system("cat out.txt")
     os.system("rm -f out.json out.txt")

--- a/tests/vspec/test_overlay_on_instance/expected.json
+++ b/tests/vspec/test_overlay_on_instance/expected.json
@@ -168,11 +168,11 @@
                     "unit": "km"
                   }
                 },
-                "description": null,
+                "description": "Also mandatory!",
                 "type": "branch"
               }
             },
-            "description": null,
+            "description": "Is mandatory!",
             "type": "branch"
           }
         },
@@ -193,7 +193,7 @@
                     "unit": "km"
                   }
                 },
-                "description": null,
+                "description": "Obligatorisch!!!",
                 "type": "branch"
               },
               "T": {
@@ -218,7 +218,7 @@
                     "unit": "km"
                   }
                 },
-                "description": null,
+                "description": "Obligatorisch!!!",
                 "type": "branch"
               },
               "T": {

--- a/tests/vspec/test_overlay_on_instance/overlay_2.vspec
+++ b/tests/vspec/test_overlay_on_instance/overlay_2.vspec
@@ -5,8 +5,8 @@ A.B.Row2.Left.E:
   type: sensor
   unit: km
   description: Signal A.B.E.
-  
-  
+
+
 # Individual ones shall have precedence
 # Give custom attribute to all
 
@@ -44,22 +44,36 @@ A.B.Row3.Right.C:
   my_id: Lund
 
 # Adding one outside instance range, shall not inherit original comment
+# Row5 and Row5.Right does not exist in standard tree, so explicit definition with description needed
+A.B.Row5:
+  type: branch
+  description: Is mandatory!
+
+A.B.Row5.Right:
+  type: branch
+  description: Also mandatory!
+
 A.B.Row5.Right.C:
   datatype: float
   type: sensor
   unit: km
   my_id: Landskrona
   description: New Muhaha
-  
+
 #Shall inherit comment
 A.S.Front.T:
   datatype: float
   type: sensor
   unit: km
   description: Changed description, shall inherit comment
-  
+
 #Totally new, shall not inherit anything, will not be considered as extending instantiation
 # I.e. will be expanded to A.S.Front.Down.T and A.S.Rear.Down.T
+
+A.S.Down:
+  type: branch
+  description: Obligatorisch!!!
+
 A.S.Down.T:
   datatype: float
   type: sensor

--- a/tests/vspec/test_overlay_on_instance/test_overlay_on_instance.py
+++ b/tests/vspec/test_overlay_on_instance/test_overlay_on_instance.py
@@ -20,8 +20,8 @@ def change_test_dir(request, monkeypatch):
 
 
 def test_expanded_overlay(change_test_dir):
-    test_str = "../../../vspec2json.py  -e my_id --json-pretty --no-uuid test.vspec -u ../test_units.yaml " + \
-               "-o overlay_1.vspec -o overlay_2.vspec out.json > out.txt"
+    test_str = "../../../vspec2json.py  -e my_id --json-pretty --no-uuid -u ../test_units.yaml test.vspec " + \
+               "-o overlay_1.vspec -o overlay_2.vspec out.json > out.txt 2>&1"
     result = os.system(test_str)
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) == 0

--- a/tests/vspec/test_structs/VehicleDataTypesStructWithDataType.vspec
+++ b/tests/vspec/test_structs/VehicleDataTypesStructWithDataType.vspec
@@ -3,6 +3,7 @@ VehicleDataTypes:
   description: Top-level branch for vehicle data types.
 
 VehicleDataTypes.TestBranch1:
+  description: "A branch"
   type: branch
 
 VehicleDataTypes.TestBranch1.NestedStruct:

--- a/tests/vspec/test_type_error/branch_wrong_case.vspec
+++ b/tests/vspec/test_type_error/branch_wrong_case.vspec
@@ -1,0 +1,9 @@
+A:
+  type: BRANCH
+  description: VSS is case sensitive
+
+A.UInt8:
+  datatype: uint8
+  type: sensor
+  unit: km
+  description: This description is mandatory!

--- a/tests/vspec/test_type_error/correct.vspec
+++ b/tests/vspec/test_type_error/correct.vspec
@@ -1,0 +1,10 @@
+#
+A:
+  type: branch
+  description: This description is mandatory!
+
+A.UInt8:
+  datatype: uint8
+  type: sensor
+  unit: km
+  description: This description is mandatory!

--- a/tests/vspec/test_type_error/no_type_branch.vspec
+++ b/tests/vspec/test_type_error/no_type_branch.vspec
@@ -1,0 +1,8 @@
+A:
+  description: This description is mandatory!
+
+A.UInt8:
+  datatype: uint8
+  type: sensor
+  unit: km
+  description: This description is mandatory!

--- a/tests/vspec/test_type_error/no_type_overlay.vspec
+++ b/tests/vspec/test_type_error/no_type_overlay.vspec
@@ -1,0 +1,6 @@
+# This is intended as an overlay to correct.vspec
+
+A.B:
+  datatype: uint8
+  unit: km
+  description: This description is mandatory!

--- a/tests/vspec/test_type_error/no_type_property.vspec
+++ b/tests/vspec/test_type_error/no_type_property.vspec
@@ -1,0 +1,17 @@
+VehicleDataTypes:
+  type: branch
+  description: Top-level branch for vehicle data types.
+
+# No description on next
+VehicleDataTypes.Struct:
+  type: struct
+  description: djkdfjkdf
+
+VehicleDataTypes.Struct.x:
+  description: "x property"
+  datatype: double
+
+VehicleDataTypes.Struct.y:
+  type: property
+  description: "y property"
+  datatype: double

--- a/tests/vspec/test_type_error/no_type_signal.vspec
+++ b/tests/vspec/test_type_error/no_type_signal.vspec
@@ -1,0 +1,8 @@
+A:
+  type: branch
+  description: This description is mandatory!
+
+A.UInt8:
+  datatype: uint8
+  unit: km
+  description: This description is mandatory!

--- a/tests/vspec/test_type_error/no_type_struct.vspec
+++ b/tests/vspec/test_type_error/no_type_struct.vspec
@@ -1,0 +1,17 @@
+VehicleDataTypes:
+  type: branch
+  description: Top-level branch for vehicle data types.
+
+# No description on next
+VehicleDataTypes.Struct:
+  description: djkdfjkdf
+
+VehicleDataTypes.Struct.x:
+  type: property
+  description: "x property"
+  datatype: double
+
+VehicleDataTypes.Struct.y:
+  type: property
+  description: "y property"
+  datatype: double

--- a/tests/vspec/test_type_error/test_type_error.py
+++ b/tests/vspec/test_type_error/test_type_error.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+#
+# (C) 2023 Robert Bosch GmbH
+#
+# All files and artifacts in this repository are licensed under the
+# provisions of the license provided by the LICENSE file in this repository.
+#
+
+import pytest
+import os
+
+
+@pytest.fixture
+def change_test_dir(request, monkeypatch):
+    # To make sure we run from test directory
+    monkeypatch.chdir(request.fspath.dirname)
+
+
+@pytest.mark.parametrize("vspec_file, type_str", [
+    ("no_type_branch.vspec", ""),
+    ("no_type_signal.vspec", ""),
+    ("correct.vspec", "-o no_type_overlay.vspec"),
+    ("correct.vspec", "-vt no_type_struct.vspec -ot ot.json"),
+    ("correct.vspec", "-vt no_type_property.vspec -ot ot.json")
+    ])
+def test_description_error(vspec_file: str, type_str: str, change_test_dir):
+    test_str = "../../../vspec2json.py --json-pretty -u ../test_units.yaml " + type_str + " " + \
+               vspec_file + " out.json > out.txt 2>&1"
+    result = os.system(test_str)
+    assert os.WIFEXITED(result)
+    # failure expected
+    assert os.WEXITSTATUS(result) != 0
+
+    test_str = 'grep \"No type specified\" out.txt > /dev/null'
+    result = os.system(test_str)
+    os.system("cat out.txt")
+    os.system("rm -f out.json out.txt")
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0
+
+
+# Currently disabled, add "test_" at beginning if we decided to require case sensitivity
+def case_sensitive(change_test_dir):
+    test_str = "../../../vspec2json.py --json-pretty --no-uuid " + \
+               "branch_wrong_case.vspec out.json > out.txt 2>&1"
+    result = os.system(test_str)
+    assert os.WIFEXITED(result)
+    # failure expected
+    assert os.WEXITSTATUS(result) != 0
+
+    test_str = 'grep \"Unknown type: BRANCH\" out.txt > /dev/null'
+    result = os.system(test_str)
+    os.system("cat out.txt")
+    os.system("rm -f out.json out.txt")
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0

--- a/vspec/model/exceptions.py
+++ b/vspec/model/exceptions.py
@@ -7,13 +7,6 @@
 # provisions of the license provided by the LICENSE file in this repository.
 #
 
-class UnknownAttributeException(Exception):
-    def __init__(self, message):
-
-        # Call the base class constructor with the parameters it needs
-        super().__init__(message)
-
-
 class NameStyleValidationException(Exception):
     def __init__(self, message):
 

--- a/vspec2x.py
+++ b/vspec2x.py
@@ -156,19 +156,19 @@ def main(arguments):
     data_type_tree = None
     if args.vspec_types_file or args.types_output_file:
         data_type_tree = processDataTypeTree(
-            parser, args, include_dirs, abort_on_unknown_attribute, abort_on_namestyle)
+            parser, args, include_dirs, abort_on_namestyle)
+        vspec.verify_mandatory_attributes(data_type_tree, abort_on_unknown_attribute)
 
     try:
         logging.info(f"Loading vspec from {args.vspec_file}...")
         tree = vspec.load_tree(
             args.vspec_file, include_dirs, VSSTreeType.SIGNAL_TREE,
-            break_on_unknown_attribute=abort_on_unknown_attribute, break_on_name_style_violation=abort_on_namestyle,
+            break_on_name_style_violation=abort_on_namestyle,
             expand_inst=False, data_type_tree=data_type_tree)
 
         for overlay in args.overlays:
             logging.info(f"Applying VSS overlay from {overlay}...")
             othertree = vspec.load_tree(overlay, include_dirs, VSSTreeType.SIGNAL_TREE,
-                                        break_on_unknown_attribute=abort_on_unknown_attribute,
                                         break_on_name_style_violation=abort_on_namestyle, expand_inst=False,
                                         data_type_tree=data_type_tree)
             vspec.merge_tree(tree, othertree)
@@ -176,6 +176,7 @@ def main(arguments):
         vspec.expand_tree_instances(tree)
 
         vspec.clean_metadata(tree)
+        vspec.verify_mandatory_attributes(tree, abort_on_unknown_attribute)
         logging.info("Calling exporter...")
 
         # temporary until all exporters support data type tree
@@ -193,7 +194,7 @@ def main(arguments):
 
 
 def processDataTypeTree(parser: argparse.ArgumentParser, args, include_dirs,
-                        abort_on_unknown_attribute: bool, abort_on_namestyle: bool) -> VSSNode:
+                        abort_on_namestyle: bool) -> VSSNode:
     """
     Helper function to process command line arguments and invoke logic for processing data
     type information provided in vspec format
@@ -214,7 +215,6 @@ def processDataTypeTree(parser: argparse.ArgumentParser, args, include_dirs,
     logging.info(
         f"Loading and processing struct/data type tree from {args.vspec_types_file}")
     return vspec.load_tree(args.vspec_types_file, include_dirs, VSSTreeType.DATA_TYPE_TREE,
-                           break_on_unknown_attribute=abort_on_unknown_attribute,
                            break_on_name_style_violation=abort_on_namestyle, expand_inst=False)
 
 


### PR DESCRIPTION
Also refactoring existing checks somewhat to check when tree is finished rather than on individual nodes.
That relaxes requirements on individual overlays, I think we say in documentation today that an overlay shall be a valid tree in itself. That is however not strictly needed as it is not intended to be usable by itself. 

With this change the "defect" in VSS 3.1 with a branch without description would had been detected