### PR TITLE
Using rich for logging format, added .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+layout python3

--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ celerybeat-schedule
 
 # virtualenv
 .venv/
+.direnv/
 venv/
 ENV/
 

--- a/Pipfile
+++ b/Pipfile
@@ -11,6 +11,7 @@ deprecation = ">=2.1.0"
 pytest = ">=2.7.2"
 PyYAML = ">=5.1"
 rdflib = ">=6.0.0"
+rich = ">=13.7.1"
 vss-tools = {editable = true, path = "."}
 graphql-core = "*"
 importlib-metadata = ">=7.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "7f4f92123b5aa8439474f87981d5b801d6c2aac053c721fef8555c2e1c9d8094"
+            "sha256": "5218d0ec49db979072eca2651fa58d381e056178809872887433994b54ce1501"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -22,7 +22,6 @@
                 "sha256:5ea9e61caf96db1e5b3d0a914378d2cd83c269dfce1fb8242ce96589fa3382f0"
             ],
             "index": "pypi",
-            "markers": "python_version < '4' and python_full_version >= '3.7.2'",
             "version": "==2.12.1"
         },
         "deprecation": {
@@ -33,31 +32,21 @@
             "index": "pypi",
             "version": "==2.1.0"
         },
-        "exceptiongroup": {
-            "hashes": [
-                "sha256:5258b9ed329c5bbdd31a309f53cbfb0b155341807f6ff7606a1e801a891b29ad",
-                "sha256:a4785e48b045528f5bfe627b6ad554ff32def154f42372786903b7abcfe1aa16"
-            ],
-            "markers": "python_version < '3.11'",
-            "version": "==1.2.1"
-        },
         "graphql-core": {
             "hashes": [
                 "sha256:06d2aad0ac723e35b1cb47885d3e5c45e956a53bc1b209a9fc5369007fe46676",
                 "sha256:5766780452bd5ec8ba133f8bf287dc92713e3868ddd83aee4faab9fc3e303dc3"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6' and python_version < '4'",
             "version": "==3.2.3"
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:30962b96c0c223483ed6cc7280e7f0199feb01a0e40cfae4d4450fc6fab1f570",
-                "sha256:b78938b926ee8d5f020fc4772d487045805a55ddbad2ecf21c6d60938dc7fcd2"
+                "sha256:04e4aad329b8b948a5711d394fa8759cb80f009225441b4f2a02bd4d8e5f426c",
+                "sha256:3ff4519071ed42740522d494d04819b666541b9752c43012f85afb2cc220fcc6"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==7.1.0"
+            "version": "==7.2.0"
         },
         "iniconfig": {
             "hashes": [
@@ -73,6 +62,22 @@
                 "sha256:48c5881de7e8b0a0d648cb024c8062dc84e7b840ed81e864c7614fd3c127bde9"
             ],
             "version": "==0.6.1"
+        },
+        "markdown-it-py": {
+            "hashes": [
+                "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1",
+                "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.0.0"
+        },
+        "mdurl": {
+            "hashes": [
+                "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
+                "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.1.2"
         },
         "packaging": {
             "hashes": [
@@ -90,6 +95,14 @@
             "markers": "python_version >= '3.8'",
             "version": "==1.5.0"
         },
+        "pygments": {
+            "hashes": [
+                "sha256:786ff802f32e91311bff3889f6e9a86e81505fe99f2735bb6d60ae0c5004f199",
+                "sha256:b8e6aca0523f3ab76fee51799c488e38782ac06eafcf95e7ba832985c8e7b13a"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==2.18.0"
+        },
         "pyparsing": {
             "hashes": [
                 "sha256:a1bac0ce561155ecc3ed78ca94d3c9378656ad4c94c1270de543f621420f94ad",
@@ -104,7 +117,6 @@
                 "sha256:de4bb8104e201939ccdc688b27a89a7be2079b22e2bd2b07f806b6ba71117977"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
             "version": "==8.2.2"
         },
         "pyyaml": {
@@ -162,7 +174,6 @@
                 "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==6.0.1"
         },
         "rdflib": {
@@ -171,8 +182,15 @@
                 "sha256:9995eb8569428059b8c1affd26b25eac510d64f5043d9ce8c84e0d0036e995ae"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.8.1' and python_full_version < '4.0.0'",
             "version": "==7.0.0"
+        },
+        "rich": {
+            "hashes": [
+                "sha256:4edbae314f59eb482f54e9e30bf00d33350aaa94f4bfcd4e9e3110e64d0d7222",
+                "sha256:9be308cb1fe2f1f57d67ce99e95af38a1e2bc71ad9813b0e247cf7ffbcc3a432"
+            ],
+            "index": "pypi",
+            "version": "==13.7.1"
         },
         "six": {
             "hashes": [
@@ -181,14 +199,6 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
-        },
-        "tomli": {
-            "hashes": [
-                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
-                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
-            ],
-            "markers": "python_version < '3.11'",
-            "version": "==2.0.1"
         },
         "vss-tools": {
             "editable": true,
@@ -221,20 +231,19 @@
         },
         "filelock": {
             "hashes": [
-                "sha256:58a2549afdf9e02e10720eaa4d4470f56386d7a6f72edd7d0596337af8ed7ad8",
-                "sha256:71b3102950e91dfc1bb4209b64be4dc8854f40e5f534428d8684f953ac847fac"
+                "sha256:0151273e5b5d6cf753a61ec83b3a9b7d8821c39ae9af9d7ecf2f9e2f17404103",
+                "sha256:e1199bf5194a2277273dacd50269f0d87d0682088a3c561c15674ea9005d8635"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.15.1"
+            "version": "==3.15.3"
         },
         "flake8": {
             "hashes": [
-                "sha256:33f96621059e65eec474169085dc92bf26e7b2d47366b70be2f67ab80dc25132",
-                "sha256:a6dfbb75e03252917f2473ea9653f7cd799c3064e54d4c8140044c5c065f53c3"
+                "sha256:2e416edcc62471a64cea09353f4e7bdba32aeb079b6e360554c659a122b1bc6a",
+                "sha256:48a07b626b55236e0fb4784ee69a465fbf59d79eec1f5b4785c3d3bc57d17aa5"
             ],
             "index": "pypi",
-            "markers": "python_full_version >= '3.8.1'",
-            "version": "==7.0.0"
+            "version": "==7.1.0"
         },
         "identify": {
             "hashes": [
@@ -274,16 +283,15 @@
                 "sha256:fae36fd1d7ad7d6a5a1c0b0d5adb2ed1a3bda5a21bf6c3e5372073d7a11cd4c5"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.9'",
             "version": "==3.7.1"
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:41ba0e7afc9752dfb53ced5489e89f8186be00e599e712660695b7a75ff2663f",
-                "sha256:44fe31000b2d866f2e41841b18528a505fbd7fef9017b04eff4e2648a0fadc67"
+                "sha256:442f950141b4f43df752dd303511ffded3a04c2b6fb7f65980574f0c31e6e79c",
+                "sha256:949a39f6b86c3e1515ba1787c2022131d165a8ad271b11370a8819aa070269e4"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.11.1"
+            "version": "==2.12.0"
         },
         "pyflakes": {
             "hashes": [
@@ -348,7 +356,6 @@
                 "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.6'",
             "version": "==6.0.1"
         },
         "virtualenv": {

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ setup(
              'vspec2id.py'],
     python_requires='>=3.10',
     install_requires=['pyyaml>=5.1', 'anytree>=2.8.0', 'deprecation>=2.1.0', 'graphql-core',
-                      'importlib-metadata>=7.0'],
+                      'importlib-metadata>=7.0', 'rich>=13.7.1'],
     tests_require=['pytest>=2.7.2'],
     package_data={'vspec': [
         'py.typed'

--- a/tests/generators/test_generator.py
+++ b/tests/generators/test_generator.py
@@ -6,25 +6,23 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-import pytest
+import subprocess
+from pathlib import Path
 import os
 
 
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
-
-
-def test_generator(change_test_dir):
-
-    test_str = "./example_generator.py -k \"VSS Contributor\" -u ../vspec/test_units.yaml test.vspec > out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-    test_str = 'grep \"I found 2 comments with vss contributor\" out.txt > /dev/null'
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-    os.system("rm -f  out.txt")
+def test_generator():
+    cmd = [
+        "python",
+        "example_generator.py",
+        "-k",
+        "VSS Contributor",
+        "-u",
+        "../vspec/test_units.yaml",
+        "test.vspec",
+    ]
+    env = os.environ.copy()
+    env["COLUMNS"] = "120"
+    p = subprocess.run(cmd, capture_output=True, text=True, cwd=Path(__file__).resolve().parent, env=env)
+    assert p.returncode == 0
+    assert "I found 2 comments with vss contributor" in p.stdout

--- a/tests/vspec/test_datatypes_error/test_datatypes_error.py
+++ b/tests/vspec/test_datatypes_error/test_datatypes_error.py
@@ -8,44 +8,48 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-import pytest
 import os
+import subprocess
+from pathlib import Path
 
 
-# #################### Helper methods #############################
+def test_datatype_error(tmp_path):
+    cmd = (
+        f"../../../vspec2json.py --json-pretty -u ../test_units.yaml test.vspec ${tmp_path / 'out.json'}"
+    )
+    env = os.environ.copy()
+    env["COLUMNS"] = "120"
+    p = subprocess.run(
+        cmd.split(),
+        capture_output=True,
+        text=True,
+        cwd=Path(__file__).resolve().parent,
+        env=env,
+    )
+    assert p.returncode != 0
 
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
-
-
-def test_datatype_error(change_test_dir):
-    test_str = "../../../vspec2json.py --json-pretty -u ../test_units.yaml test.vspec out.json > out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    # failure expected
-    assert os.WEXITSTATUS(result) != 0
-
-    test_str = 'grep \"Following types were referenced in signals but have not been defined\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+    assert (
+        "Following types were referenced in signals but have not been defined"
+        in p.stdout)
 
 
-def test_datatype_branch(change_test_dir):
-    test_str = "../../../vspec2json.py --json-pretty -u ../test_units.yaml " \
-               "test_datatype_branch.vspec out.json > out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    # failure expected
-    assert os.WEXITSTATUS(result) != 0
+def test_datatype_branch(tmp_path):
+    cmd = (
+        "../../../vspec2json.py --json-pretty -u ../test_units.yaml "
+        f"test_datatype_branch.vspec ${tmp_path / 'out.json'}"
+    )
+    env = os.environ.copy()
+    env["COLUMNS"] = "120"
+    p = subprocess.run(
+        cmd.split(),
+        capture_output=True,
+        text=True,
+        cwd=Path(__file__).resolve().parent,
+        env=env,
+    )
+    assert p.returncode != 0
 
-    test_str = 'grep \"cannot have datatype\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+    assert (
+        "cannot have datatype"
+        in p.stdout
+    )

--- a/vspec/__init__.py
+++ b/vspec/__init__.py
@@ -114,7 +114,7 @@ def check_type_usage(tree: VSSNode, tree_type: VSSTreeType, type_tree: Optional[
     Check usages of datatypes within the tree.
     This methods shall be called after overlays (or additional type files) have been merged.
     """
-    logging.info("Check type usdage")
+    logging.info("Check type usage")
 
     if tree_type == VSSTreeType.DATA_TYPE_TREE:
 

--- a/vspec/loggingconfig.py
+++ b/vspec/loggingconfig.py
@@ -13,10 +13,16 @@
 #
 
 import logging
+from rich.logging import RichHandler
 
 
 def initLogging():
     """
     Initialize logging
     """
-    logging.basicConfig(level=logging.INFO, format='%(levelname)-8s %(message)s')
+    logging.basicConfig(
+        level="INFO",
+        format="%(message)s",
+        datefmt="[%X]",
+        handlers=[RichHandler(rich_tracebacks=True)],
+    )


### PR DESCRIPTION
# About

Using [rich](https://rich.readthedocs.io/en/stable/introduction.html) as logging formatter for readability.

Before:
<img width="819" alt="image" src="https://github.com/COVESA/vss-tools/assets/12069137/ceec9505-5f8a-40c3-9648-2264c492c707">

After:
<img width="900" alt="image" src="https://github.com/COVESA/vss-tools/assets/12069137/55c5329b-0ca3-4dae-9ab1-b77f32b5c4b2">

Also added an [direnv](https://github.com/direnv/direnv) config for python3. Added gitignore entry accordingly