### PR TITLE
Simplify overlay handling

### DIFF
--- a/tests/vspec/test_faulty_type/test_faulty_type.py
+++ b/tests/vspec/test_faulty_type/test_faulty_type.py
@@ -24,7 +24,7 @@ def test_error(change_test_dir):
     assert os.WIFEXITED(result)
     # failure expected
     assert os.WEXITSTATUS(result) != 0
-    test_str = 'grep \"Unknown type: bosch\" out.txt > /dev/null'
+    test_str = 'grep \"Type not allowed: bosch\" out.txt > /dev/null'
     result = os.system(test_str)
     os.system("cat out.txt")
     os.system("rm -f out.json out.txt")

--- a/tests/vspec/test_overlay/expected_no_datatype.json
+++ b/tests/vspec/test_overlay/expected_no_datatype.json
@@ -1,0 +1,26 @@
+{
+  "A": {
+    "children": {
+      "AA": {
+        "children": {
+          "SignalAA": {
+            "datatype": "int8",
+            "description": "This is yet another signal.",
+            "type": "sensor",
+            "unit": "km"
+          }
+        },
+        "description": "Branch A.AA.",
+        "type": "branch"
+      },
+      "SignalA": {
+        "datatype": "int8",
+        "description": "No datatype OK if signal exist since before",
+        "type": "sensor",
+        "unit": "celsius"
+      }
+    },
+    "description": "Branch A.",
+    "type": "branch"
+  }
+}

--- a/tests/vspec/test_overlay/expected_no_type.json
+++ b/tests/vspec/test_overlay/expected_no_type.json
@@ -1,0 +1,26 @@
+{
+  "A": {
+    "children": {
+      "AA": {
+        "children": {
+          "SignalAA": {
+            "datatype": "int8",
+            "description": "This is yet another signal.",
+            "type": "sensor",
+            "unit": "km"
+          }
+        },
+        "description": "Branch A.AA.",
+        "type": "branch"
+      },
+      "SignalA": {
+        "datatype": "int8",
+        "description": "No type and datatype OK if signal exist since before",
+        "type": "sensor",
+        "unit": "celsius"
+      }
+    },
+    "description": "Branch A.",
+    "type": "branch"
+  }
+}

--- a/tests/vspec/test_overlay/overlay_error.vspec
+++ b/tests/vspec/test_overlay/overlay_error.vspec
@@ -1,9 +1,16 @@
+# Copyright (c) 2024 Contributors to COVESA
 #
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
 A:
   type: branch
   description: Branch A.
 
-A.SignalA:
+A.SignalXXXX:
   type: sensor
   unit: celsius
-  description: We will have an error if datatype is not given
+  description: We will have an error if datatype is not given and signal does not exist

--- a/tests/vspec/test_overlay/overlay_no_datatype.vspec
+++ b/tests/vspec/test_overlay/overlay_no_datatype.vspec
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Contributors to COVESA
+# Copyright (c) 2024 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the
 # terms of the Mozilla Public License 2.0 which is available at
@@ -7,11 +7,10 @@
 # SPDX-License-Identifier: MPL-2.0
 
 A:
-  type: BRANCH
-  description: VSS is case sensitive
+  type: branch
+  description: Branch A.
 
-A.UInt8:
-  datatype: uint8
+A.SignalA:
   type: sensor
-  unit: km
-  description: This description is mandatory!
+  unit: celsius
+  description: No datatype OK if signal exist since before

--- a/tests/vspec/test_overlay/overlay_no_type.vspec
+++ b/tests/vspec/test_overlay/overlay_no_type.vspec
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Contributors to COVESA
+# Copyright (c) 2024 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the
 # terms of the Mozilla Public License 2.0 which is available at
@@ -7,11 +7,9 @@
 # SPDX-License-Identifier: MPL-2.0
 
 A:
-  type: BRANCH
-  description: VSS is case sensitive
+  type: branch
+  description: Branch A.
 
-A.UInt8:
-  datatype: uint8
-  type: sensor
-  unit: km
-  description: This description is mandatory!
+A.SignalA:
+  unit: celsius
+  description: No type and datatype OK if signal exist since before

--- a/tests/vspec/test_overlay/test_overlay.py
+++ b/tests/vspec/test_overlay/test_overlay.py
@@ -43,6 +43,14 @@ def test_implicit_overlay(change_test_dir):
     run_overlay("implicit_branches")
 
 
+def test_no_datatype(change_test_dir):
+    run_overlay("no_datatype")
+
+
+def test_no_type(change_test_dir):
+    run_overlay("no_type")
+
+
 def test_overlay_error(change_test_dir):
 
     test_str = "../../../vspec2json.py --json-pretty -u ../test_units.yaml -o overlay_error.vspec " + \

