### PR TITLE
Refactor copyright and license statement

### DIFF
--- a/.github/actions/verify-headers/action.yml
+++ b/.github/actions/verify-headers/action.yml
@@ -1,0 +1,17 @@
+name: verify-headers
+description: Verify that files affected by a PR include expected header
+
+branding:
+  icon: zap
+  color: gray-dark
+
+inputs:
+  files:
+    description: >
+      A comma-separated list of all files to check.
+    default: ''
+runs:
+  using: "composite"
+  steps:
+    - run: $GITHUB_ACTION_PATH/verify-headers.py
+      shell: bash

--- a/.github/actions/verify-headers/verify-headers.py
+++ b/.github/actions/verify-headers/verify-headers.py
@@ -1,0 +1,38 @@
+#!/usr/bin/python3
+# Copyright (c) 2023 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import os
+
+
+def string_exists(file_path, search_string) -> bool:
+    with open(file_path, 'r') as file:
+        content = file.read()
+        if search_string in content:
+            return True
+    return False
+
+
+if __name__ == '__main__':
+
+    files = os.getenv('files')
+    files = files.split(',')
+    for file in files:
+        file = os.path.abspath(file)
+        if os.path.isfile(file):
+            ext = os.path.splitext(file)[1]
+            if ext in [".vspec", ".py"]:
+                if not string_exists(file, "Contributors to COVESA"):
+                    print(f"No contribution statement found in {file}")
+                    raise Exception("Check the output, some files have not the right contribution statement!")
+                if not string_exists(file, "SPDX-License-Identifier: MPL-2.0"):
+                    print(f"Incorrect license statement found in {file}")
+                    raise Exception("Check the output, some files have not the right SPDX statement!")
+
+                print(f"Check succeeded for {file}")
+    raise SystemExit(0)

--- a/.github/workflows/check-header.yml
+++ b/.github/workflows/check-header.yml
@@ -1,0 +1,28 @@
+name: check-header
+
+on:
+  pull_request
+
+concurrency:
+      group: ${{ github.ref }}-${{ github.workflow }}
+      cancel-in-progress: true
+
+jobs:
+  check-headers:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        # required to grab the history of the PR
+        fetch-depth: 0
+
+    - name: Get changed files
+      run: |
+        echo "files=$(git diff --name-only ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }} | tr '\n' ',')" >> $GITHUB_ENV
+
+    - uses: ./.github/actions/verify-headers
+      with:
+        files: "${{ env.files }}"

--- a/contrib/vspec2ttl/vspec2ttl.py
+++ b/contrib/vspec2ttl/vspec2ttl.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python3
 
-# (C) 2021 BMW Group - All rights reserved.
-# AUTHOR: Daniel Wilms BMW Group;
-
+# Copyright (c) 2021 Contributors to COVESA
 #
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-#
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
-#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # Convert vspec file to TTL

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,13 @@
 #!/usr/bin/env python3
+
+# Copyright (c) 2019 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
 from setuptools import setup, find_packages
 from pathlib import Path
 

--- a/vspec/__init__.py
+++ b/vspec/__init__.py
@@ -1,11 +1,11 @@
+# Copyright (c) 2016 Contributors to COVESA
 #
-# (C) 2021 Robert Bosch GmbH
-# (C) 2018 Volvo Cars
-# (C) 2016 Jaguar Land Rover
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
-#
+# SPDX-License-Identifier: MPL-2.0
+
 #
 # VSpec file parser.
 #

--- a/vspec/loggingconfig.py
+++ b/vspec/loggingconfig.py
@@ -1,8 +1,13 @@
 #!/usr/bin/env python3
 
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# Copyright (c) 2023 Contributors to COVESA
 #
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
 #
 # Convert vspec files to various other formats
 #

--- a/vspec/model/__init__.py
+++ b/vspec/model/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2021 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0

