### PR TITLE
Validate against circular refs for property types

### DIFF
--- a/tests/vspec/test_structs/VehicleDataTypesWithCircularRefs.vspec
+++ b/tests/vspec/test_structs/VehicleDataTypesWithCircularRefs.vspec
@@ -1,0 +1,45 @@
+VehicleDataTypes:
+  type: branch
+  description: Top-level branch for vehicle data types.
+
+VehicleDataTypes.TestBranch1:
+  type: branch
+  description: "Test branch with structs and properties definitions"
+
+VehicleDataTypes.TestBranch1.NestedStruct:
+  type: struct
+  description: "A struct with properties containing circular references"
+
+VehicleDataTypes.TestBranch1.NestedStruct.a_property:
+  type: property
+  description: "Normal"
+  datatype: double
+
+VehicleDataTypes.TestBranch1.ParentStruct:
+  type: struct
+  description: "A struct with properties containing circular references"
+
+VehicleDataTypes.TestBranch1.ParentStruct.a_property:
+  type: property
+  description: "Normal"
+  datatype: double
+
+VehicleDataTypes.TestBranch1.ParentStruct.b_property:
+  type: property
+  description: "Circular"
+  datatype: ParentStruct
+
+VehicleDataTypes.TestBranch1.ParentStruct.c_property:
+  type: property
+  description: "Circular"
+  datatype: ParentStruct[]
+
+VehicleDataTypes.TestBranch1.ParentStruct.d_property:
+  type: property
+  description: "Circular"
+  datatype: VehicleDataTypes.TestBranch1.ParentStruct
+
+VehicleDataTypes.TestBranch1.ParentStruct.e_property:
+  type: property
+  description: "Circular"
+  datatype: VehicleDataTypes.TestBranch1.ParentStruct[]

--- a/tests/vspec/test_structs/test_data_type_parsing.py
+++ b/tests/vspec/test_structs/test_data_type_parsing.py
@@ -135,6 +135,8 @@ def test_data_types_export_to_proto(signal_vspec_file, type_vspec_file, expected
 @pytest.mark.parametrize("types_file,error_msg", [
     ('VehicleDataTypesInvalidStructWithQualifiedName.vspec',
      '2 data type reference errors detected'),
+    ('VehicleDataTypesWithCircularRefs.vspec',
+     '4 data type reference errors detected'),
     ('VehicleDataTypesInvalidStruct.vspec', 'Data type not found. Data Type: NestedStruct1')])
 def test_data_types_invalid_reference_in_data_type_tree(
         types_file, error_msg, change_test_dir):

--- a/vspec/__init__.py
+++ b/vspec/__init__.py
@@ -911,6 +911,15 @@ def check_data_type_references_recursive(
                     f"Data Type reference invalid. Node Name: {node.name}. "
                     f"Node Qualified Name: {node.qualified_name()}. "
                     f"Data Type: {undecorated_data_type}")
+
+            separator = "."
+            # is the property circularly refereing to the struct in which it is defined?
+            member_of = separator.join(node.qualified_name(separator).split(separator)[:-1])
+            if member_of == undecorated_data_type:
+                errors.append(
+                    "Circular reference detected in data type. "
+                    f"Data Type: {member_of}. Property: {node.name}")
+
     for n in node.children:
         check_data_type_references_recursive(
             n, data_type_qualified_names, errors)

--- a/vspec/model/vsstree.py
+++ b/vspec/model/vsstree.py
@@ -362,12 +362,12 @@ class VSSNode(Node):
                         logging.error(
                             f"Data type not found. Data Type: {undecorated_datatype_str}")
                         sys.exit(-1)
+
+                    # replace data type with qualified name
+                    if is_array:
+                        self.data_type_str = struct_fqn + ARRAY_SUBSCRIPT_OP
                     else:
-                        # replace data type with qualified name
-                        if is_array:
-                            self.data_type_str = struct_fqn + ARRAY_SUBSCRIPT_OP
-                        else:
-                            self.data_type_str = struct_fqn
+                        self.data_type_str = struct_fqn
             elif self.is_signal():
                 # This is a signal possibly referencing a user-defined type.
                 # Just assign the string value for now. Validation will be


### PR DESCRIPTION
## Summary
Validate that a struct's property cannot reference its own struct as a data type.

Sample error message:

```
ERROR    4 data type reference errors detected. Errors: Circular reference detected in data type. Data Type: VehicleDataTypes.TestBranch1.ParentStruct. Property: b_property,Circular reference detected in data type. Data Type: VehicleDataTypes.TestBranch1.ParentStruct. Property: c_property,Circular reference detected in data type. Data Type: VehicleDataTypes.TestBranch1.ParentStruct. Property: d_property,Circular reference detected in data type. Data Type: VehicleDataTypes.TestBranch1.ParentStruct. Property: e_property
```
### Testing
- Added unit test

https://github.com/COVESA/vss-tools/issues/266