--- a/tests/vspec/test_overlay_on_instance/overlay_no_type_datatype.vspec
+++ b/tests/vspec/test_overlay_on_instance/overlay_no_type_datatype.vspec
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Contributors to COVESA
+# Copyright (c) 2024 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the
 # terms of the Mozilla Public License 2.0 which is available at
@@ -6,12 +6,8 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-A:
-  type: BRANCH
-  description: VSS is case sensitive
+# This file tries to use implicit type/datatype for already existing signals
+# That does not work due to a limitation in current name lookup
 
-A.UInt8:
-  datatype: uint8
-  type: sensor
-  unit: km
-  description: This description is mandatory!
+A.B.Row1.Left.C:
+  my_id: Varberg

--- a/tests/vspec/test_overlay_on_instance/test_overlay_on_instance.py
+++ b/tests/vspec/test_overlay_on_instance/test_overlay_on_instance.py
@@ -32,3 +32,23 @@ def test_expanded_overlay(change_test_dir):
     os.system("rm -f out.json out.txt")
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) == 0
+
+
+def test_expanded_overlay_no_type_datatype(change_test_dir):
+    """
+    This test shows current limitation on type/datatype lookup.
+    We cannot do lookup on expanded names containing instances.
+    That would require quite some more advanced lookup considering instance declarations.
+    Not impossible, but more complex.
+    """
+    test_str = "../../../vspec2json.py  -e my_id --json-pretty -u ../test_units.yaml test.vspec " + \
+               "-o overlay_no_type_datatype.vspec  out.json > out.txt 2>&1"
+    result = os.system(test_str)
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) != 0
+
+    test_str = 'grep \"No type specified for A.B.Row1.Left.C\" out.txt > /dev/null'
+    result = os.system(test_str)
+    os.system("rm -f out.json out.txt")
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0

--- a/tests/vspec/test_struct_as_root/struct1.vspec
+++ b/tests/vspec/test_struct_as_root/struct1.vspec
@@ -1,10 +1,18 @@
+# Copyright (c) 2023 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
 # This typefile is a bit special as it contain a struct as top node
 # That is possibly not explicitly stated in documentation, but is not supported by some tools
 # so we give an error
 
 Struct1:
   type: struct
-  description: "A struct with datatype property defined."
+  description: "Struct on root level - not allowed!"
 
 Struct1.x:
   type: property

--- a/tests/vspec/test_struct_as_root/test.vspec
+++ b/tests/vspec/test_struct_as_root/test.vspec
@@ -1,3 +1,10 @@
+# Copyright (c) 2023 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
 #
 A:
   type: branch

--- a/tests/vspec/test_struct_as_root/test_struct_as_root.py
+++ b/tests/vspec/test_struct_as_root/test_struct_as_root.py
@@ -19,14 +19,14 @@ def change_test_dir(request, monkeypatch):
 
 
 def test_struct_as_root(change_test_dir):
-    test_str = "../../../vspec2csv.py -vt struct1.vspec -o overlay.vspec" + \
+    test_str = "../../../vspec2csv.py -vt struct1.vspec" + \
                " -u ../test_units.yaml test.vspec out.csv > out.txt 2>&1"
     result = os.system(test_str)
     assert os.WIFEXITED(result)
     # failure expected
     assert os.WEXITSTATUS(result) != 0
 
-    test_str = 'grep \"root must be branch\" out.txt > /dev/null'
+    test_str = 'grep \"Root node Struct1 is not of branch type\" out.txt > /dev/null'
     result = os.system(test_str)
     os.system("cat out.txt")
     os.system("rm -f out.json out.txt")

--- a/tests/vspec/test_type_error/branch_in_signal.vspec
+++ b/tests/vspec/test_type_error/branch_in_signal.vspec
@@ -7,11 +7,16 @@
 # SPDX-License-Identifier: MPL-2.0
 
 A:
-  type: BRANCH
-  description: VSS is case sensitive
+  type: branch
+  description: ok
 
 A.UInt8:
   datatype: uint8
   type: sensor
   unit: km
-  description: This description is mandatory!
+  description: ok!
+
+
+A.UInt8.CCC:
+  type: branch
+  description: Branch in sensor shall not be allowed

--- a/tests/vspec/test_type_error/correct.vspec
+++ b/tests/vspec/test_type_error/correct.vspec
@@ -1,4 +1,11 @@
+# Copyright (c) 2023 Contributors to COVESA
 #
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
 A:
   type: branch
   description: This description is mandatory!

--- a/tests/vspec/test_type_error/no_type_branch.vspec
+++ b/tests/vspec/test_type_error/no_type_branch.vspec
@@ -1,3 +1,11 @@
+# Copyright (c) 2023 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
 A:
   description: This description is mandatory!
 

