### PR TITLE
Update unit handling

### DIFF
--- a/tests/binary/test_binary.py
+++ b/tests/binary/test_binary.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-
 # Copyright (c) 2023 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the
@@ -64,4 +63,5 @@ def test_binary(change_test_dir):
     check_expected('A.String', 'Node type=SENSOR')
     check_expected('A.Int', 'Node type=ACTUATOR')
 
-    os.system("rm -f test.binary ctestparser out.txt ../../binary/go_parser/gotestparser")
+    os.system("rm -f test.binary ctestparser out.txt")
+    os.system("rm -f ../../binary/go_parser/gotestparser  ../../binary/go_parser/out.txt")

--- a/tests/model/explicit_units.yaml
+++ b/tests/model/explicit_units.yaml
@@ -1,9 +1,8 @@
-units:
-  puncheon:
-    label: Puncheon
-    description: Volume measure in puncheons (1 puncheon = 318 liters)
-    domain: volume
-  hogshead:
-    label: Hogshead
-    description: Volume measure in hogsheads (1 hogshead = 238 liters)
-    domain: volume
+puncheon:
+  definition: Volume measure in puncheons (1 puncheon = 318 liters)
+  unit: Puncheon
+  quantity: volume
+hogshead:
+  definition: Volume measure in hogsheads (1 hogshead = 238 liters)
+  unit: Hogshead
+  quantity: volume

--- a/tests/model/explicit_units_old_syntax.yaml
+++ b/tests/model/explicit_units_old_syntax.yaml
@@ -1,0 +1,9 @@
+units:
+  puncheon:
+    label: Puncheon
+    description: Volume measure in puncheons (1 puncheon = 318 liters)
+    domain: volume
+  hogshead:
+    label: Hogshead
+    description: Volume measure in hogsheads (1 hogshead = 238 liters)
+    domain: volume

--- a/tests/model/test_contants.py
+++ b/tests/model/test_contants.py
@@ -9,7 +9,7 @@
 import pytest
 import os
 
