### PR TITLE
Extend existing implementation of DDSIDL exporter to support struct types.

### DIFF
--- a/tests/vspec/test_structs/test.idl
+++ b/tests/vspec/test_structs/test.idl
@@ -1,0 +1,42 @@
+module VehicleDataTypes {
+module TestBranch1 {
+    struct NestedStruct {
+        double x;
+        double y;
+        double z;
+    };
+
+    struct ParentStruct {
+        VehicleDataTypes::TestBranch1::NestedStruct x_property;
+        VehicleDataTypes::TestBranch1::NestedStruct y_property;
+        sequence<VehicleDataTypes::TestBranch1::NestedStruct, 10> x_properties;
+        sequence<VehicleDataTypes::TestBranch1::NestedStruct> y_properties;
+        double z_property;
+    };
+
+};
+};
+module A
+{
+    struct _UInt8
+    {
+        octet value;
+        const string unit="km";
+        const string type ="sensor";
+        const string description="A uint8.";
+    };
+
+    struct ParentStructSensor
+    {
+        VehicleDataTypes::TestBranch1::ParentStruct value;
+        const string type ="sensor";
+        const string description="A rich sensor with user-defined data type.";
+    };
+
+    struct NestedStructSensor
+    {
+        VehicleDataTypes::TestBranch1::NestedStruct value;
+        const string type ="sensor";
+        const string description="A rich sensor with user-defined data type.";
+    };
+};

--- a/tests/vspec/test_structs/test_commandline.py
+++ b/tests/vspec/test_structs/test_commandline.py
@@ -35,7 +35,7 @@ def test_error_when_data_types_file_is_missing(change_test_dir):
     assert os.WEXITSTATUS(result) == 0
 
 
-@pytest.mark.parametrize("format", ["binary", "franca", "idl", "graphql"])
+@pytest.mark.parametrize("format", ["binary", "franca", "graphql"])
 def test_error_with_non_compatible_formats(format, change_test_dir):
     # test that program fails due to parser error
     cmdline = ('../../../vspec2x.py -u ../test_units.yaml -vt VehicleDataTypes.vspec -ot output_types_file.json'

--- a/vspec2x.py
+++ b/vspec2x.py
@@ -24,7 +24,7 @@ import vspec
 from vspec.vssexporters import vss2json, vss2csv, vss2yaml, \
     vss2binary, vss2franca, vss2ddsidl, vss2graphql, vss2protobuf, vss2jsonschema
 
-SUPPORTED_STRUCT_EXPORT_FORMATS = set(["json", "yaml", "csv", "protobuf", "jsonschema"])
+SUPPORTED_STRUCT_EXPORT_FORMATS = set(["json", "yaml", "csv", "protobuf", "jsonschema", "idl"])
 
 
 class Exporter(Enum):


### PR DESCRIPTION
Confirm expected output for DDSIDL before proceeding with the implementation

- Each struct in vspec is translated to corresponding struct in DDSIDL.
- The struct name is same as the base name of the node
- The qualified name of the struct becomes a module