### PR TITLE
Improving version printout

### DIFF
--- a/vspec/vspec2x.py
+++ b/vspec/vspec2x.py
@@ -23,7 +23,12 @@ import sys
 import vspec
 
 import importlib_metadata
-VERSION = importlib_metadata.version("vss-tools")
+
+try:
+    VERSION = importlib_metadata.version("vss-tools")
+except importlib_metadata.PackageNotFoundError:
+    # No installed version of vss-tools found, that likely means we are running from local source
+    VERSION = "local"
 
 
 class Vspec2X():


### PR DESCRIPTION
It was detected by @UlfBj that our new automatic version printout gives error if not having installed vss-tools. This fixes that by printing `local`instead of giving an exception

```
erik@debian6:~/vehicle_signal_specification$ make csv
./vss-tools/vspec2csv.py -u ./spec/units.yaml --strict ./spec/VehicleSignalSpecification.vspec vss_rel_$(cat VERSION).csv
INFO     VSS-tools version local
INFO     Added 29 quantities from /home/erik/vehicle_signal_specification/spec/quantities.yaml
INFO     Added 61 units from ./spec/units.yaml
INFO     Loading vspec from ./spec/VehicleSignalSpecification.vspec...
INFO     Calling exporter...
INFO     Generating CSV output...
INFO     All done.
```

One can argue that the "importlib" solution we have can give misleading info if you are working on vss-tools source but have vss-tools installed with pip (`pip install vss-tools`). if you work with local source of vss-tools you could do `pip install -e .` to get a pip install that corresponds to your source code.



