### PR TITLE
Removing --no-uuid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,11 +91,10 @@ From now on, if new units are needed for the VSS catalog they shall be added to 
 
 Adding of struct support for exporters currently not supporting structs.
 
-## Planned Changes VSS-Tools 5.0
+## Changes to be included in VSS-Tools 5.0
 
 
 ### Change in UUID handling.
 
-For VSS-Tools 5.0 the following behavior shall be implemented:
 
-* The parameter `--no-uuid` shall now be removed, and an error shall be given if `--no-uuid` is used.
+* The parameter `--no-uuid` is now removed, and an error is given if `--no-uuid` is used.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The environment can be tested by calling one of the tools without arguments, the
 ```sh
 user@ubuntu:~/vss-tools$ ./vspec2csv.py
 usage: vspec2csv.py [-h] [-I dir] [-e EXTENDED_ATTRIBUTES] [-s] [--abort-on-unknown-attribute] [--abort-on-name-style] [--format format] [--uuid]
-                    [--no-uuid] [-o overlays] [-u unit_file] [--json-all-extended-attributes] [--json-pretty] [--yaml-all-extended-attributes]
+                    [-o overlays] [-u unit_file] [--json-all-extended-attributes] [--json-pretty] [--yaml-all-extended-attributes]
                     [-v version] [--all-idl-features] [--gqlfield GQLFIELD GQLFIELD]
                     <vspec_file> <output_file>
 vspec2csv.py: error: the following arguments are required: <vspec_file>, <output_file>
@@ -130,7 +130,7 @@ Launching subshell in virtual environment...
 user@ubuntu:~/vss-tools$  . /home/user/vss-tools/.venv/bin/activate
 (vss-tools) user@ubuntu:~/vss-tools$ ./vspec2yaml.py
 usage: vspec2yaml.py [-h] [-I dir] [-e EXTENDED_ATTRIBUTES] [-s] [--abort-on-unknown-attribute] [--abort-on-name-style] [--format format] [--uuid]
-                     [--no-uuid] [-o overlays] [-u unit_file] [--json-all-extended-attributes] [--json-pretty] [--yaml-all-extended-attributes]
+                     [-o overlays] [-u unit_file] [--json-all-extended-attributes] [--json-pretty] [--yaml-all-extended-attributes]
                      [-v version] [--all-idl-features] [--gqlfield GQLFIELD GQLFIELD]
                      <vspec_file> <output_file>
 vspec2yaml.py: error: the following arguments are required: <vspec_file>, <output_file>

--- a/docs/vspec2x.md
+++ b/docs/vspec2x.md
@@ -12,7 +12,7 @@ The supported arguments might look like this
 
  ```
 usage: vspec2x.py [-h] [-I dir] [-e EXTENDED_ATTRIBUTES] [-s] [--abort-on-unknown-attribute] [--abort-on-name-style]
-                  [--format format] [--uuid] [--no-uuid] [--no_expand] [-o overlays] [-u unit_file]
+                  [--format format] [--uuid] [--no_expand] [-o overlays] [-u unit_file]
                   [-vt vspec_types_file] [-ot <types_output_file>]
                   [--json-all-extended-attributes] [--json-pretty]
                   [--yaml-all-extended-attributes] [-v version] [--all-idl-features] [--gqlfield GQLFIELD GQLFIELD]
@@ -62,11 +62,6 @@ Equivalent to setting `--abort-on-unknown-attribute` and `--abort-on-name-style`
 
 ### --uuid
 Request the exporter to output uuids. This setting may not apply to all exporters, some exporters will never output uuids.
-This is currently the default behavior. From VSS 4.0 `--no-uuid` will be the default behavior.
-
-### --no-uuid
-Request the exporter to not output uuids.
-From VSS 4.0 this will be the default behavior and then this parameter will be deprecated.
 
 ### --no-expand
 
