### PR TITLE
Add ddsidl struct tests and make -ot configurable

### DIFF
--- a/tests/vspec/test_structs/expected-signals-types.idl
+++ b/tests/vspec/test_structs/expected-signals-types.idl
@@ -1,0 +1,38 @@
+module VehicleDataTypes {
+module TestBranch1 {
+struct NestedStruct {
+double x;
+double y;
+double z;
+};
+struct ParentStruct {
+VehicleDataTypes::TestBranch1::NestedStruct x_property;
+VehicleDataTypes::TestBranch1::NestedStruct y_property;
+sequence<VehicleDataTypes::TestBranch1::NestedStruct> x_properties;
+sequence<VehicleDataTypes::TestBranch1::NestedStruct> y_properties;
+double z_property;
+};
+};
+};
+module A
+{
+struct _UInt8
+{
+octet value;
+//const string unit="km";
+//const string type ="sensor";
+//const string description="A uint8.";
+};
+struct ParentStructSensor
+{
+VehicleDataTypes::TestBranch1::ParentStruct value;
+//const string type ="sensor";
+//const string description="A rich sensor with user-defined data type.";
+};
+struct NestedStructSensor
+{
+VehicleDataTypes::TestBranch1::NestedStruct value;
+//const string type ="sensor";
+//const string description="A rich sensor with user-defined data type.";
+};
+};

--- a/tests/vspec/test_structs/test_commandline.py
+++ b/tests/vspec/test_structs/test_commandline.py
@@ -55,3 +55,25 @@ def test_error_with_non_compatible_formats(format, change_test_dir):
     os.system("rm -f out.json out.txt output_types_file.json output_file.json")
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) == 0
+
+
+@pytest.mark.parametrize("format", ["ddsidl"])
+def test_error_with_ot(format, change_test_dir):
+    # test that program fails due to parser error
+    cmdline = ('../../../vspec2' + format + '.py -u ../test_units.yaml -vt VehicleDataTypes.vspec '
+               '-ot output_types_file.json '
+               'test.vspec output_file.json')
+    test_str = cmdline + " 1> out.txt 2>&1"
+    result = os.system(test_str)
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) != 0
+
+    # test that the expected error is outputed
+    # At the moment we get an odd error as "-ot" is interpreted as "-o t"
+    test_str = 'grep \"error: unrecognized arguments\" ' + \
+        'out.txt > /dev/null'
+    result = os.system(test_str)
+    os.system("cat out.txt")
+    os.system("rm -f out.json out.txt output_types_file.json output_file.json")
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0

--- a/tests/vspec/test_structs/test_data_type_parsing.py
+++ b/tests/vspec/test_structs/test_data_type_parsing.py
@@ -23,7 +23,8 @@ def change_test_dir(request, monkeypatch):
     ('json', 'signals-out.json', 'expected-signals-types.json', 'VehicleDataTypes.vspec'),
     ('json', 'signals-out.json', 'expected-signals-types.json', 'VehicleDataTypesFlat.vspec'),
     ('yaml', 'signals-out.yaml', 'expected-signals-types.yaml', 'VehicleDataTypes.vspec'),
-    ('csv', 'signals-out.csv', 'expected-signals-types.csv', 'VehicleDataTypes.vspec')])
+    ('csv', 'signals-out.csv', 'expected-signals-types.csv', 'VehicleDataTypes.vspec'),
+    ('ddsidl', 'signals-out.idl', 'expected-signals-types.idl', 'VehicleDataTypes.vspec')])
 def test_data_types_export_single_file(format, signals_out, expected_signal, type_file, change_test_dir):
     """
     Test that data types provided in vspec format are converted correctly
@@ -57,6 +58,7 @@ def test_data_types_export_multi_file(format, signals_out, data_types_out,
                                       expected_signal, expected_data_types, change_test_dir):
     """
     Test that data types provided in vspec format are converted correctly
+    Note that DDSIDL does not support -ot
     """
     args = ["../../../vspec2" + format + ".py"]
     if format == 'json':

--- a/vspec/vspec2vss_config.py
+++ b/vspec/vspec2vss_config.py
@@ -33,6 +33,9 @@ class Vspec2VssConfig:
         self.extended_attributes_supported = True
         # Shall it be possible to give a type tree
         self.type_tree_supported = True
+        # Is it supported to get type data generated to a separate file
+        # Only relevant if self.type_tree_supported is True
+        self.separate_output_type_file_supported = True
 
         # shall vspec2vss expand the model (by default)
         self.expand_model = True

--- a/vspec/vssexporters/vss2ddsidl.py
+++ b/vspec/vssexporters/vss2ddsidl.py
@@ -272,6 +272,7 @@ class Vss2DdsIdl(Vss2X):
 
     def __init__(self, vspec2vss_config: Vspec2VssConfig):
         vspec2vss_config.no_expand_option_supported = False
+        vspec2vss_config.separate_output_type_file_supported = False
 
     def add_arguments(self, parser: argparse.ArgumentParser):
         parser.description = "The DDS-IDL exporter"


### PR DESCRIPTION
This is inspired by:

- https://github.com/COVESA/vss-tools/issues/238
- https://github.com/COVESA/vss-tools/issues/339

This PR does two things:

- It adds a testcase with struct output for DDSIDL
- It extends the tool config so that you can indicate that a tool does not support `-ot`