### PR TITLE
Add additional documentation on data type exports

### DIFF
--- a/docs/vspec2x.md
+++ b/docs/vspec2x.md
@@ -105,6 +105,8 @@ The export format is similar to the export format of VSS signals. The below tabl
 
 The YAML exporter maintains the file structure of the vspec file being exported.
 
+**NOTE:** For YAML and JSON, if a separate output file is not provided, the complex data types are exported under the key - `ComplexDataTypes`. See the snippets below for illustration.
+
 **CSV snippet**
 ```csv
 "Node","Type","DataType","Deprecated","Unit","Min","Max","Desc","Comment","Allowed","Default"
@@ -113,7 +115,7 @@ The YAML exporter maintains the file structure of the vspec file being exported.
 "<PropertyName>","property","<DataType>","<Deprecation>","<Unit>","<Min>","<Max>","<Description>","<Comment>","<Allowed values>","<Default Value>"
 ```
 
-**JSON snippet**
+**JSON snippet (data types are exported to a separate file)**
 ```json
 {
   "VehicleDataTypes": {
@@ -135,6 +137,41 @@ The YAML exporter maintains the file structure of the vspec file being exported.
         }
         "description": "<Description>",
         "type": "branch"
+      }
+    }
+  }
+}
+```
+
+**JSON snippet (signals and data types are exported to a single file)**
+```json
+{
+  "Vehicle": {
+    "type": "branch"
+    // Signal tree
+  },
+  "ComplexDataTypes": {
+    "VehicleDataTypes": {
+      // complex data type tree
+      "children": {
+        "<Branch>": {
+          "children": {
+            "<Struct>": {
+              "children": {
+                "<Property>": {
+                  "type": "property",
+                  "datatype": "<Data Type>",
+                  "description": "<Description",
+                  //                  ...
+                }
+              },
+              "description": "<Description>",
+              "type": "struct"
+            }
+          }
+          "description": "<Description>",
+          "type": "branch"
+        }
       }
     }
   }

--- a/vspec2x.py
+++ b/vspec2x.py
@@ -97,7 +97,10 @@ def main(arguments):
     type_group.add_argument('-vt', '--vspec-types-file', metavar='vspec_types_file', type=str, required=False,
                             help='Data types file in vspec format.')
     type_group.add_argument('-ot', '--types-output-file', metavar='<types_output_file>',
-                            help='Output file for writing data types from vspec file.')
+                            help='Output file for writing data types from vspec file. ' +
+                                 'If not specified, a single file is used where applicable. ' +
+                                 'In case of JSON and YAML, the data is exported under a ' +
+                                 'special key - "ComplexDataTypes"')
 
     for entry in Exporter:
         entry.value.add_arguments(parser.add_argument_group(


### PR DESCRIPTION
### Summary
Add documentation around the special key used for textual export of complex data types in JSON and YAML. 

### Testing
Unit tests pass

Signed-off-by: Krishna Koppolu <kkoppolu@amazon.com>
