### PR TITLE
Step pypi version to release version without printout

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     description='COVESA Vehicle Signal Specification tooling.',
     long_description=long_description,
     long_description_content_type='text/markdown',
-    version='4.0',
+    version='4.0.1',
     url='https://github.com/COVESA/vss-tools',
     license='Mozilla Public License 2.0',
     packages=find_packages(exclude=('tests', 'contrib')),


### PR DESCRIPTION
The uploaded vss-tools 4.0 did not contain all changes actually included in the released VSS 4.0 - it included for example an extra printout that was included by mistake. This PR just steps PyPI version.