### PR TITLE
Fix hard-coded username in pipenv installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Install this project and its dependencies in the local `.venv` folder in this pr
 ```sh
 export PIPENV_VENV_IN_PROJECT=1 # will create a local `.venv` in the project, otherwise uses global location
 pip install pipenv
-export PATH=/home/user/.local/bin:$PATH
+export PATH=/home/${USER}/.local/bin:${PATH}
 pipenv install --dev # install the development dependencies as well
 ```
 


### PR DESCRIPTION
Copy/pasting the instructions for installing pipenv fail because of a hard-coded /home/user, forcing user to modify the instructions before executing the command. This can be addressed by using the ${USER} environment variable.

Signed-off-by: Pierre Pierre Blais <ppblais@blackberry.com>