### PR TITLE
Adding go.sum for binary/go_parser/parserlib

### DIFF
--- a/binary/go_parser/parserlib/go.sum
+++ b/binary/go_parser/parserlib/go.sum
@@ -1,0 +1,2 @@
+github.com/COVESA/vss-tools/binary/go_parser/datamodel v0.0.0-20211207094201-7208d48f32b6 h1:X/QMw3rKleUgS8PrSplIyLehxt9cyIEsUsjReWHkGu8=
+github.com/COVESA/vss-tools/binary/go_parser/datamodel v0.0.0-20211207094201-7208d48f32b6/go.mod h1:g2N97BLJNriANqodWem0usF9fKwwUFHP+VxG1dfSsZQ=


### PR DESCRIPTION
Seems to be needed, and was missed when we added the same file for binary/go_parser