### PR TITLE
Streamlining for pypi packaging

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -77,3 +77,29 @@ jobs:
           cd ${{ env.VSS_TOOLS_PATH }}/binary/go_parser
           go build -o gotestparser testparser.go
           go list -m -json -buildvcs=false all
+
+  pypitest:
+    name: Test PyPI packaging
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout vss-tools
+        uses: actions/checkout@v2
+      - name: Test Pypi packaging
+        run: |
+          # Separate build as we want a clean environment to make sure all dependencies are present
+          python -m pip --quiet --no-input install --upgrade pip
+          pip install -e .
+      - name: Test that tools can be started
+        run: |
+          # Verify that it works from any directory
+          mkdir /tmp/pypi_vss_test
+          cd /tmp/pypi_vss_test
+          # Just verify that we can start the tools
+          vspec2x.py --help
+          vspec2csv.py --help
+          vspec2json.py --help
+          vspec2yaml.py --help
+          vspec2franca.py --help
+          vspec2ddsidl.py --help
+          vspec2protobuf.py --help
+          vspec2graphql.py --help

--- a/README.md
+++ b/README.md
@@ -138,3 +138,24 @@ vspec2yaml.py: error: the following arguments are required: <vspec_file>, <outpu
 
 ## Pre-commit set up
 This repository is set up to use pre-commit hooks. After you clone the project, run `pre-commit install` to install pre-commit into your git hooks. pre-commit will now run on every commit. Every time you clone a project using pre-commit running pre-commit install should always be the first thing you do.
