### PR TITLE
Give error if unit is used for branch or struct

### DIFF
--- a/tests/instances/resources/instance_exclude_node.vspec
+++ b/tests/instances/resources/instance_exclude_node.vspec
@@ -6,7 +6,6 @@ Vehicle:
 Vehicle.SomeThing:
   type: branch
   description: "SomeThing description"
-  datatype: string
 
 Vehicle.SomeThing.SomethingLeaf:
   type: sensor
@@ -16,7 +15,6 @@ Vehicle.SomeThing.SomethingLeaf:
 Vehicle.ExcludeSomeThing:
   type: branch
   description: "ExcludeSomeThing description"
-  datatype: string
   instantiate: False
 
 Vehicle.ExcludeSomeThing.ExcludeSomethingLeaf:

--- a/tests/vspec/test_datatypes_error/test.vspec
+++ b/tests/vspec/test_datatypes_error/test.vspec
@@ -6,5 +6,5 @@ A:
 A.UInt7:
   datatype: uint7
   type: sensor
-  unit: km
   description: Oops, that datatype does not exist!
+  comment: If we specify unit as well then error message will be that non-standard datatypes cannot use unit

--- a/tests/vspec/test_datatypes_error/test_datatype_branch.vspec
+++ b/tests/vspec/test_datatypes_error/test_datatype_branch.vspec
@@ -1,0 +1,11 @@
+#
+A:
+  type: branch
+  description: Branch shall not have datatype
+  datatype: uint8
+
+A.UInt7:
+  datatype: uint8
+  type: sensor
+  unit: km
+  description: ok!

--- a/tests/vspec/test_datatypes_error/test_datatypes_error.py
+++ b/tests/vspec/test_datatypes_error/test_datatypes_error.py
@@ -32,3 +32,19 @@ def test_datatype_error(change_test_dir):
     os.system("rm -f out.json out.txt")
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) == 0
+
+
+def test_datatype_branch(change_test_dir):
+    test_str = "../../../vspec2json.py --json-pretty -u ../test_units.yaml " \
+               "test_datatype_branch.vspec out.json > out.txt 2>&1"
+    result = os.system(test_str)
+    assert os.WIFEXITED(result)
+    # failure expected
+    assert os.WEXITSTATUS(result) != 0
+
+    test_str = 'grep \"cannot have datatype\" out.txt > /dev/null'
+    result = os.system(test_str)
+    os.system("cat out.txt")
+    os.system("rm -f out.json out.txt")
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0

--- a/tests/vspec/test_structs/VehicleDataTypesStructWithUnit.vspec
+++ b/tests/vspec/test_structs/VehicleDataTypesStructWithUnit.vspec
@@ -1,0 +1,26 @@
+VehicleDataTypes:
+  type: branch
+  description: Top-level branch for vehicle data types.
+
+VehicleDataTypes.TestBranch1:
+  description: "A branch"
+  type: branch
+
+VehicleDataTypes.TestBranch1.NestedStruct:
+  type: struct
+  description: "ERROR: A struct with unit defined."
+  unit: km
+
+VehicleDataTypes.TestBranch1.NestedStruct.x:
+  type: property
+  description: "x property"
+  datatype: double
+
+VehicleDataTypes.TestBranch1.ParentStruct:
+  type: struct
+  description: "A struct that is going to contain properties that are structs themselves"
+
+VehicleDataTypes.TestBranch1.ParentStruct.x_property:
+  type: property
+  description: "A property of struct-type. The struct name is specified relative to the branch"
+  datatype: NestedStruct

--- a/tests/vspec/test_structs/test-invalid-datatypes.vspec
+++ b/tests/vspec/test_structs/test-invalid-datatypes.vspec
@@ -12,11 +12,9 @@ A.UInt8:
 A.ParentStructSensor:
   datatype: VehicleDataTypes.TestBranch1.ParentStruct1
   type: sensor
-  unit: km
   description: A rich sensor with user-defined data type.
 
 A.NestedStructSensor:
   datatype: VehicleDataTypes.TestBranch1.NestedStruct1
   type: sensor
-  unit: km
   description: A rich sensor with user-defined data type.

--- a/tests/vspec/test_structs/test.vspec
+++ b/tests/vspec/test_structs/test.vspec
@@ -12,11 +12,9 @@ A.UInt8:
 A.ParentStructSensor:
   datatype: VehicleDataTypes.TestBranch1.ParentStruct
   type: sensor