@@ -96,7 +91,7 @@ Below is an example using user-defined types for JSON generation.
 Please see [test cases](https://github.com/COVESA/vss-tools/tree/master/tests/vspec/test_structs) for more details.
 
 ```bash
-python vspec2json.py --no-uuid --json-pretty -vt VehicleDataTypes.vspec -ot VehicleDataTypes.json test.vspec out.json
+python vspec2json.py --json-pretty -vt VehicleDataTypes.vspec -ot VehicleDataTypes.json test.vspec out.json
 ```
 
 Current status for exportes:
@@ -196,7 +191,7 @@ It is possible to specify your own unit file(s) by the `-u <file>` parameter.
 `-u` can be used multiple times to specify additional files like in the example below:
 
 ```bash
-python ./vss-tools/vspec2csv.py -I ./spec -u vss-tools/vspec/config.yaml -u vss-tools/vspec/extra.yaml --no-uuid ./spec/VehicleSignalSpecification.vspec output.csv
+python ./vss-tools/vspec2csv.py -I ./spec -u vss-tools/vspec/config.yaml -u vss-tools/vspec/extra.yaml ./spec/VehicleSignalSpecification.vspec output.csv
 ```
 
 When deciding which units to use the tooling use the following logic:

--- a/tests/vspec/test_allowed/test_allowed.py
+++ b/tests/vspec/test_allowed/test_allowed.py
@@ -48,4 +48,4 @@ def test_uuid(change_test_dir):
     # Exception is "binary", as it is assumed output may vary depending on target
     exporters = ["json", "ddsidl", "csv", "yaml", "franca", "graphql"]
     for exporter in exporters:
-        run_exporter(exporter, "--no-uuid -u ../test_units.yaml")
+        run_exporter(exporter, "-u ../test_units.yaml")

--- a/tests/vspec/test_datatypes_error/test_datatypes_error.py
+++ b/tests/vspec/test_datatypes_error/test_datatypes_error.py
@@ -20,7 +20,7 @@ def change_test_dir(request, monkeypatch):
 
 
 def test_datatype_error(change_test_dir):
-    test_str = "../../../vspec2json.py --json-pretty --no-uuid -u ../test_units.yaml test.vspec out.json > out.txt 2>&1"
+    test_str = "../../../vspec2json.py --json-pretty -u ../test_units.yaml test.vspec out.json > out.txt 2>&1"
     result = os.system(test_str)
     assert os.WIFEXITED(result)
     # failure expected

--- a/tests/vspec/test_default_unit/test_default_units.py
+++ b/tests/vspec/test_default_unit/test_default_units.py
@@ -20,7 +20,7 @@ def change_test_dir(request, monkeypatch):
 
 
 def run_unit(vspec_file, unit_argument, expected_file):
-    test_str = "../../../vspec2json.py --json-pretty --no-uuid " + \
+    test_str = "../../../vspec2json.py --json-pretty " + \
         vspec_file + " " + unit_argument + " out.json > out.txt 2>&1"
     result = os.system(test_str)
     assert os.WIFEXITED(result)
@@ -34,7 +34,7 @@ def run_unit(vspec_file, unit_argument, expected_file):
 
 
 def run_unit_error(vspec_file, unit_argument, grep_error):
-    test_str = "../../../vspec2json.py --json-pretty --no-uuid " + \
+    test_str = "../../../vspec2json.py --json-pretty " + \
         vspec_file + " " + unit_argument + " out.json > out.txt 2>&1"
     result = os.system(test_str)
     assert os.WIFEXITED(result)

--- a/tests/vspec/test_include/test_include.py
+++ b/tests/vspec/test_include/test_include.py
@@ -18,7 +18,7 @@ def change_test_dir(request, monkeypatch):
 
 
 def test_include(change_test_dir):
-    test_str = "../../../vspec2json.py -u ../test_units.yaml --no-uuid  --json-pretty test.vspec out.json" + \
+    test_str = "../../../vspec2json.py -u ../test_units.yaml --json-pretty test.vspec out.json" + \
                " 1> out.txt 2>&1"
     result = os.system(test_str)
     assert os.WIFEXITED(result)
@@ -33,7 +33,7 @@ def test_include(change_test_dir):
 
 
 def test_error(change_test_dir):
-    test_str = "../../../vspec2json.py -u ../test_units.yaml --no-uuid  --json-pretty test_error.vspec out.json " + \
+    test_str = "../../../vspec2json.py -u ../test_units.yaml --json-pretty test_error.vspec out.json " + \
                "1> out.txt 2>&1"
     result = os.system(test_str)
     assert os.WIFEXITED(result)

--- a/tests/vspec/test_overlay/test_overlay.py
+++ b/tests/vspec/test_overlay/test_overlay.py
@@ -21,7 +21,7 @@ def change_test_dir(request, monkeypatch):
 
 
 def run_overlay(overlay_prefix):
-    test_str = "../../../vspec2json.py --json-pretty -u ../test_units.yaml -e dbc --no-uuid test.vspec -o overlay_" + \
+    test_str = "../../../vspec2json.py --json-pretty -u ../test_units.yaml -e dbc test.vspec -o overlay_" + \
         overlay_prefix + ".vspec out.json > out.txt"
     result = os.system(test_str)
     assert os.WIFEXITED(result)

--- a/tests/vspec/test_overlay_on_instance/test_overlay_on_instance.py
+++ b/tests/vspec/test_overlay_on_instance/test_overlay_on_instance.py
@@ -20,7 +20,7 @@ def change_test_dir(request, monkeypatch):
 
 
 def test_expanded_overlay(change_test_dir):
-    test_str = "../../../vspec2json.py  -e my_id --json-pretty --no-uuid -u ../test_units.yaml test.vspec " + \
+    test_str = "../../../vspec2json.py  -e my_id --json-pretty -u ../test_units.yaml test.vspec " + \
                "-o overlay_1.vspec -o overlay_2.vspec out.json > out.txt 2>&1"
     result = os.system(test_str)
     assert os.WIFEXITED(result)

--- a/tests/vspec/test_overlay_struct/test_overlay_struct.py
+++ b/tests/vspec/test_overlay_struct/test_overlay_struct.py
@@ -28,7 +28,7 @@ def test_overlay_struct(format, signals_out, expected_signal, change_test_dir):
     """
     Test that data types provided in vspec format are converted correctly
     """
-    args = ["../../../vspec2x.py", "--no-uuid", "--format", format]
+    args = ["../../../vspec2x.py", "--format", format]
     if format == 'json':
         args.append('--json-pretty')
     args.extend(["-vt", "struct1.vspec", "-vt", "struct2.vspec", "-u", "../test_units.yaml",
@@ -63,7 +63,7 @@ def test_overlay_struct_using_struct(format, signals_out, expected_signal, chang
     """
     Test that data types provided in vspec format are converted correctly
     """
-    args = ["../../../vspec2x.py", "--no-uuid", "--format", format]
+    args = ["../../../vspec2x.py", "--format", format]
     if format == 'json':
         args.append('--json-pretty')
     args.extend(["-vt", "struct1.vspec", "-vt", "struct2_using_struct1.vspec", "-u", "../test_units.yaml",

--- a/tests/vspec/test_overlay_struct_array/test_overlay_struct_array.py
+++ b/tests/vspec/test_overlay_struct_array/test_overlay_struct_array.py
@@ -28,7 +28,7 @@ def test_overlay_struct_array(format, signals_out, expected_signal, change_test_
     """
     Test that data types provided in vspec format are converted correctly
     """
-    args = ["../../../vspec2x.py", "--no-uuid", "--format", format]
+    args = ["../../../vspec2x.py", "--format", format]
     if format == 'json':
         args.append('--json-pretty')
     args.extend(["-vt", "struct1.vspec", "-u", "../test_units.yaml",

--- a/tests/vspec/test_struct_as_root/test_struct_as_root.py
+++ b/tests/vspec/test_struct_as_root/test_struct_as_root.py
@@ -18,7 +18,7 @@ def change_test_dir(request, monkeypatch):
 
 
 def test_struct_as_root(change_test_dir):
-    test_str = "../../../vspec2x.py --no-uuid --format csv -vt struct1.vspec -o overlay.vspec" + \
+    test_str = "../../../vspec2x.py --format csv -vt struct1.vspec -o overlay.vspec" + \
                " -u ../test_units.yaml test.vspec out.csv > out.txt 2>&1"
     result = os.system(test_str)
     assert os.WIFEXITED(result)

--- a/tests/vspec/test_structs/test_data_type_parsing.py
+++ b/tests/vspec/test_structs/test_data_type_parsing.py
@@ -23,7 +23,7 @@ def test_data_types_export_single_file(format, signals_out, expected_signal, cha
     """
     Test that data types provided in vspec format are converted correctly
     """
-    args = ["../../../vspec2x.py", "--no-uuid", "--format", format]
+    args = ["../../../vspec2x.py", "--format", format]
     if format == 'json':
         args.append('--json-pretty')
     args.extend(["-vt", "VehicleDataTypes.vspec", "-u", "../test_units.yaml",
@@ -53,7 +53,7 @@ def test_data_types_export_multi_file(format, signals_out, data_types_out,
     """
     Test that data types provided in vspec format are converted correctly
     """
-    args = ["../../../vspec2x.py", "--no-uuid", "--format", format]
+    args = ["../../../vspec2x.py", "--format", format]
     if format == 'json':
         args.append('--json-pretty')
     args.extend(["-vt", "VehicleDataTypes.vspec", "-u", "../test_units.yaml", "-ot", data_types_out,
@@ -98,7 +98,7 @@ def test_data_types_export_to_proto(signal_vspec_file, type_vspec_file, expected
     """
 
     data_types_out = Path.cwd() / "unused.proto"
-    args = ["../../../vspec2x.py", "--no-uuid", "--format", "protobuf",
+    args = ["../../../vspec2x.py", "--format", "protobuf",
             "-vt", type_vspec_file, "-u", "../test_units.yaml",
             "-ot", str(data_types_out), signal_vspec_file, actual_signal_file, "1>", "out.txt", "2>&1"]
     test_str = " ".join(args)
@@ -143,7 +143,7 @@ def test_data_types_invalid_reference_in_data_type_tree(
     """
     Test that errors are surfaced when data type name references are invalid within the data type tree
     """
-    test_str = " ".join(["../../../vspec2json.py", "-u", "../test_units.yaml", "--no-uuid", "--format", "json",
+    test_str = " ".join(["../../../vspec2json.py", "-u", "../test_units.yaml", "--format", "json",
                          "--json-pretty", "-vt",
                          types_file, "-ot", "VehicleDataTypes.json", "test.vspec", "out.json", "1>", "out.txt", "2>&1"])
     result = os.system(test_str)
@@ -166,7 +166,7 @@ def test_data_types_orphan_properties(
     """
     Test that errors are surfaced when a property is not defined under a struct
     """
-    test_str = " ".join(["../../../vspec2json.py",  "-u", "../test_units.yaml", "--no-uuid", "--format", "json",
+    test_str = " ".join(["../../../vspec2json.py",  "-u", "../test_units.yaml", "--format", "json",
                          "--json-pretty", "-vt",
                          types_file, "-ot", "VehicleDataTypes.json", "test.vspec", "out.json", "1>", "out.txt", "2>&1"])
     result = os.system(test_str)
@@ -185,7 +185,7 @@ def test_data_types_invalid_reference_in_signal_tree(change_test_dir):
     """
     Test that errors are surfaced when data type name references are invalid in the signal tree
     """
-    test_str = " ".join(["../../../vspec2json.py", "-u", "../test_units.yaml", "--no-uuid", "--format", "json",
+    test_str = " ".join(["../../../vspec2json.py", "-u", "../test_units.yaml", "--format", "json",
                          "--json-pretty", "-vt",
                          "VehicleDataTypes.vspec", "-ot", "VehicleDataTypes.json", "test-invalid-datatypes.vspec",
                          "out.json", "1>", "out.txt", "2>&1"])
@@ -208,7 +208,7 @@ def test_error_when_no_user_defined_data_types_are_provided(change_test_dir):
     Test that error message is provided when user-defined types are specified
     in the signal tree but no data type tree is provided.
     """
-    test_str = " ".join(["../../../vspec2json.py", "-u", "../test_units.yaml", "--no-uuid", "--format", "json",
+    test_str = " ".join(["../../../vspec2json.py", "-u", "../test_units.yaml", "--format", "json",
                          "--json-pretty", "test.vspec", "out.json", "1>", "out.txt", "2>&1"])
     result = os.system(test_str)
     assert os.WIFEXITED(result)
@@ -228,7 +228,7 @@ def test_warning_when_data_type_is_provided_for_struct_nodes(change_test_dir):
     """
     Test that warning message is provided when datatype is specified for struct nodes.
     """
-    test_str = " ".join(["../../../vspec2json.py", "-u", "../test_units.yaml", "--no-uuid", "--format", "json",
+    test_str = " ".join(["../../../vspec2json.py", "-u", "../test_units.yaml", "--format", "json",
                          "--json-pretty", "-vt",
                          "VehicleDataTypesStructWithDataType.vspec", "-ot", "VehicleDataTypes.json", "test.vspec",
                          "out.json", "1>", "out.txt", "2>&1"])

--- a/tests/vspec/test_type_error/test_type_error.py
+++ b/tests/vspec/test_type_error/test_type_error.py
@@ -45,7 +45,7 @@ def test_description_error(vspec_file: str, type_str: str, change_test_dir):
     ("sensor_wrong_case.vspec")
     ])
 def type_case_sensitive(vspec_file: str, change_test_dir):
-    test_str = "../../../vspec2json.py --json-pretty --no-uuid " + \
+    test_str = "../../../vspec2json.py --json-pretty " + \
                vspec_file + " out.json > out.txt 2>&1"
     result = os.system(test_str)
     assert os.WIFEXITED(result)

--- a/tests/vspec/test_types_with_uuid/test_uuid.py
+++ b/tests/vspec/test_types_with_uuid/test_uuid.py
@@ -38,41 +38,30 @@ def test_uuid(change_test_dir):
     exporters = ["json", "ddsidl", "csv", "yaml", "franca", "graphql"]
     for exporter in exporters:
         run_exporter(exporter, "--uuid", "uuid")
-        run_exporter(exporter, "--no-uuid", "no_uuid")
         # Same behavior expected if no argument
         run_exporter(exporter, "", "no_uuid")
 
 
-def run_deprecation_test(argument, deprecation_expected: bool):
+def run_obsolete_arg_test(argument, obsolete_arg_expected: bool):
     test_str = "../../../vspec2json.py " + argument + " -u ../test_units.yaml test.vspec out.json 1> out.txt 2>&1"
     result = os.system(test_str)
     assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-    test_str = 'grep \"The argument --no-uuid is deprecated and will be removed in VSS 5.0\" out.txt > /dev/null'
+    if obsolete_arg_expected:
+        assert os.WEXITSTATUS(result) != 0
+    else:
+        assert os.WEXITSTATUS(result) == 0
+    test_str = 'grep \"error: unrecognized arguments\" out.txt > /dev/null'
     result = os.system(test_str)
     os.system("cat out.txt")
     os.system("rm -f out.json out.txt")
     assert os.WIFEXITED(result)
-    if deprecation_expected:
+    if obsolete_arg_expected:
         assert os.WEXITSTATUS(result) == 0
     else:
         assert os.WEXITSTATUS(result) != 0
 
 
-def test_deprecation(change_test_dir):
-    run_deprecation_test("", False)
-    run_deprecation_test("--uuid", False)
-    run_deprecation_test("--no-uuid", True)
-
-
-def test_error_no_uuid_uuid_parameter(change_test_dir):
-    test_str = "../../../vspec2json.py -u ../test_units.yaml --uuid --no-uuid test.vspec out.json 1> out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) != 0
-    test_str = 'grep \"Can not use --uuid and --no-uuid at the same time\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+def test_obsolete_arg(change_test_dir):
+    run_obsolete_arg_test("", False)
+    run_obsolete_arg_test("--uuid", False)
+    run_obsolete_arg_test("--no-uuid", True)

--- a/tests/vspec/test_units/test_units.py
+++ b/tests/vspec/test_units/test_units.py
@@ -20,7 +20,7 @@ def change_test_dir(request, monkeypatch):
 
 
 def run_unit(vspec_file, unit_argument, expected_file):
-    test_str = "../../../vspec2json.py --json-pretty --no-uuid " + \
+    test_str = "../../../vspec2json.py --json-pretty " + \
         vspec_file + " " + unit_argument + " out.json > out.txt 2>&1"
     result = os.system(test_str)
     assert os.WIFEXITED(result)
@@ -34,7 +34,7 @@ def run_unit(vspec_file, unit_argument, expected_file):
 
 
 def run_unit_error(vspec_file, unit_argument, grep_error):
-    test_str = "../../../vspec2json.py --json-pretty --no-uuid " + \
+    test_str = "../../../vspec2json.py --json-pretty " + \
         vspec_file + " " + unit_argument + " out.json > out.txt 2>&1"
     result = os.system(test_str)
     assert os.WIFEXITED(result)

--- a/vspec2x.py
+++ b/vspec2x.py
@@ -81,9 +81,6 @@ def main(arguments):
                         help='Include uuid in generated files.')
     parser.add_argument('--no-expand', action='store_true',
                         help='Do not expand tree.')
-    parser.add_argument('--no-uuid', action='store_true',
-                        help='Exclude uuid in generated files.  This is currently the default behavior. ' +
-                             ' This argument is deprecated and will be removed in VSS 5.0')
     parser.add_argument('-o', '--overlays', action='append', metavar='overlays', type=str, default=[],
                         help='Add overlay that will be layered on top of the VSS file in the order they appear.')
     parser.add_argument('-u', '--unit-file', action='append', metavar='unit_file', type=str, default=[],
@@ -149,11 +146,6 @@ def main(arguments):
 
     exporter = args.format.value
 
-    if args.uuid and args.no_uuid:
-        logging.error("Can not use --uuid and --no-uuid at the same time")
-        sys.exit(-1)
-    if args.no_uuid:
-        logging.warning("The argument --no-uuid is deprecated and will be removed in VSS 5.0")
     print_uuid = False
     if args.uuid:
         print_uuid = True


### PR DESCRIPTION
This addresses what we previously has written in changelog; that no UUID shall be default and thus no reason to have a --no-uuid argument.

**Shall not be cherry-picked to 4.X branch!**