-from vspec.model.constants import VSSType, VSSDataType, Unit, StringStyle, VSSTreeType, VSSConstant
+from vspec.model.constants import VSSType, VSSDataType, VSSUnitCollection, StringStyle, VSSTreeType, VSSUnit
 
 
 @pytest.mark.parametrize("style_enum, style_str",
@@ -38,19 +38,26 @@ def test_invalid_string_styles():
         StringStyle.from_str("not_a_valid_case")
 
 
-def test_manually_loaded_units():
+@pytest.mark.parametrize("unit_file",
+                         ['explicit_units.yaml',
+                          'explicit_units_old_syntax.yaml'])
+def test_manually_loaded_units(unit_file):
     """
     Test correct parsing of units
     """
-    unit_file = os.path.join(os.path.dirname(__file__), 'explicit_units.yaml')
-    Unit.load_config_file(unit_file)
-    assert Unit.PUNCHEON == Unit.from_str("puncheon")
-    assert Unit.HOGSHEAD == Unit.from_str("hogshead")
+    unit_file = os.path.join(os.path.dirname(__file__), unit_file)
+    VSSUnitCollection.load_config_file(unit_file)
+    assert VSSUnitCollection.get_unit("puncheon") == "puncheon"
+    assert VSSUnitCollection.get_unit("puncheon").definition == \
+           "Volume measure in puncheons (1 puncheon = 318 liters)"
+    assert VSSUnitCollection.get_unit("puncheon").unit == \
+           "Puncheon"
+    assert VSSUnitCollection.get_unit("puncheon").quantity == \
+           "volume"
 
 
 def test_invalid_unit():
-    with pytest.raises(Exception):
-        Unit.from_str("not_a_valid_case")
+    assert VSSUnitCollection.get_unit("unknown") is None
 
 
 @pytest.mark.parametrize("type_enum,type_str",
@@ -116,12 +123,12 @@ def test_invalid_vss_tree_types():
         VSSDataType.from_str("not_a_valid_case")
 
 
-def test_vss_constants():
-    """ Test VSSConstant class """
-    item = VSSConstant("mylabel", "myvalue", "mydescription", "mydomain")
-    assert item.value == "myvalue"
-    assert item.label == "mylabel"
-    assert item.description == "mydescription"
-    assert item.domain == "mydomain"
-    # String subclass so just comparing shall get "value"
-    assert item == "myvalue"
+def test_unit():
+    """ Test Unit class """
+    item = VSSUnit("myid", "myunit", "mydefinition", "myquantity")
+    assert item.value == "myid"
+    assert item.unit == "myunit"
+    assert item.definition == "mydefinition"
+    assert item.quantity == "myquantity"
+    # String subclass so just comparing shall get "myid"
+    assert item == "myid"

--- a/tests/model/test_vsstree.py
+++ b/tests/model/test_vsstree.py
@@ -9,7 +9,7 @@
 import unittest
 import os
 
-from vspec.model.constants import VSSType, VSSDataType, Unit, VSSTreeType
+from vspec.model.constants import VSSType, VSSDataType, VSSUnitCollection, VSSTreeType
 from vspec.model.vsstree import VSSNode
 
 
@@ -43,7 +43,7 @@ class TestVSSNode(unittest.TestCase):
                   "aggregate": False,
                   "default": "test-default", "$file_name$": "testfile"}
         unit_file = os.path.join(os.path.dirname(__file__), 'explicit_units.yaml')
-        Unit.load_config_file(unit_file)
+        VSSUnitCollection.load_config_file(unit_file)
         node = VSSNode(
             "test",
             source,
@@ -53,7 +53,7 @@ class TestVSSNode(unittest.TestCase):
         self.assertEqual(VSSType.SENSOR, node.type)
         self.assertEqual("26d6e362-a422-11ea-bb37-0242ac130002", node.uuid)
         self.assertEqual(VSSDataType.UINT8, node.datatype)
-        self.assertEqual(Unit.HOGSHEAD, node.unit)
+        self.assertEqual(VSSUnitCollection.get_unit("hogshead"), node.unit)
         self.assertEqual(0, node.min)
         self.assertEqual(100, node.max)
         self.assertEqual(["one", "two"], node.allowed)
@@ -79,7 +79,7 @@ class TestVSSNode(unittest.TestCase):
                   "datatype": "uint8", "unit": "hogshead", "min": 0, "max": 100, "$file_name$": "testfile"}
 
         unit_file = os.path.join(os.path.dirname(__file__), 'explicit_units.yaml')
-        Unit.load_config_file(unit_file)
+        VSSUnitCollection.load_config_file(unit_file)
 
         node_target = VSSNode(
             "MyNode",
@@ -103,7 +103,7 @@ class TestVSSNode(unittest.TestCase):
             node_target.uuid)
         self.assertTrue(node_target.has_datatype())
         self.assertEqual(VSSDataType.UINT8, node_target.datatype)
-        self.assertEqual(Unit.HOGSHEAD, node_target.unit)
+        self.assertEqual(VSSUnitCollection.get_unit("hogshead"), node_target.unit)
         self.assertEqual(0, node_target.min)
         self.assertEqual(100, node_target.max)
 

--- a/vspec/__init__.py
+++ b/vspec/__init__.py
@@ -23,7 +23,7 @@ from anytree import (Resolver, LevelOrderIter, PreOrderIter, RenderTree)  # type
 
 from .model.vsstree import VSSNode
 from .model.exceptions import ImpossibleMergeException, IncompleteElementException
-from .model.constants import VSSTreeType, Unit
+from .model.constants import VSSTreeType, VSSUnitCollection
 
 nestable_types = set(["branch", "struct"])
 
@@ -871,11 +871,11 @@ def load_units(vspec_file: str, unit_files: List[str]):
         vspec_dir = os.path.dirname(os.path.realpath(vspec_file))
         default_vss_unit_file = vspec_dir + os.path.sep + 'units.yaml'
         if os.path.exists(default_vss_unit_file):
-            total_nbr_units = Unit.load_config_file(default_vss_unit_file)
+            total_nbr_units = VSSUnitCollection.load_config_file(default_vss_unit_file)
             logging.info(f"Added {total_nbr_units} units from {default_vss_unit_file}")
     else:
         for unit_file in unit_files:
-            nbr_units = Unit.load_config_file(unit_file)
+            nbr_units = VSSUnitCollection.load_config_file(unit_file)
             if (nbr_units == 0):
                 logging.warning(f"Warning: No units found in {unit_file}")
             else:

--- a/vspec/model/vsstree.py
+++ b/vspec/model/vsstree.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 from anytree import Node, Resolver, ChildResolverError, RenderTree  # type: ignore[import]
-from .constants import VSSType, VSSDataType, Unit, VSSConstant
+from .constants import VSSType, VSSDataType, VSSUnitCollection, VSSUnit
 from .exceptions import NameStyleValidationException, \
     ImpossibleMergeException, IncompleteElementException
 from typing import Any, Optional, Set, List
@@ -46,7 +46,7 @@ class VSSNode(Node):
     # neither in core or extended,
     whitelisted_extended_attributes: List[str] = []
 
-    unit: Optional[VSSConstant]
+    unit: Optional[VSSUnit]
 
     min = ""
     max = ""
@@ -149,9 +149,8 @@ class VSSNode(Node):
                 sys.exit(-1)
 
             unit = self.source_dict["unit"]
-            try:
-                self.unit = Unit.from_str(unit)
-            except KeyError:
+            self.unit = VSSUnitCollection.get_unit(unit)
+            if self.unit is None:
                 logging.error(f"Unknown unit {unit} for signal {self.qualified_name()}. Terminating.")
                 sys.exit(-1)
 


### PR DESCRIPTION
This refactors unit handling so that it keeps supporting old format but also supports format in
https://github.com/COVESA/vehicle_signal_specification/pull/669.

- It only focus on keeping existing functionality.
- No functionality for parsing and verifying domains added.
- It also does some general cleanup, removing some reverse lookup functionality and slight renaming of classes

