### PR TITLE
Remove experimental references for struct

### DIFF
--- a/tests/vspec/test_types_with_uuid/test_uuid.py
+++ b/tests/vspec/test_types_with_uuid/test_uuid.py
@@ -29,6 +29,7 @@ def run_exporter(exporter, argument, compare_suffix):
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) == 0
 
+
 def test_uuid(change_test_dir):
 
     # Run all "supported" exporters, i.e. not those in contrib

--- a/vspec2x.py
+++ b/vspec2x.py
@@ -93,7 +93,7 @@ def main(arguments):
 
     type_group = parser.add_argument_group(
         'VSS Data Type Tree arguments',
-        'Arguments related to struct/type support [Experimental]')
+        'Arguments related to struct/type support')
     type_group.add_argument('-vt', '--vspec-types-file', metavar='vspec_types_file', type=str, required=False,
                             help='Data types file in vspec format.')
     type_group.add_argument('-ot', '--types-output-file', metavar='<types_output_file>',


### PR DESCRIPTION
Remove experimental references for struct usage in preparation for major release.
Other usages of the word have been removed in https://github.com/COVESA/vss-tools/issues/234.


https://github.com/COVESA/vss-tools/issues/234