--- a/vspec/model/constants.py
+++ b/vspec/model/constants.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
+# Copyright (c) 2021 Contributors to COVESA
 #
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-#
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
-#
+# SPDX-License-Identifier: MPL-2.0
 
 #
 # Constant Types and Mappings

--- a/vspec/model/exceptions.py
+++ b/vspec/model/exceptions.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
+# Copyright (c) 2023 Contributors to COVESA
 #
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-#
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
-#
+# SPDX-License-Identifier: MPL-2.0
 
 class NameStyleValidationException(Exception):
     def __init__(self, message):

--- a/vspec/model/vsstree.py
+++ b/vspec/model/vsstree.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
+# Copyright (c) 2021 Contributors to COVESA
 #
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-#
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
-#
+# SPDX-License-Identifier: MPL-2.0
 
 from anytree import Node, Resolver, ChildResolverError, RenderTree  # type: ignore[import]
 from .constants import VSSType, VSSDataType, Unit, VSSConstant

--- a/vspec/utils/__init__.py
+++ b/vspec/utils/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2023 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0

--- a/vspec/utils/stringstyle.py
+++ b/vspec/utils/stringstyle.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
+# Copyright (c) 2023 Contributors to COVESA
 #
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-#
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
-#
+# SPDX-License-Identifier: MPL-2.0
 
 import re
 

--- a/vspec/vssexporters/__init__.py
+++ b/vspec/vssexporters/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2022 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0

--- a/vspec/vssexporters/vss2binary.py
+++ b/vspec/vssexporters/vss2binary.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
-# (c) 2022 Geotab Inc
+# Copyright (c) 2022 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-#
+# SPDX-License-Identifier: MPL-2.0
+
 # Convert vspec tree to binary format
 
 import argparse

--- a/vspec/vssexporters/vss2csv.py
+++ b/vspec/vssexporters/vss2csv.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 
-# (c) 2022 Robert Bosch GmbH
-# (c) 2021 BMW Group
+# Copyright (c) 2021 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-#
+# SPDX-License-Identifier: MPL-2.0
+
 # Convert vspec tree to CSV
 
 

--- a/vspec/vssexporters/vss2ddsidl.py
+++ b/vspec/vssexporters/vss2ddsidl.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
+# Copyright (c) 2022 Contributors to COVESA
 #
-# (c) 2022 Robert Bosch GmbH
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
-#
+# SPDX-License-Identifier: MPL-2.0
+
 #
 # Convert vspec files to DDS-IDL
 #

--- a/vspec/vssexporters/vss2franca.py
+++ b/vspec/vssexporters/vss2franca.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
-# (c) 2021 BMW Group
+# Copyright (c) 2021 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-#
+# SPDX-License-Identifier: MPL-2.0
+
 # Convert vspec tree to franca
 
 

--- a/vspec/vssexporters/vss2graphql.py
+++ b/vspec/vssexporters/vss2graphql.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 
+# Copyright (c) 2022 Contributors to COVESA
 #
-# Copyright (C) 2022, Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
-#
+# SPDX-License-Identifier: MPL-2.0
 
 import argparse
 from vspec.model.vsstree import VSSNode

--- a/vspec/vssexporters/vss2json.py
+++ b/vspec/vssexporters/vss2json.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
-# (c) 2022 Robert Bosch GmbH
+# Copyright (c) 2022 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-#
+# SPDX-License-Identifier: MPL-2.0
+
 # Convert vspec tree to JSON
 
 from vspec.model.vsstree import VSSNode

--- a/vspec/vssexporters/vss2protobuf.py
+++ b/vspec/vssexporters/vss2protobuf.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
-# Copyright (c) 2021 Motius GmbH
+# Copyright (c) 2021 Contributors to COVESA
 #
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
+# SPDX-License-Identifier: MPL-2.0
+
 # Convert vspec file to proto
 #
 

--- a/vspec/vssexporters/vss2yaml.py
+++ b/vspec/vssexporters/vss2yaml.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python3
 
+# Copyright (c) 2016 Contributors to COVESA
 #
