### PR TITLE
Update pre-commit dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.5.0
     hooks:
     -   id: trailing-whitespace
         exclude_types: ["csv", "proto"]
@@ -13,6 +13,6 @@ repos:
     -   id: check-added-large-files
 
 -   repo: https://github.com/pycqa/flake8
-    rev: '6.0.0'
+    rev: '6.1.0'
     hooks:
     -   id: flake8


### PR DESCRIPTION
flake8 + 6.0.0 can give problems if using Python 3.12 (multiline f-strings)