-  unit: km
   description: A rich sensor with user-defined data type.
 
 A.NestedStructSensor:
   datatype: VehicleDataTypes.TestBranch1.NestedStruct
   type: sensor
-  unit: km
   description: A rich sensor with user-defined data type.

--- a/tests/vspec/test_structs/test_data_type_parsing.py
+++ b/tests/vspec/test_structs/test_data_type_parsing.py
@@ -224,19 +224,25 @@ def test_error_when_no_user_defined_data_types_are_provided(change_test_dir):
     assert os.WEXITSTATUS(result) == 0
 
 
-def test_warning_when_data_type_is_provided_for_struct_nodes(change_test_dir):
+@pytest.mark.parametrize("vspec_file,types_file,error_msg", [
+    ('test.vspec', 'VehicleDataTypesStructWithDataType.vspec',
+     'cannot have datatype, only allowed for signal and property'),
+    ('test.vspec', 'VehicleDataTypesStructWithUnit.vspec',
+     'cannot have unit'),
+    ('test_with_unit_on_struct_signal.vspec', 'VehicleDataTypes.vspec',
+     'Unit specified for item not using standard datatype')])
+def test_faulty_use_of_standard_attributes(
+        vspec_file, types_file, error_msg, change_test_dir):
     """
-    Test that warning message is provided when datatype is specified for struct nodes.
+    Test faulty use of datatype and unit for structs
     """
     test_str = " ".join(["../../../vspec2json.py", "-u", "../test_units.yaml", "--format", "json",
-                         "--json-pretty", "-vt",
-                         "VehicleDataTypesStructWithDataType.vspec", "-ot", "VehicleDataTypes.json", "test.vspec",
+                         "--json-pretty", "-vt", types_file, "-ot", "VehicleDataTypes.json", vspec_file,
                          "out.json", "1>", "out.txt", "2>&1"])
     result = os.system(test_str)
     assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+    assert os.WEXITSTATUS(result) != 0
 
-    error_msg = 'Data type specified for struct node: NestedStruct. Ignoring it'
     test_str = f'grep \"{error_msg}\" out.txt > /dev/null'
     result = os.system(test_str)
     os.system("cat out.txt")

--- a/tests/vspec/test_structs/test_with_unit_on_struct_signal.vspec
+++ b/tests/vspec/test_structs/test_with_unit_on_struct_signal.vspec
@@ -10,11 +10,12 @@ A.UInt8:
   description: A uint8.
 
 A.ParentStructSensor:
-  datatype: VehicleDataTypes.TestBranch2.ParentStruct
+  datatype: VehicleDataTypes.TestBranch1.ParentStruct
   type: sensor
+  unit: km
   description: A rich sensor with user-defined data type.
 
 A.NestedStructSensor:
-  datatype: VehicleDataTypes.TestBranch3.NestedStruct
+  datatype: VehicleDataTypes.TestBranch1.NestedStruct
   type: sensor
   description: A rich sensor with user-defined data type.

--- a/tests/vspec/test_units/test_units.py
+++ b/tests/vspec/test_units/test_units.py
@@ -96,8 +96,12 @@ def test_unit_error_no_unit_file(change_test_dir):
 def test_unit_error_unit_file_incomplete(change_test_dir):
     run_unit_error("signals_with_special_units.vspec", "-u units_hogshead.yaml", "Unknown unit")
 
-# FIle not found
+# File not found
 
 
 def test_unit_error_missing_file(change_test_dir):
     run_unit_error("signals_with_special_units.vspec", "-u file_that_does_not_exist.yaml", "FileNotFoundError")
+
+
+def test_unit_on_branch(change_test_dir):
+    run_unit_error("unit_on_branch.vspec", "-u units_all.yaml", "cannot have unit")

--- a/tests/vspec/test_units/unit_on_branch.vspec
+++ b/tests/vspec/test_units/unit_on_branch.vspec
@@ -1,0 +1,10 @@
+A:
+  type: branch
+  description: Specifying unit on branch is not allowed!
+  unit: hogshead
+
+A.UInt8:
+  datatype: uint8
+  type: sensor
+  unit: hogshead
+  description: This description is mandatory!


### PR DESCRIPTION
We do not list `unit` as an allowed keyword for branches in our [documentation](https://covesa.github.io/vehicle_signal_specification/rule_set/branches/). However, as of today we do not check that. This PR addresses that.