--- a/tests/vspec/test_type_error/no_type_overlay.vspec
+++ b/tests/vspec/test_type_error/no_type_overlay.vspec
@@ -1,3 +1,11 @@
+# Copyright (c) 2023 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
 # This is intended as an overlay to correct.vspec
 
 A.B:

--- a/tests/vspec/test_type_error/no_type_property.vspec
+++ b/tests/vspec/test_type_error/no_type_property.vspec
@@ -1,3 +1,11 @@
+# Copyright (c) 2023 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
 VehicleDataTypes:
   type: branch
   description: Top-level branch for vehicle data types.

--- a/tests/vspec/test_type_error/no_type_signal.vspec
+++ b/tests/vspec/test_type_error/no_type_signal.vspec
@@ -1,3 +1,11 @@
+# Copyright (c) 2023 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
 A:
   type: branch
   description: This description is mandatory!

--- a/tests/vspec/test_type_error/no_type_struct.vspec
+++ b/tests/vspec/test_type_error/no_type_struct.vspec
@@ -1,3 +1,11 @@
+# Copyright (c) 2023 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
 VehicleDataTypes:
   type: branch
   description: Top-level branch for vehicle data types.

--- a/tests/vspec/test_type_error/test_type_error.py
+++ b/tests/vspec/test_type_error/test_type_error.py
@@ -59,3 +59,22 @@ def type_case_sensitive(vspec_file: str, change_test_dir):
     os.system("rm -f out.json out.txt")
     assert os.WIFEXITED(result)
     assert os.WEXITSTATUS(result) == 0
+
+
+@pytest.mark.parametrize("vspec_file", [
+    ("branch_in_signal.vspec"),
+    ])
+def test_scope_error(vspec_file: str,  change_test_dir):
+    test_str = "../../../vspec2json.py --json-pretty -u ../test_units.yaml " + \
+               vspec_file + " out.json > out.txt 2>&1"
+    result = os.system(test_str)
+    assert os.WIFEXITED(result)
+    # failure expected
+    assert os.WEXITSTATUS(result) != 0
+
+    test_str = 'grep \"VSS Node A.UInt8 cannot have children\" out.txt > /dev/null'
+    result = os.system(test_str)
+    os.system("cat out.txt")
+    os.system("rm -f out.json out.txt")
+    assert os.WIFEXITED(result)
+    assert os.WEXITSTATUS(result) == 0

--- a/vspec/vspec2x.py
+++ b/vspec/vspec2x.py
@@ -146,6 +146,8 @@ class Vspec2X():
                 break_on_name_style_violation=abort_on_namestyle,
                 expand_inst=False, data_type_tree=data_type_tree)
 
+            VSSNode.set_reference_tree(tree)
+
             for overlay in args.overlays:
                 logging.info(f"Applying VSS overlay from {overlay}...")
                 othertree = vspec.load_tree(overlay, include_dirs, VSSTreeType.SIGNAL_TREE,

--- a/vspec/vssexporters/vss2graphql.py
+++ b/vspec/vssexporters/vss2graphql.py
@@ -84,10 +84,14 @@ def get_schema_from_tree(root_node: VSSNode, additional_leaf_fields: list) -> st
 
 
 def to_gql_type(node: VSSNode, additional_leaf_fields: list) -> GraphQLObjectType:
+
+    if node.has_datatype():
+        fields = leaf_fields(node, additional_leaf_fields)
+    else:
+        fields = branch_fields(node, additional_leaf_fields)
     return GraphQLObjectType(
         name=node.qualified_name("_"),
-        fields=leaf_fields(node, additional_leaf_fields) if hasattr(
-            node, "datatype") else branch_fields(node, additional_leaf_fields),
+        fields=fields,
         description=node.description,
     )
 


### PR DESCRIPTION
This is an idea for simplifying overlays. If a node is found in overlay without type (e.g. `branch`, `sensor`) or datatype (e.g. `uint8`) it will try to do a look-up if a node with the same name already exist, and then use that type/datatype value.

There are limitations, like if you add something to `Vehicle.Axle.Front.SomeSignal` in an overlay (i.e. only for a single instance) it will not find source signal `Vehicle.Axle.SomeSignal`.

Many of the changes are just adding license headers. As I got failure on some changed files I also updated some files that were not changed.

Next step if this is merged is to adapt documentation in VSS repo. Possibly saying something like: 

- _In most cases you do not need to specify `datatype` and `type` in overlay if you are modifying an existing signal._
- _Specifying `datatype` and `type` is needed if overlay addresses specific instances of a branch, like front left wheel._