+
+## Building and installing with Pip
+
+Vss-tools can be installed by Pip. If you just want the latest version this should be sufficient:
+
+```sh
+pip install vss-tools
+```
+
+When installed tools like `vspec2x.py` shall be available on your path.
+
+For more information see the [wiki](https://github.com/COVESA/vss-tools/wiki/PyPI-packing).
+
+### Pip versioning
+
+This is the versions types that may exist in PyPI for vss-tools and used for local pip install (`pip install -e .`)
+
+* X.Y or X.Y.Z - A released version.
+* X.Y.devN, N starting from 0 - Developer builds - may be published to PyPI if needed for testing purposes.
+* X.YaN, N starting from 0 - Pre-releases, may be published to PyPI if needed for testing purposes.
+* X.YrcN, N starting from 0 - Release candidates, to be published around two weeks before a major/minor release.

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,30 @@
 #!/usr/bin/env python3
 from setuptools import setup, find_packages
-import subprocess
 
-# Use tag as version, *if* it is a tagged commit...
-r = subprocess.run(['git', 'tag', '--points-at=HEAD'], stdout=subprocess.PIPE)
-version = r.stdout.rstrip().decode('UTF-8')
-
-# ...otherwise, use abbreviated git commit hash
-if version == '':
-    r = subprocess.run(['git', 'rev-parse', '--short=8', 'HEAD'], stdout=subprocess.PIPE)
-    version = '4.1.dev+' + r.stdout.rstrip().decode('UTF-8')
+# Proposed versioning mechanism
+#
+# General: - Use 3 numbers only if needed, i.e. do not use X.Y.0
+#          - Master branch should by default always have a dev-version, except for released commits
+#
+# * During development (in master), use X.Y.devN, use N==0 as starting point, only increase N if needed for pypi
+#   reasons, like if a maintainer has pushed 4.0.dev0 to pypi, then update to 4.0.dev1
+# * For release candidates use X.YrcN, use N==0 as starting point
+# * If needed (for bigger functionality, dependencies, .., create pre-releases like 0.4a0
+# * When working on patches just add a third number, like 0.4.1.dev0, 0.4.1rc0 (if needed at all)
+#
+#
 
 setup(
     name='vss-tools',
-    version=version,
     description='COVESA Vehicle Signal Specification tooling.',
+    version='4.1.dev5',
     url='https://github.com/COVESA/vss-tools',
     license='Mozilla Public License 2.0',
     packages=find_packages(exclude=('tests', 'contrib')),
-    scripts=['vspec2csv.py', 'vspec2x.py', 'vspec2franca.py', 'vspec2binary.py', 'vspec2json.py', 'vspec2ddsidl.py',
-             'vspec2yaml.py', 'vspec2protobuf.py'],
+    scripts=['vspec2csv.py', 'vspec2x.py', 'vspec2franca.py', 'vspec2json.py', 'vspec2ddsidl.py',
+             'vspec2yaml.py', 'vspec2protobuf.py', 'vspec2graphql.py'],
     python_requires='>=3.8',
-    install_requires=['pyyaml>=5.1', 'anytree>=2.8.0', 'deprecation>=2.1.0'],
+    install_requires=['pyyaml>=5.1', 'anytree>=2.8.0', 'deprecation>=2.1.0', 'graphql-core'],
     tests_require=['pytest>=2.7.2'],
     package_data={'vspec': [
         'py.typed'

--- a/vspec/vssexporters/vss2binary.py
+++ b/vspec/vssexporters/vss2binary.py
@@ -9,16 +9,21 @@
 # Convert vspec tree to binary format
 
 import argparse
+import logging
 import ctypes
 import os.path
 from vspec.model.vsstree import VSSNode, VSSType
 
-out_file=""
-_cbinary=None
+out_file = ""
+_cbinary = None
 
-def createBinaryCnode(fname, nodename, nodetype, uuid, description, nodedatatype, nodemin, nodemax, unit, allowed, defaultAllowed, validate, children):
+
+def createBinaryCnode(fname, nodename, nodetype, uuid, description, nodedatatype, nodemin, nodemax, unit, allowed,
+                      defaultAllowed, validate, children):
     global _cbinary
-    _cbinary.createBinaryCnode(fname, nodename, nodetype, uuid, description, nodedatatype, nodemin, nodemax, unit, allowed, defaultAllowed, validate, children)
+    _cbinary.createBinaryCnode(fname, nodename, nodetype, uuid, description, nodedatatype, nodemin, nodemax, unit,
+                               allowed, defaultAllowed, validate, children)
+
 
 def allowedString(allowedList):
     allowedStr = ""
@@ -27,11 +32,13 @@ def allowedString(allowedList):
 #    print("allowedstr=" + allowedStr + "\n")
     return allowedStr
 
+
 def hexAllowedLen(allowed):
     hexDigit1 = len(allowed) // 16
     hexDigit2 = len(allowed) - hexDigit1*16
 #    print("Hexdigs:" + str(hexDigit1) + str(hexDigit2))
     return "".join([intToHexChar(hexDigit1), intToHexChar(hexDigit2)])
+
 
 def intToHexChar(hexInt):
     if (hexInt < 10):
@@ -39,8 +46,9 @@ def intToHexChar(hexInt):
     else:
         return chr(hexInt - 10 + ord('A'))
 
+
 def add_arguments(parser: argparse.ArgumentParser):
-    parser.description="The binary exporter does not support any additional arguments."
+    parser.description = "The binary exporter does not support any additional arguments."
 
 
 def export_node(node, generate_uuid, out_file):
@@ -61,12 +69,8 @@ def export_node(node, generate_uuid, out_file):
     nodeunit = ""
     nodeallowed = ""
     nodedefault = ""
-    nodecomment = ""
     nodeuuid = ""
-    nodevalidate = "" #exported to binary
-    # not exported to binary
-    nodedeprecation = ""
-    nodeaggregate = ""
+    nodevalidate = ""  # exported to binary
 
     if node.type == VSSType.SENSOR or node.type == VSSType.ACTUATOR or node.type == VSSType.ATTRIBUTE:
         nodedatatype = str(node.datatype.value)
@@ -89,26 +93,12 @@ def export_node(node, generate_uuid, out_file):
         nodedefault = str(node.default)
     b_nodedefault = nodedefault.encode('utf-8')
 
-    if node.deprecation != "":
-        nodedeprecation = node.deprecation
-    b_nodedeprecation = nodedeprecation.encode('utf-8')
-
     # in case of unit or aggregate, the attribute will be missing
     try:
         nodeunit = str(node.unit.value)
     except AttributeError:
         pass
     b_nodeunit = nodeunit.encode('utf-8')
-
-    try:
-        nodeaggregate = node.aggregate
-    except AttributeError:
-        pass
-    b_nodeaggregate = nodeaggregate.encode('utf-8')
-
-    if node.comment != "":
-        nodecomment = node.comment
-    b_nodecomment = nodecomment.encode('utf-8')
 
     if generate_uuid:
         nodeuuid = node.uuid
@@ -120,7 +110,8 @@ def export_node(node, generate_uuid, out_file):
 
     b_fname = out_file.encode('utf-8')
 
-    createBinaryCnode(b_fname, b_nodename, b_nodetype, b_nodeuuid, b_nodedescription, b_nodedatatype, b_nodemin, b_nodemax, b_nodeunit, b_nodeallowed, b_nodedefault, b_nodevalidate, children)
+    createBinaryCnode(b_fname, b_nodename, b_nodetype, b_nodeuuid, b_nodedescription, b_nodedatatype, b_nodemin,
+                      b_nodemax, b_nodeunit, b_nodeallowed, b_nodedefault, b_nodevalidate, children)
 
     for child in node.children:
         export_node(child, generate_uuid, out_file)
@@ -130,18 +121,19 @@ def export(config: argparse.Namespace, root: VSSNode, print_uuid):
     global _cbinary
     dllName = "../../binary/binarytool.so"
     dllAbsPath = os.path.dirname(os.path.abspath(__file__)) + os.path.sep + dllName
+    if not os.path.isfile(dllAbsPath):
+        logging.error("The required library binarytool.so is not available, exiting!")
+        logging.info("You must build the library, "
+                     "see https://github.com/COVESA/vss-tools/blob/master/binary/README.md!")
+        return
     _cbinary = ctypes.CDLL(dllAbsPath)
 
-    #void createBinaryCnode(char* fname, char* name, char* type, char* uuid, char* descr, char* datatype, char* min, char* max, char* unit, char* allowed, char* defaultAllowed, char* validate, int children);
-    _cbinary.createBinaryCnode.argtypes = (ctypes.c_char_p,ctypes.c_char_p,ctypes.c_char_p,ctypes.c_char_p,ctypes.c_char_p,ctypes.c_char_p,ctypes.c_char_p,ctypes.c_char_p,ctypes.c_char_p,ctypes.c_char_p,ctypes.c_char_p,ctypes.c_char_p,ctypes.c_int)
-    
-    print("Generating binary output...")
+    _cbinary.createBinaryCnode.argtypes = (ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p,
+                                           ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p,
+                                           ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p,
+                                           ctypes.c_int)
+
+    logging.info("Generating binary output...")
     out_file = config.output_file
     export_node(root, print_uuid, out_file)
-    print("Binary output generated in " + out_file)
-
-
-
-
-
-
+    logging.info("Binary output generated in " + out_file)


### PR DESCRIPTION
This is related to #75 

Packaging vss-tools to PyPi has some advantages, like easier to get tools without need to clone. It could also be a starting point for us to refactor tooling to make it easier to create your own tools. This PR basically just changes version handling as I had problems getting the current one to work for publishing to PyPI. There are some specific rules on versions in PyPI, so I am proposing a possible version naming guide.

What I would like to discuss:

- Anyone currently using or in the near future intending to use PyPI packaged vss-tools
- What do we intend to include in a package? At least some tools like vspec2binary are a bit cumbersome to package as it depends on a binary lib (i.e. not only package) Including "all" tools also might make the package big due to dependencies
- I.e. would it be beneficial to rather have more packages, like vss-tools-core, vss-tools-protobuf, vss-tools-graphql and so on?
- Or do we first need to refactor vspec2x.py to make it more generic, so that it in itself is unaware of what exporters that exist and only imports the one that actually is used.

Input is welcome