-# (c) 2021 Robert Bosch GmbH
-# (c) 2021 Pavel Sokolov (pavel.sokolov@gmail.com)
-# (c) 2016 Jaguar Land Rover
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-#
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
-#
+# SPDX-License-Identifier: MPL-2.0
+
 #
 # Convert all vspec input files to a single flat YAML file.
 #

--- a/vspec2binary.py
+++ b/vspec2binary.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 
+# Copyright (c) 2018 Contributors to COVESA
 #
-# (C) 2022 Geotab Inc
-# (C) 2018 Volvo Cars
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
-#
+# SPDX-License-Identifier: MPL-2.0
+
 #
 # Convert vspec file to a platform binary format.
 #

--- a/vspec2csv.py
+++ b/vspec2csv.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 #
+# Copyright (c) 2016 Contributors to COVESA
 #
-# (c) 2022 Robert Bosch GmbH
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
-#
+# SPDX-License-Identifier: MPL-2.0
+
 #
 # Convert vspec2csv wrapper for vspec2x
 #

--- a/vspec2ddsidl.py
+++ b/vspec2ddsidl.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 #
+# Copyright (c) 2022 Contributors to COVESA
 #
-# (c) 2022 Robert Bosch GmbH
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
-#
+# SPDX-License-Identifier: MPL-2.0
+
 #
 # Convert vspec2idl wrapper for vspec2x
 #

--- a/vspec2franca.py
+++ b/vspec2franca.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
-# (c) 2022 BMW Group
-# (C) 2016 Jaguar Land Rover
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
+# SPDX-License-Identifier: MPL-2.0
+
 #
 # Convert vspec file to FrancaIDL spec.
 #

--- a/vspec2graphql.py
+++ b/vspec2graphql.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 #
+# Copyright (c) 2022 Contributors to COVESA
 #
-# (c) 2022 BMW Group
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
-#
+# SPDX-License-Identifier: MPL-2.0
+
 #
 # Convert vspec2grahql wrapper for vspec2x
 #

--- a/vspec2json.py
+++ b/vspec2json.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 #
+# Copyright (c) 2016 Contributors to COVESA
 #
-# (c) 2022 Robert Bosch GmbH
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
-#
+# SPDX-License-Identifier: MPL-2.0
+
 #
 # Convert vspec2json wrapper for vspec2x
 #

--- a/vspec2jsonschema.py
+++ b/vspec2jsonschema.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
 #
+# Copyright (c) 2023 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
 #
 # Convert vspec2jsonschema wrapper for vspec2x
 #

--- a/vspec2protobuf.py
+++ b/vspec2protobuf.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
 #
+# Copyright (c) 2021 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
 #
 # Convert vspec2protobuf wrapper for vspec2x
 #

--- a/vspec2x.py
+++ b/vspec2x.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 
-# (c) 2022 BMW Group
-# (c) 2022 Robert Bosch GmbH
-# (c) 2016 Jaguar Land Rover
+# Copyright (c) 2016 Contributors to COVESA
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
+# SPDX-License-Identifier: MPL-2.0
+
 #
 # Convert vspec files to various other formats
 #

--- a/vspec2yaml.py
+++ b/vspec2yaml.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 #
+# Copyright (c) 2021 Contributors to COVESA
 #
-# (c) 2022 Robert Bosch GmbH
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
 #
-# All files and artifacts in this repository are licensed under the
-# provisions of the license provided by the LICENSE file in this repository.
-#
+# SPDX-License-Identifier: MPL-2.0
+
 #
 # Convert vspec2yaml wrapper for vspec2x
 #


### PR DESCRIPTION
This is aligning copyright headers similar to what was done for VSS-repo. It does not introduce any real changes, copyright still belongs to the contributor and license is still MPL-2.0.

I used a lazy approach - not changing test files and not changing obsolete tools, but they are not excluded from the CI check so as soon as someone touches them they need to be updated (or a maintainer needs to ignore that the corresponding check fail)