### PR TITLE
Test commit without signoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,6 @@ This repository is set up to use pre-commit hooks. After you clone the project, 
 ## Building and installing with Pip
 
 For usage of VSS-Tools with Pip (PyPI) please see [README-PYPI.md](README-PYPI.md)
+
+
+sdjdsjkldsllködslköds


### PR DESCRIPTION
This is  a test of using the [DCO github app](https://github.com/apps/dco) rather than an action (as today). Not intended for merge - it does not contain any reasonable changes! It is just to test DCO that has been configured for this repository.

Potential benefits:

- Could possibly be activated for all COVESA Github repos (but that is not for us to decide), or just for "ours"
- Easier to maintain than separate actions on all repos
- The "old" DCO action does not seem to be that frequently updated - may give problems in the future as it uses Node.js 12

Please check build actions and compare reports for "old" and "new" DCO check. If we are "happy" with using DCO App we can later remove the old check and activate the DCO App also for VSS repo 


![image](https://github.com/COVESA/vss-tools/assets/30996601/7acce336-7703-4641-9920-654342d3648f)
