### PR TITLE
Tests Refactoring

### DIFF
--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -43,13 +43,13 @@ jobs:
       - name: flake8
         run: |
           poetry run flake8 src tests contrib
-      - name: Run tests
-        run: |
-          poetry run pytest
-      - name: Build binary library
+      - name: Build binary library (Needed for pytest)
         run: |
           cd binary
           make
+      - name: Run tests
+        run: |
+          poetry run pytest
       - name: Test Binary Go Parser
         run: |
           cd binary/go_parser

--- a/.github/workflows/buildcheck.yml
+++ b/.github/workflows/buildcheck.yml
@@ -49,7 +49,7 @@ jobs:
           make
       - name: Run tests
         run: |
-          poetry run pytest
+          poetry run pytest --cov=vss_tools --cov-report=term-missing --cov-fail-under=90
       - name: Test Binary Go Parser
         run: |
           cd binary/go_parser

--- a/poetry.lock
+++ b/poetry.lock
@@ -37,6 +37,73 @@ files = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.5.4"
+description = "Code coverage measurement for Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "coverage-7.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6cfb5a4f556bb51aba274588200a46e4dd6b505fb1a5f8c5ae408222eb416f99"},
+    {file = "coverage-7.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2174e7c23e0a454ffe12267a10732c273243b4f2d50d07544a91198f05c48f47"},
+    {file = "coverage-7.5.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2214ee920787d85db1b6a0bd9da5f8503ccc8fcd5814d90796c2f2493a2f4d2e"},
+    {file = "coverage-7.5.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1137f46adb28e3813dec8c01fefadcb8c614f33576f672962e323b5128d9a68d"},
+    {file = "coverage-7.5.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b385d49609f8e9efc885790a5a0e89f2e3ae042cdf12958b6034cc442de428d3"},
+    {file = "coverage-7.5.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b4a474f799456e0eb46d78ab07303286a84a3140e9700b9e154cfebc8f527016"},
+    {file = "coverage-7.5.4-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5cd64adedf3be66f8ccee418473c2916492d53cbafbfcff851cbec5a8454b136"},
+    {file = "coverage-7.5.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e564c2cf45d2f44a9da56f4e3a26b2236504a496eb4cb0ca7221cd4cc7a9aca9"},
+    {file = "coverage-7.5.4-cp310-cp310-win32.whl", hash = "sha256:7076b4b3a5f6d2b5d7f1185fde25b1e54eb66e647a1dfef0e2c2bfaf9b4c88c8"},
+    {file = "coverage-7.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:018a12985185038a5b2bcafab04ab833a9a0f2c59995b3cec07e10074c78635f"},
+    {file = "coverage-7.5.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:db14f552ac38f10758ad14dd7b983dbab424e731588d300c7db25b6f89e335b5"},
+    {file = "coverage-7.5.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3257fdd8e574805f27bb5342b77bc65578e98cbc004a92232106344053f319ba"},
+    {file = "coverage-7.5.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3a6612c99081d8d6134005b1354191e103ec9705d7ba2754e848211ac8cacc6b"},
+    {file = "coverage-7.5.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d45d3cbd94159c468b9b8c5a556e3f6b81a8d1af2a92b77320e887c3e7a5d080"},
+    {file = "coverage-7.5.4-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ed550e7442f278af76d9d65af48069f1fb84c9f745ae249c1a183c1e9d1b025c"},
+    {file = "coverage-7.5.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:7a892be37ca35eb5019ec85402c3371b0f7cda5ab5056023a7f13da0961e60da"},
+    {file = "coverage-7.5.4-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8192794d120167e2a64721d88dbd688584675e86e15d0569599257566dec9bf0"},
+    {file = "coverage-7.5.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:820bc841faa502e727a48311948e0461132a9c8baa42f6b2b84a29ced24cc078"},
+    {file = "coverage-7.5.4-cp311-cp311-win32.whl", hash = "sha256:6aae5cce399a0f065da65c7bb1e8abd5c7a3043da9dceb429ebe1b289bc07806"},
+    {file = "coverage-7.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:d2e344d6adc8ef81c5a233d3a57b3c7d5181f40e79e05e1c143da143ccb6377d"},
+    {file = "coverage-7.5.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:54317c2b806354cbb2dc7ac27e2b93f97096912cc16b18289c5d4e44fc663233"},
+    {file = "coverage-7.5.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:042183de01f8b6d531e10c197f7f0315a61e8d805ab29c5f7b51a01d62782747"},
+    {file = "coverage-7.5.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a6bb74ed465d5fb204b2ec41d79bcd28afccf817de721e8a807d5141c3426638"},
+    {file = "coverage-7.5.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b3d45ff86efb129c599a3b287ae2e44c1e281ae0f9a9bad0edc202179bcc3a2e"},
+    {file = "coverage-7.5.4-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5013ed890dc917cef2c9f765c4c6a8ae9df983cd60dbb635df8ed9f4ebc9f555"},
+    {file = "coverage-7.5.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1014fbf665fef86cdfd6cb5b7371496ce35e4d2a00cda501cf9f5b9e6fced69f"},
+    {file = "coverage-7.5.4-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:3684bc2ff328f935981847082ba4fdc950d58906a40eafa93510d1b54c08a66c"},
+    {file = "coverage-7.5.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:581ea96f92bf71a5ec0974001f900db495488434a6928a2ca7f01eee20c23805"},
+    {file = "coverage-7.5.4-cp312-cp312-win32.whl", hash = "sha256:73ca8fbc5bc622e54627314c1a6f1dfdd8db69788f3443e752c215f29fa87a0b"},
+    {file = "coverage-7.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:cef4649ec906ea7ea5e9e796e68b987f83fa9a718514fe147f538cfeda76d7a7"},
+    {file = "coverage-7.5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cdd31315fc20868c194130de9ee6bfd99755cc9565edff98ecc12585b90be882"},
+    {file = "coverage-7.5.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:02ff6e898197cc1e9fa375581382b72498eb2e6d5fc0b53f03e496cfee3fac6d"},
+    {file = "coverage-7.5.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d05c16cf4b4c2fc880cb12ba4c9b526e9e5d5bb1d81313d4d732a5b9fe2b9d53"},
+    {file = "coverage-7.5.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c5986ee7ea0795a4095ac4d113cbb3448601efca7f158ec7f7087a6c705304e4"},
+    {file = "coverage-7.5.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5df54843b88901fdc2f598ac06737f03d71168fd1175728054c8f5a2739ac3e4"},
+    {file = "coverage-7.5.4-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:ab73b35e8d109bffbda9a3e91c64e29fe26e03e49addf5b43d85fc426dde11f9"},
+    {file = "coverage-7.5.4-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:aea072a941b033813f5e4814541fc265a5c12ed9720daef11ca516aeacd3bd7f"},
+    {file = "coverage-7.5.4-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:16852febd96acd953b0d55fc842ce2dac1710f26729b31c80b940b9afcd9896f"},
+    {file = "coverage-7.5.4-cp38-cp38-win32.whl", hash = "sha256:8f894208794b164e6bd4bba61fc98bf6b06be4d390cf2daacfa6eca0a6d2bb4f"},
+    {file = "coverage-7.5.4-cp38-cp38-win_amd64.whl", hash = "sha256:e2afe743289273209c992075a5a4913e8d007d569a406ffed0bd080ea02b0633"},
+    {file = "coverage-7.5.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b95c3a8cb0463ba9f77383d0fa8c9194cf91f64445a63fc26fb2327e1e1eb088"},
+    {file = "coverage-7.5.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3d7564cc09dd91b5a6001754a5b3c6ecc4aba6323baf33a12bd751036c998be4"},
+    {file = "coverage-7.5.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:44da56a2589b684813f86d07597fdf8a9c6ce77f58976727329272f5a01f99f7"},
+    {file = "coverage-7.5.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e16f3d6b491c48c5ae726308e6ab1e18ee830b4cdd6913f2d7f77354b33f91c8"},
+    {file = "coverage-7.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dbc5958cb471e5a5af41b0ddaea96a37e74ed289535e8deca404811f6cb0bc3d"},
+    {file = "coverage-7.5.4-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:a04e990a2a41740b02d6182b498ee9796cf60eefe40cf859b016650147908029"},
+    {file = "coverage-7.5.4-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:ddbd2f9713a79e8e7242d7c51f1929611e991d855f414ca9996c20e44a895f7c"},
+    {file = "coverage-7.5.4-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:b1ccf5e728ccf83acd313c89f07c22d70d6c375a9c6f339233dcf792094bcbf7"},
+    {file = "coverage-7.5.4-cp39-cp39-win32.whl", hash = "sha256:56b4eafa21c6c175b3ede004ca12c653a88b6f922494b023aeb1e836df953ace"},
+    {file = "coverage-7.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:65e528e2e921ba8fd67d9055e6b9f9e34b21ebd6768ae1c1723f4ea6ace1234d"},
+    {file = "coverage-7.5.4-pp38.pp39.pp310-none-any.whl", hash = "sha256:79b356f3dd5b26f3ad23b35c75dbdaf1f9e2450b6bcefc6d0825ea0aa3f86ca5"},
+    {file = "coverage-7.5.4.tar.gz", hash = "sha256:a44963520b069e12789d0faea4e9fdb1e410cdc4aab89d94f7f55cbb7fef0353"},
+]
+
+[package.dependencies]
+tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
+
+[package.extras]
+toml = ["tomli"]
+
+[[package]]
 name = "deprecation"
 version = "2.1.0"
 description = "A library to handle automated deprecations"
@@ -77,13 +144,13 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "filelock"
-version = "3.15.3"
+version = "3.15.4"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.15.3-py3-none-any.whl", hash = "sha256:0151273e5b5d6cf753a61ec83b3a9b7d8821c39ae9af9d7ecf2f9e2f17404103"},
-    {file = "filelock-3.15.3.tar.gz", hash = "sha256:e1199bf5194a2277273dacd50269f0d87d0682088a3c561c15674ea9005d8635"},
+    {file = "filelock-3.15.4-py3-none-any.whl", hash = "sha256:6ca1fffae96225dab4c6eaf1c4f4f28cd2568d3ec2a44e15a08520504de468e7"},
+    {file = "filelock-3.15.4.tar.gz", hash = "sha256:2207938cbc1844345cb01a5a95524dae30f0ce089eba5b00378295a17e3e90cb"},
 ]
 
 [package.extras]
@@ -134,13 +201,13 @@ license = ["ukkonen"]
 
 [[package]]
 name = "importlib-metadata"
-version = "7.2.0"
+version = "7.2.1"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "importlib_metadata-7.2.0-py3-none-any.whl", hash = "sha256:04e4aad329b8b948a5711d394fa8759cb80f009225441b4f2a02bd4d8e5f426c"},
-    {file = "importlib_metadata-7.2.0.tar.gz", hash = "sha256:3ff4519071ed42740522d494d04819b666541b9752c43012f85afb2cc220fcc6"},
+    {file = "importlib_metadata-7.2.1-py3-none-any.whl", hash = "sha256:ffef94b0b66046dd8ea2d619b701fe978d9264d38f3998bc4c27ec3b146a87c8"},
+    {file = "importlib_metadata-7.2.1.tar.gz", hash = "sha256:509ecb2ab77071db5137c655e24ceb3eee66e7bbc6574165d0d114d9fc4bbe68"},
 ]
 
 [package.dependencies]
@@ -224,38 +291,38 @@ files = [
 
 [[package]]
 name = "mypy"
-version = "1.10.0"
+version = "1.10.1"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mypy-1.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:da1cbf08fb3b851ab3b9523a884c232774008267b1f83371ace57f412fe308c2"},
-    {file = "mypy-1.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:12b6bfc1b1a66095ab413160a6e520e1dc076a28f3e22f7fb25ba3b000b4ef99"},
-    {file = "mypy-1.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e36fb078cce9904c7989b9693e41cb9711e0600139ce3970c6ef814b6ebc2b2"},
-    {file = "mypy-1.10.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2b0695d605ddcd3eb2f736cd8b4e388288c21e7de85001e9f85df9187f2b50f9"},
-    {file = "mypy-1.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:cd777b780312ddb135bceb9bc8722a73ec95e042f911cc279e2ec3c667076051"},
-    {file = "mypy-1.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3be66771aa5c97602f382230165b856c231d1277c511c9a8dd058be4784472e1"},
-    {file = "mypy-1.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8b2cbaca148d0754a54d44121b5825ae71868c7592a53b7292eeb0f3fdae95ee"},
-    {file = "mypy-1.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ec404a7cbe9fc0e92cb0e67f55ce0c025014e26d33e54d9e506a0f2d07fe5de"},
-    {file = "mypy-1.10.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e22e1527dc3d4aa94311d246b59e47f6455b8729f4968765ac1eacf9a4760bc7"},
-    {file = "mypy-1.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:a87dbfa85971e8d59c9cc1fcf534efe664d8949e4c0b6b44e8ca548e746a8d53"},
-    {file = "mypy-1.10.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:a781f6ad4bab20eef8b65174a57e5203f4be627b46291f4589879bf4e257b97b"},
-    {file = "mypy-1.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b808e12113505b97d9023b0b5e0c0705a90571c6feefc6f215c1df9381256e30"},
-    {file = "mypy-1.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f55583b12156c399dce2df7d16f8a5095291354f1e839c252ec6c0611e86e2e"},
-    {file = "mypy-1.10.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4cf18f9d0efa1b16478c4c129eabec36148032575391095f73cae2e722fcf9d5"},
-    {file = "mypy-1.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:bc6ac273b23c6b82da3bb25f4136c4fd42665f17f2cd850771cb600bdd2ebeda"},
-    {file = "mypy-1.10.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9fd50226364cd2737351c79807775136b0abe084433b55b2e29181a4c3c878c0"},
-    {file = "mypy-1.10.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:f90cff89eea89273727d8783fef5d4a934be2fdca11b47def50cf5d311aff727"},
-    {file = "mypy-1.10.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fcfc70599efde5c67862a07a1aaf50e55bce629ace26bb19dc17cece5dd31ca4"},
-    {file = "mypy-1.10.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:075cbf81f3e134eadaf247de187bd604748171d6b79736fa9b6c9685b4083061"},
-    {file = "mypy-1.10.0-cp38-cp38-win_amd64.whl", hash = "sha256:3f298531bca95ff615b6e9f2fc0333aae27fa48052903a0ac90215021cdcfa4f"},
-    {file = "mypy-1.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fa7ef5244615a2523b56c034becde4e9e3f9b034854c93639adb667ec9ec2976"},
-    {file = "mypy-1.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3236a4c8f535a0631f85f5fcdffba71c7feeef76a6002fcba7c1a8e57c8be1ec"},
-    {file = "mypy-1.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a2b5cdbb5dd35aa08ea9114436e0d79aceb2f38e32c21684dcf8e24e1e92821"},
-    {file = "mypy-1.10.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:92f93b21c0fe73dc00abf91022234c79d793318b8a96faac147cd579c1671746"},
-    {file = "mypy-1.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:28d0e038361b45f099cc086d9dd99c15ff14d0188f44ac883010e172ce86c38a"},
-    {file = "mypy-1.10.0-py3-none-any.whl", hash = "sha256:f8c083976eb530019175aabadb60921e73b4f45736760826aa1689dda8208aee"},
-    {file = "mypy-1.10.0.tar.gz", hash = "sha256:3d087fcbec056c4ee34974da493a826ce316947485cef3901f511848e687c131"},
+    {file = "mypy-1.10.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e36f229acfe250dc660790840916eb49726c928e8ce10fbdf90715090fe4ae02"},
+    {file = "mypy-1.10.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:51a46974340baaa4145363b9e051812a2446cf583dfaeba124af966fa44593f7"},
+    {file = "mypy-1.10.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:901c89c2d67bba57aaaca91ccdb659aa3a312de67f23b9dfb059727cce2e2e0a"},
+    {file = "mypy-1.10.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0cd62192a4a32b77ceb31272d9e74d23cd88c8060c34d1d3622db3267679a5d9"},
+    {file = "mypy-1.10.1-cp310-cp310-win_amd64.whl", hash = "sha256:a2cbc68cb9e943ac0814c13e2452d2046c2f2b23ff0278e26599224cf164e78d"},
+    {file = "mypy-1.10.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:bd6f629b67bb43dc0d9211ee98b96d8dabc97b1ad38b9b25f5e4c4d7569a0c6a"},
+    {file = "mypy-1.10.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a1bbb3a6f5ff319d2b9d40b4080d46cd639abe3516d5a62c070cf0114a457d84"},
+    {file = "mypy-1.10.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b8edd4e9bbbc9d7b79502eb9592cab808585516ae1bcc1446eb9122656c6066f"},
+    {file = "mypy-1.10.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:6166a88b15f1759f94a46fa474c7b1b05d134b1b61fca627dd7335454cc9aa6b"},
+    {file = "mypy-1.10.1-cp311-cp311-win_amd64.whl", hash = "sha256:5bb9cd11c01c8606a9d0b83ffa91d0b236a0e91bc4126d9ba9ce62906ada868e"},
+    {file = "mypy-1.10.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:d8681909f7b44d0b7b86e653ca152d6dff0eb5eb41694e163c6092124f8246d7"},
+    {file = "mypy-1.10.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:378c03f53f10bbdd55ca94e46ec3ba255279706a6aacaecac52ad248f98205d3"},
+    {file = "mypy-1.10.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bacf8f3a3d7d849f40ca6caea5c055122efe70e81480c8328ad29c55c69e93e"},
+    {file = "mypy-1.10.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:701b5f71413f1e9855566a34d6e9d12624e9e0a8818a5704d74d6b0402e66c04"},
+    {file = "mypy-1.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:3c4c2992f6ea46ff7fce0072642cfb62af7a2484efe69017ed8b095f7b39ef31"},
+    {file = "mypy-1.10.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:604282c886497645ffb87b8f35a57ec773a4a2721161e709a4422c1636ddde5c"},
+    {file = "mypy-1.10.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:37fd87cab83f09842653f08de066ee68f1182b9b5282e4634cdb4b407266bade"},
+    {file = "mypy-1.10.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8addf6313777dbb92e9564c5d32ec122bf2c6c39d683ea64de6a1fd98b90fe37"},
+    {file = "mypy-1.10.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:5cc3ca0a244eb9a5249c7c583ad9a7e881aa5d7b73c35652296ddcdb33b2b9c7"},
+    {file = "mypy-1.10.1-cp38-cp38-win_amd64.whl", hash = "sha256:1b3a2ffce52cc4dbaeee4df762f20a2905aa171ef157b82192f2e2f368eec05d"},
+    {file = "mypy-1.10.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:fe85ed6836165d52ae8b88f99527d3d1b2362e0cb90b005409b8bed90e9059b3"},
+    {file = "mypy-1.10.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c2ae450d60d7d020d67ab440c6e3fae375809988119817214440033f26ddf7bf"},
+    {file = "mypy-1.10.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6be84c06e6abd72f960ba9a71561c14137a583093ffcf9bbfaf5e613d63fa531"},
+    {file = "mypy-1.10.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2189ff1e39db399f08205e22a797383613ce1cb0cb3b13d8bcf0170e45b96cc3"},
+    {file = "mypy-1.10.1-cp39-cp39-win_amd64.whl", hash = "sha256:97a131ee36ac37ce9581f4220311247ab6cba896b4395b9c87af0675a13a755f"},
+    {file = "mypy-1.10.1-py3-none-any.whl", hash = "sha256:71d8ac0b906354ebda8ef1673e5fde785936ac1f29ff6987c7483cfbd5a4235a"},
+    {file = "mypy-1.10.1.tar.gz", hash = "sha256:1f8f492d7db9e3593ef42d4f115f04e556130f2819ad33ab84551403e97dd4c0"},
 ]
 
 [package.dependencies]
@@ -424,6 +491,24 @@ tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-cov"
+version = "5.0.0"
+description = "Pytest plugin for measuring coverage."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-cov-5.0.0.tar.gz", hash = "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857"},
+    {file = "pytest_cov-5.0.0-py3-none-any.whl", hash = "sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652"},
+]
+
+[package.dependencies]
+coverage = {version = ">=5.2.1", extras = ["toml"]}
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests", "pytest-xdist", "virtualenv"]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.1"
 description = "YAML parser and emitter for Python"
@@ -557,13 +642,13 @@ files = [
 
 [[package]]
 name = "types-setuptools"
-version = "70.0.0.20240524"
+version = "70.1.0.20240625"
 description = "Typing stubs for setuptools"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "types-setuptools-70.0.0.20240524.tar.gz", hash = "sha256:e31fee7b9d15ef53980526579ac6089b3ae51a005a281acf97178e90ac71aff6"},
-    {file = "types_setuptools-70.0.0.20240524-py3-none-any.whl", hash = "sha256:8f5379b9948682d72a9ab531fbe52932e84c4f38deda570255f9bae3edd766bc"},
+    {file = "types-setuptools-70.1.0.20240625.tar.gz", hash = "sha256:eb7175c9a304de4de9f4dfd0f299c754ac94cd9e30a262fbb5ff3047a0a6c517"},
+    {file = "types_setuptools-70.1.0.20240625-py3-none-any.whl", hash = "sha256:181986729bdae9fa7efc7d37f1578361739e35dd6ec456d37de8e8f3bd2be1ef"},
 ]
 
 [[package]]
@@ -579,13 +664,13 @@ files = [
 
 [[package]]
 name = "virtualenv"
-version = "20.26.2"
+version = "20.26.3"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "virtualenv-20.26.2-py3-none-any.whl", hash = "sha256:a624db5e94f01ad993d476b9ee5346fdf7b9de43ccaee0e0197012dc838a0e9b"},
-    {file = "virtualenv-20.26.2.tar.gz", hash = "sha256:82bf0f4eebbb78d36ddaee0283d43fe5736b53880b8a8cdcd37390a07ac3741c"},
+    {file = "virtualenv-20.26.3-py3-none-any.whl", hash = "sha256:8cc4a31139e796e9a7de2cd5cf2489de1217193116a8fd42328f1bd65f434589"},
+    {file = "virtualenv-20.26.3.tar.gz", hash = "sha256:4c43a2a236279d9ea36a0d76f98d84bd6ca94ac4e0f4a3b9d46d05e10fea542a"},
 ]
 
 [package.dependencies]
@@ -615,4 +700,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "8f5dd807a90f06b92c4c5a0bb0019a3db856ce5cabfc4629b3ff1378171466ff"
+content-hash = "7d9aa56aba1e20cdfe123dd1cba585e4313582e00117c5c3f52532a102a564bb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,12 @@ importlib-metadata = "^7.0"
 [tool.poetry.group.dev.dependencies]
 mypy = "*"
 pytest = "*"
+pytest-cov = "*"
 types-setuptools = "*"
 types-PyYAML = "*"
 flake8 = "^6.0.0"
 pre-commit = "*"
+
 
 [tool.poetry.scripts]
 vspec2binary = "vss_tools.vspec2binary:main"

--- a/tests/backward_compatibility/test_compatibility.py
+++ b/tests/backward_compatibility/test_compatibility.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2024 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the

--- a/tests/backward_compatibility/test_compatibility.py
+++ b/tests/backward_compatibility/test_compatibility.py
@@ -9,19 +9,7 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import pytest
-import os
-
-
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
-
-
-@pytest.fixture(scope="function", autouse=True)
-def delete_files(change_test_dir):
-    yield None
-    os.system("rm -rf out.json out.txt vehicle_signal_specification")
+import subprocess
 
 # Test all VSS versions we support
 #
@@ -46,17 +34,18 @@ def delete_files(change_test_dir):
                           'v4.0',
                           'v4.1',
                           'v4.2'])
-def test_compatibility(tag, change_test_dir):
+def test_compatibility(tag, tmp_path):
     """
     Test that we still can analyze wanted versions without error
     """
+    url = "https://github.com/COVESA/vehicle_signal_specification"
+    vss_dir = tmp_path / "vss"
+    clone_cmd = f"git clone --depth 1 --branch {tag} {url} {vss_dir}"
 
-    os.system("git clone --depth 1 --branch " + tag +
-              " https://github.com/COVESA/vehicle_signal_specification")
+    subprocess.run(clone_cmd.split(), check=True)
 
-    result = os.system("vspec2json --json-pretty "
-                       "vehicle_signal_specification/spec/VehicleSignalSpecification.vspec "
-                       "out.json 1>out.txt 2>&1")
-    os.system("cat out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+    vspec = vss_dir / "spec" / "VehicleSignalSpecification.vspec"
+    output = tmp_path / "out.json"
+
+    cmd = f"vspec2json --json-pretty {vspec} {output}"
+    subprocess.run(cmd.split(), check=True)

--- a/tests/generators/example_generator.py
+++ b/tests/generators/example_generator.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 # Copyright (c) 2023 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the

--- a/tests/generators/test_generator.py
+++ b/tests/generators/test_generator.py
@@ -7,13 +7,14 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import subprocess
+import sys
 from pathlib import Path
 import os
 
 
 def test_generator():
     cmd = [
-        "python",
+        sys.executable,
         "example_generator.py",
         "-k",
         "VSS Contributor",
@@ -23,6 +24,5 @@ def test_generator():
     ]
     env = os.environ.copy()
     env["COLUMNS"] = "120"
-    p = subprocess.run(cmd, capture_output=True, text=True, cwd=Path(__file__).resolve().parent, env=env)
-    assert p.returncode == 0
+    p = subprocess.run(cmd, check=True, capture_output=True, text=True, cwd=Path(__file__).resolve().parent, env=env)
     assert "I found 2 comments with vss contributor" in p.stdout

--- a/tests/instances/test_instances.py
+++ b/tests/instances/test_instances.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2022 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the

--- a/tests/instances/test_instances.py
+++ b/tests/instances/test_instances.py
@@ -12,12 +12,11 @@ from typing import Dict
 from vss_tools.vspec.model.vsstree import VSSNode
 from vss_tools.vspec.model.constants import VSSType, VSSTreeType
 import vss_tools.vspec as vspec
-import os
-import sys
+from pathlib import Path
 import re
 
-myDir = os.path.dirname(os.path.realpath(__file__))
-sys.path.append(os.path.join(myDir, "../.."))
+HERE = Path(__file__).resolve().parent
+RESOURCES = HERE / "resources"
 
 
 #  TEST SIMPLE INSTANCE STRUCTURE #
@@ -30,27 +29,25 @@ sys.path.append(os.path.join(myDir, "../.."))
 
 
 # Needed test files
-TEST_FILES_SIMPLE = ["resources/instance_simple_range.vspec",
-                     "resources/instance_simple_enum.vspec",
-                     "resources/instance_simple_range_list.vspec",
-                     "resources/instance_simple_enum_list.vspec"]
-
-# test function: read in the files and compare the outcome
+TEST_FILES_SIMPLE = [
+    "instance_simple_range.vspec",
+    "instance_simple_enum.vspec",
+    "instance_simple_range_list.vspec",
+    "instance_simple_enum_list.vspec",
+]
 
 
 def test_simple_structures(request):
-    test_path = os.path.dirname(request.fspath)
     for tfs in TEST_FILES_SIMPLE:
         # load the file
-        tree = vspec.load_tree(os.path.join(test_path, tfs), [os.path.join(
-            test_path, "resources/")], VSSTreeType.SIGNAL_TREE)
+        tree = vspec.load_tree(
+            str(RESOURCES / tfs), str(RESOURCES), VSSTreeType.SIGNAL_TREE
+        )
 
         # check if root node has 3 children
         assert len(tree.children) == 3
 
-        list_of_instances = ["Vehicle.Test1",
-                             "Vehicle.Test2",
-                             "Vehicle.Test3"]
+        list_of_instances = ["Vehicle.Test1", "Vehicle.Test2", "Vehicle.Test3"]
 
         for child in tree.children:
             assert child.qualified_name() in list_of_instances  # < list qualified names
@@ -73,17 +70,17 @@ def test_simple_structures(request):
 # TEST COMPLEX INSTANCE STRUCTURE #
 
 # Needed test files
-TEST_FILES_COMPLEX = ["resources/instance_complex_1.vspec",
-                      "resources/instance_complex_2.vspec",
-                      "resources/instance_complex_3.vspec",
-                      "resources/instance_complex_4.vspec"]
+TEST_FILES_COMPLEX = [
+    "instance_complex_1.vspec",
+    "instance_complex_2.vspec",
+    "instance_complex_3.vspec",
+    "instance_complex_4.vspec",
+]
 
 # test function: read in the files and compare the outcome
 
 
-def test_complex_structures(request):
-
-    test_path = os.path.dirname(request.fspath)
+def test_complex_structures():
     # helper function to check, if all information are present
 
     def check_instance_branch(branch: VSSNode, numberOfChildren: int):
@@ -92,8 +89,9 @@ def test_complex_structures(request):
 
     for tfs in TEST_FILES_COMPLEX:
         # load the file
-        tree = vspec.load_tree(os.path.join(test_path, tfs), [os.path.join(
-            test_path, "resources/")], VSSTreeType.SIGNAL_TREE)
+        tree = vspec.load_tree(
+            str(RESOURCES / tfs), str(RESOURCES), VSSTreeType.SIGNAL_TREE
+        )
 
         # check if root node has 1 child and check first instances
         assert len(tree.children) == 1
@@ -104,21 +102,25 @@ def test_complex_structures(request):
         for child in tree.children[0].children:
             # 2nd level: Test1.Test2 - Test1.Test3
             assert child.qualified_name() in [
-                "Vehicle.Test1.Test2", "Vehicle.Test1.Test3"]
+                "Vehicle.Test1.Test2",
+                "Vehicle.Test1.Test3",
+            ]
             check_instance_branch(child, 3)
             for child_2 in child.children:
                 # 2nd level: Test1.Test2.Test4 - Test1.Test3.Test6
                 print(child_2.qualified_name())
                 assert None is not re.match(
-                    "^Vehicle.Test1.Test(2|3).Test(4|5|6)",
-                    child_2.qualified_name())
+                    "^Vehicle.Test1.Test(2|3).Test(4|5|6)", child_2.qualified_name(
+                    )
+                )
                 check_instance_branch(child_2, 4)
                 for child_3 in child_2.children:
                     # 3rd level: Test1.Test2.Test4.Test7 -
                     # Test1.Test3.Test6.Test10
                     assert None is not re.match(
                         "^Vehicle.Test1.Test(2|3).Test(4|5|6).Test(7|8|9|10)",
-                        child_3.qualified_name())
+                        child_3.qualified_name(),
+                    )
                     check_instance_branch(child_3, 1)
                     assert 1 == len(child_3.children)
                     child_4 = child_3.children[0]
@@ -126,7 +128,8 @@ def test_complex_structures(request):
                     # Test1.Test3.Test6.Test10.Test11
                     assert None is not re.match(
                         "^Vehicle.Test1.Test(2|3).Test(4|5|6).Test(7|8|9|10).Test11",
-                        child_4.qualified_name())
+                        child_4.qualified_name(),
+                    )
                     # All instances are expected to have one child
                     assert 1 == len(child_4.children)
                     assert child_4.children[0].name == "SomeThing"
@@ -143,15 +146,15 @@ def test_complex_structures(request):
 # TEST EXCLUSION FROM INSTANCE STRUCTURE #
 
 # Needed test files
-TEST_FILES_EXCLUDE = ["resources/instance_exclude_node.vspec"]
+TEST_FILES_EXCLUDE = ["instance_exclude_node.vspec"]
 
 
-def test_exclusion_from_instance(request):
-    test_path = os.path.dirname(request.fspath)
+def test_exclusion_from_instance():
     for tfs in TEST_FILES_EXCLUDE:
         # load the file
-        tree = vspec.load_tree(os.path.join(test_path, tfs), [os.path.join(
-            test_path, "resources/")], VSSTreeType.SIGNAL_TREE)
+        tree = vspec.load_tree(
+            str(RESOURCES / tfs), str(RESOURCES), VSSTreeType.SIGNAL_TREE
+        )
         assert 6 == len(tree.children)
         name_list = []
         for child in tree.children:
@@ -161,7 +164,10 @@ def test_exclusion_from_instance(request):
                 assert "ExcludeSomeThing description" == child.description
                 assert 1 == len(child.children)
                 child_2 = child.children[0]
-                assert "Vehicle.ExcludeSomeThing.ExcludeSomethingLeaf" == child_2.qualified_name()
+                assert (
+                    "Vehicle.ExcludeSomeThing.ExcludeSomethingLeaf"
+                    == child_2.qualified_name()
+                )
                 assert "ExcludeSomethingLeaf description" == child_2.description
                 assert VSSType.ACTUATOR == child_2.type
 
@@ -174,11 +180,13 @@ def test_exclusion_from_instance(request):
         assert "Vehicle.ExcludeNode" in name_list
 
 
-def test_extended_attribute(request):
-    test_path = os.path.dirname(request.fspath)
+def test_extended_attribute():
     # load the file
-    tree = vspec.load_tree(os.path.join(test_path, "resources/instance_extended_attribute.vspec"), [os.path.join(
-                        test_path, "resources/")], VSSTreeType.SIGNAL_TREE)
+    tree = vspec.load_tree(
+        str(RESOURCES / "instance_extended_attribute.vspec"),
+        str(RESOURCES),
+        VSSTreeType.SIGNAL_TREE,
+    )
 
     # check if root node has 3 children
     assert len(tree.children) == 3
@@ -190,8 +198,11 @@ def test_extended_attribute(request):
             assert len(child.children) == 1
             assert child.children[0].name == "SomeThing"  # <... SomeThing
             assert len(child.children[0].extended_attributes.items()) == 1
-            assert isinstance(child.children[0].extended_attributes["dbc"], Dict)
-            assert isinstance(child.children[0].extended_attributes["dbc"]["signal"], str)
+            assert isinstance(
+                child.children[0].extended_attributes["dbc"], Dict)
+            assert isinstance(
+                child.children[0].extended_attributes["dbc"]["signal"], str
+            )
             assert child.children[0].extended_attributes["dbc"]["signal"] == "bababa"
             child.children[0].extended_attributes["dbc"]["signal"] = "lalala"
 

--- a/tests/model/test_vsstree_default.py
+++ b/tests/model/test_vsstree_default.py
@@ -14,12 +14,6 @@ from vss_tools.vspec.model.constants import VSSTreeType
 from vss_tools.vspec.model.vsstree import VSSNode
 
 
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
-
-
 @pytest.mark.parametrize("type_name, is_signal_tree, is_default_supported", [
     ("attribute", True, True),
     ("actuator", True, True),
@@ -29,7 +23,7 @@ def change_test_dir(request, monkeypatch):
     ("struct", False, False),
     ("property", False, True)
     ])
-def test_default(type_name: str, is_signal_tree: bool, is_default_supported: bool, change_test_dir):
+def test_default(type_name: str, is_signal_tree: bool, is_default_supported: bool):
     """
     Verify that tooling complains if "default" is used where it should not be used
     """

--- a/tests/model/test_vsstree_default.py
+++ b/tests/model/test_vsstree_default.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2023 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the

--- a/tests/vspec/test_allowed/test_allowed.py
+++ b/tests/vspec/test_allowed/test_allowed.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2023 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the
@@ -21,8 +19,7 @@ def run_exporter(exporter, argument, tmp_path):
     output = tmp_path / f"out.{exporter}"
     cmd = f"vspec2{exporter}{argument} {spec} {output}"
 
-    process = subprocess.run(cmd.split(), capture_output=True, text=True)
-    assert process.returncode == 0
+    process = subprocess.run(cmd.split(), check=True, capture_output=True, text=True)
     expected = HERE / f"expected.{exporter}"
     assert filecmp.cmp(output, expected)
 

--- a/tests/vspec/test_allowed/test_allowed.py
+++ b/tests/vspec/test_allowed/test_allowed.py
@@ -8,45 +8,34 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-import pytest
-import os
+from pathlib import Path
+import subprocess
+import filecmp
+
+HERE = Path(__file__).resolve().parent
+TEST_UNITS = HERE / ".." / "test_units.yaml"
 
 
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
+def run_exporter(exporter, argument, tmp_path):
+    spec = HERE / "test.vspec"
+    output = tmp_path / f"out.{exporter}"
+    cmd = f"vspec2{exporter}{argument} {spec} {output}"
 
-
-def run_exporter(exporter, argument):
-    test_str = "vspec2" + exporter + argument + " test.vspec out." + exporter + " > out.txt"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-    test_str = "diff out." + exporter + " expected." + exporter
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
+    assert process.returncode == 0
+    expected = HERE / f"expected.{exporter}"
+    assert filecmp.cmp(output, expected)
 
     # Check if warning given
     # ddsidl can not handle float and integer
     # Some other tools ignore "allowed" all together
     if exporter in ["ddsidl"]:
-        expected_grep_result = 0
-    else:
-        expected_grep_result = 1
-
-    test_str = 'grep \"can only handle allowed values for string type\" out.txt > /dev/null'
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == expected_grep_result
-    os.system("rm -f out." + exporter + " out.txt")
+        assert "can only handle allowed values for string type" in process.stdout
 
 
-def test_allowed(change_test_dir):
-
+def test_allowed(tmp_path):
     # Run all "supported" exporters, i.e. not those in contrib
     # Exception is "binary", as it is assumed output may vary depending on target
     exporters = ["json", "ddsidl", "csv", "yaml", "franca", "graphql"]
     for exporter in exporters:
-        run_exporter(exporter, " -u ../test_units.yaml")
+        run_exporter(exporter, f" -u {TEST_UNITS}", tmp_path)

--- a/tests/vspec/test_datatypes_error/test_datatypes_error.py
+++ b/tests/vspec/test_datatypes_error/test_datatypes_error.py
@@ -8,48 +8,37 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-import os
-import subprocess
 from pathlib import Path
+import subprocess
+import os
+
+HERE = Path(__file__).resolve().parent
+TEST_UNITS = HERE / ".." / "test_units.yaml"
 
 
 def test_datatype_error(tmp_path):
-    cmd = (
-        f"vspec2json --json-pretty -u ../test_units.yaml test.vspec ${tmp_path / 'out.json'}"
-    )
+    spec = HERE / "test.vspec"
+    output = tmp_path / "out.json"
+    cmd = f"vspec2json --json-pretty -u {TEST_UNITS} {spec} {output}"
     env = os.environ.copy()
-    env["COLUMNS"] = "120"
-    p = subprocess.run(
-        cmd.split(),
-        capture_output=True,
-        text=True,
-        cwd=Path(__file__).resolve().parent,
-        env=env,
-    )
-    assert p.returncode != 0
+    env["COLUMNS"] = "200"
+    process = subprocess.run(cmd.split(), capture_output=True, text=True, env=env)
+    assert process.returncode != 0
 
     assert (
-        "Following types were referenced in signals but have not been defined"
-        in p.stdout)
+        "Following types were referenced in signals but have not been defined: uint7"
+        in process.stdout
+    )
 
 
 def test_datatype_branch(tmp_path):
-    cmd = (
-        "vspec2json --json-pretty -u ../test_units.yaml "
-        f"test_datatype_branch.vspec ${tmp_path / 'out.json'}"
-    )
-    env = os.environ.copy()
-    env["COLUMNS"] = "120"
-    p = subprocess.run(
-        cmd.split(),
-        capture_output=True,
-        text=True,
-        cwd=Path(__file__).resolve().parent,
-        env=env,
-    )
-    assert p.returncode != 0
+    spec = HERE / "test_datatype_branch.vspec"
+    output = tmp_path / "out.json"
+    cmd = f"vspec2json --json-pretty -u {TEST_UNITS} {spec} {output}"
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
+    assert process.returncode != 0
 
     assert (
         "cannot have datatype"
-        in p.stdout
+        in process.stdout
     )

--- a/tests/vspec/test_datatypes_error/test_datatypes_error.py
+++ b/tests/vspec/test_datatypes_error/test_datatypes_error.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2023 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the

--- a/tests/vspec/test_default_unit/test_default_units.py
+++ b/tests/vspec/test_default_unit/test_default_units.py
@@ -8,61 +8,54 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-import pytest
-import os
+from pathlib import Path
+import subprocess
+import filecmp
+
+HERE = Path(__file__).resolve().parent
+TEST_UNITS = HERE / ".." / "test_units.yaml"
 
 
-# #################### Helper methods #############################
-
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
-
-
-def run_unit(vspec_file, unit_argument, expected_file):
-    test_str = "vspec2json --json-pretty " + \
-        vspec_file + " " + unit_argument + " out.json > out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-    test_str = "diff out.json " + expected_file
-    result = os.system(test_str)
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+def run_unit(vspec_file, unit_argument, expected_file, tmp_path):
+    output = tmp_path / "out.json"
+    cmd = f"vspec2json --json-pretty {vspec_file} {unit_argument} {output}"
+    subprocess.run(cmd.split(), check=True)
+    assert filecmp.cmp(expected_file, output)
 
 
-def run_unit_error(vspec_file, unit_argument, grep_error):
-    test_str = "vspec2json --json-pretty " + \
-        vspec_file + " " + unit_argument + " out.json > out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    # failure expected
-    assert os.WEXITSTATUS(result) != 0
-
-    test_str = 'grep \"' + grep_error + '\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-# #################### Tests related to default units (config.yaml) #############################
+def run_unit_error(vspec_file, unit_argument, check_message, tmp_path):
+    output = tmp_path / "out.json"
+    cmd = f"vspec2json --json-pretty {vspec_file} {unit_argument} {output}"
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
+    assert process.returncode != 0
+    assert check_message in process.stdout
 
 
-# Test with no unit specified - shall pass as file "units.yaml" with wanted type exists in same folder
-def test_default_ok(change_test_dir):
-    run_unit("signals_with_default_units.vspec", "", "expected_default.json")
+def test_default_ok(tmp_path):
+    run_unit(
+        HERE / "signals_with_default_units.vspec",
+        "",
+        HERE / "expected_default.json",
+        tmp_path,
+    )
 
 
 # Explicitly stating same file shall also be ok
-def test_default_explicit(change_test_dir):
-    run_unit("signals_with_default_units.vspec", "", "expected_default.json")
+def test_default_explicit(tmp_path):
+    units = HERE / "units.yaml"
+    run_unit(
+        HERE / "signals_with_default_units.vspec",
+        f"-u {units}",
+        HERE / "expected_default.json",
+        tmp_path,
+    )
+
 
 # If specifying another unit file an error is expected
-
-
-def test_default_error(change_test_dir):
-    run_unit_error("signals_with_default_units.vspec", "-u ../test_units.yaml", "Unknown unit")
+def test_default_error(tmp_path):
+    run_unit_error(
+        HERE / "signals_with_default_units.vspec",
+        f"-u {TEST_UNITS}",
+        "Unknown unit",
+        tmp_path,
+    )

--- a/tests/vspec/test_default_unit/test_default_units.py
+++ b/tests/vspec/test_default_unit/test_default_units.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2023 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the

--- a/tests/vspec/test_description_error/test_description_error.py
+++ b/tests/vspec/test_description_error/test_description_error.py
@@ -9,33 +9,34 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import pytest
-import os
+from pathlib import Path
+import subprocess
+
+HERE = Path(__file__).resolve().parent
+TEST_UNITS = HERE / ".." / "test_units.yaml"
 
 
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
+@pytest.mark.parametrize(
+    "vspec_file, type_file, type_out_file",
+    [
+        ("no_description_branch.vspec", None, None),
+        ("no_description_signal.vspec", None, None),
+        ("correct.vspec", "no_description_type_branch.vspec", "ot.json"),
+        ("correct.vspec", "no_description_type_struct.vspec", "ot.json"),
+        ("correct.vspec", "no_description_type_property.vspec", "ot.json"),
+    ],
+)
+def test_description_error(
+    vspec_file: str, type_file: str, type_out_file: str, tmp_path
+):
+    output = tmp_path / "out.json"
+    cmd = f"vspec2json --json-pretty -u {TEST_UNITS}"
+    if type_file:
+        cmd += f" -vt {HERE / type_file}"
+    if type_out_file:
+        cmd += f" -ot {tmp_path / type_out_file}"
+    cmd += f" {HERE / vspec_file} {output}"
 
-
-@pytest.mark.parametrize("vspec_file, type_str", [
-    ("no_description_branch.vspec", ""),
-    ("no_description_signal.vspec", ""),
-    ("correct.vspec", "-vt no_description_type_branch.vspec -ot ot.json"),
-    ("correct.vspec", "-vt no_description_type_struct.vspec -ot ot.json"),
-    ("correct.vspec", "-vt no_description_type_property.vspec -ot ot.json")
-    ])
-def test_description_error(vspec_file: str, type_str: str, change_test_dir):
-    test_str = "vspec2json --json-pretty -u ../test_units.yaml " + type_str + " " + vspec_file + \
-               " out.json > out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    # failure expected
-    assert os.WEXITSTATUS(result) != 0
-
-    test_str = 'grep \"Invalid VSS element\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
+    assert process.returncode != 0
+    assert "Invalid VSS element" in process.stdout

--- a/tests/vspec/test_description_error/test_description_error.py
+++ b/tests/vspec/test_description_error/test_description_error.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2023 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the

--- a/tests/vspec/test_faulty_type/test_faulty_type.py
+++ b/tests/vspec/test_faulty_type/test_faulty_type.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2022 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the

--- a/tests/vspec/test_faulty_type/test_faulty_type.py
+++ b/tests/vspec/test_faulty_type/test_faulty_type.py
@@ -8,25 +8,17 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-import pytest
-import os
+from pathlib import Path
+import subprocess
+
+HERE = Path(__file__).resolve().parent
+TEST_UNITS = HERE / ".." / "test_units.yaml"
 
 
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
-
-
-def test_error(change_test_dir):
-    test_str = "vspec2json -u ../test_units.yaml test.vspec out.json 1> out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    # failure expected
-    assert os.WEXITSTATUS(result) != 0
-    test_str = 'grep \"Type not allowed: bosch\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+def test_error(tmp_path):
+    spec = HERE / "test.vspec"
+    output = tmp_path / "out.json"
+    cmd = f"vspec2json -u {TEST_UNITS} {spec} {output}"
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
+    assert process.returncode != 0
+    assert "Type not allowed: bosch" in process.stdout

--- a/tests/vspec/test_generic.py
+++ b/tests/vspec/test_generic.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2022 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the
@@ -39,8 +37,7 @@ def run_exporter(directory, exporter, tmp_path):
     output = tmp_path / f"out.{exporter}"
     expected = directory / f"expected.{exporter}"
     cmd = f"vspec2{exporter} -u {TEST_UNITS} {vspec} {output}"
-    process = subprocess.run(cmd.split())
-    assert process.returncode == 0
+    subprocess.run(cmd.split(), check=True)
     assert filecmp.cmp(output, expected)
 
 

--- a/tests/vspec/test_generic.py
+++ b/tests/vspec/test_generic.py
@@ -10,14 +10,17 @@
 
 import pathlib
 import pytest
-import os
+import filecmp
+from pathlib import Path
+import subprocess
 
-dir_path = os.path.dirname(os.path.realpath(__file__))
+HERE = Path(__file__).resolve().parent
+TEST_UNITS = HERE / "test_units.yaml"
 
 
 def default_directories() -> list:
     directories = []
-    for path in pathlib.Path(dir_path).iterdir():
+    for path in HERE.iterdir():
         if path.is_dir():
             if list(path.rglob("*.vspec")):
                 # Exclude directories with custom made python file
@@ -25,41 +28,28 @@ def default_directories() -> list:
                     directories.append(path)
     return directories
 
+
 # Use directory name as test name
-
-
 def idfn(directory: pathlib.PosixPath):
     return directory.name
 
 
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
+def run_exporter(directory, exporter, tmp_path):
+    vspec = directory / "test.vspec"
+    output = tmp_path / f"out.{exporter}"
+    expected = directory / f"expected.{exporter}"
+    cmd = f"vspec2{exporter} -u {TEST_UNITS} {vspec} {output}"
+    process = subprocess.run(cmd.split())
+    assert process.returncode == 0
+    assert filecmp.cmp(output, expected)
 
 
-def run_exporter(directory, exporter):
-    os.chdir(directory.name)
-    test_str = "vspec2" + exporter + " -u ../test_units.yaml test.vspec out." + exporter + \
-               " > out.txt"
-    result = os.system(test_str)
-    os.chdir("..")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-    os.chdir(directory.name)
-    test_str = "diff out." + exporter + " expected." + exporter
-    result = os.system(test_str)
-    os.system("rm -f out." + exporter + " out.txt")
-    os.chdir("..")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-
-@pytest.mark.parametrize('directory', default_directories(), ids=idfn)
-def test_exporters(directory, change_test_dir):
+@pytest.mark.parametrize("directory", default_directories(), ids=idfn)
+def test_exporters(directory, tmp_path):
     # Run all "supported" exporters, i.e. not those in contrib
     # Exception is "binary", as it is assumed output may vary depending on target
-    exporters = ["json", "jsonschema", "ddsidl", "csv", "yaml", "franca", "graphql"]
+    exporters = ["json", "jsonschema", "ddsidl",
+                 "csv", "yaml", "franca", "graphql"]
 
     for exporter in exporters:
-        run_exporter(directory, exporter)
+        run_exporter(directory, exporter, tmp_path)

--- a/tests/vspec/test_include/test_include.py
+++ b/tests/vspec/test_include/test_include.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2022 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the
@@ -21,8 +19,7 @@ def test_include(tmp_path):
     output = tmp_path / "out.json"
     expected = HERE / "expected.json"
     cmd = f"vspec2json -u {TEST_UNITS} --json-pretty {spec} {output}"
-    process = subprocess.run(cmd.split())
-    assert process.returncode == 0
+    subprocess.run(cmd.split(), check=True)
     filecmp.cmp(output, expected)
 
 

--- a/tests/vspec/test_include/test_include.py
+++ b/tests/vspec/test_include/test_include.py
@@ -8,49 +8,31 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-import pytest
-import os
+from pathlib import Path
+import subprocess
+import filecmp
+
+HERE = Path(__file__).resolve().parent
+TEST_UNITS = HERE / ".." / "test_units.yaml"
 
 
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
+def test_include(tmp_path):
+    spec = HERE / "test.vspec"
+    output = tmp_path / "out.json"
+    expected = HERE / "expected.json"
+    cmd = f"vspec2json -u {TEST_UNITS} --json-pretty {spec} {output}"
+    process = subprocess.run(cmd.split())
+    assert process.returncode == 0
+    filecmp.cmp(output, expected)
 
 
-def test_include(change_test_dir):
-    test_str = "vspec2json -u ../test_units.yaml --json-pretty test.vspec out.json" + \
-               " 1> out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+def test_error(tmp_path):
+    spec = HERE / "test_error.vspec"
+    output = tmp_path / "out.json"
+    cmd = f"vspec2json -u {TEST_UNITS} --json-pretty {spec} {output}"
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
+    assert process.returncode != 0
 
-    # No real need to test more than one exporter
-    result = os.system("diff out.json expected.json")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-    os.system("rm -f out.json out.txt")
-
-
-def test_error(change_test_dir):
-    test_str = "vspec2json -u ../test_units.yaml --json-pretty test_error.vspec out.json " + \
-               "1> out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    # failure expected
-    assert os.WEXITSTATUS(result) != 0
-
-    # Test on faulty include
-    test_str = 'grep \"WARNING  No branch matching\" out.txt > /dev/null'
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-    # Test on missing include, is fatal error
-    test_str = 'grep \"Exception: Invalid VSS model\" out.txt > /dev/null'
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-    os.system("rm -f out.json out.txt")
+    print(process.stdout)
+    assert "WARNING  No branch matching" in process.stdout
+    assert "Exception: Invalid VSS model" in process.stderr

--- a/tests/vspec/test_multiple_type_trees/test_multiple_type_trees.py
+++ b/tests/vspec/test_multiple_type_trees/test_multiple_type_trees.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2023 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the

--- a/tests/vspec/test_no_expand/test_no_expand.py
+++ b/tests/vspec/test_no_expand/test_no_expand.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2023 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the
@@ -74,7 +72,6 @@ def test_json_overlay(no_expand, comparison_file, tmp_path):
         cmd += " --no-expand"
     cmd += f" --json-pretty -u {TEST_UNITS} {spec} -o {overlay} {output}"
 
-    process = subprocess.run(cmd.split(), capture_output=True, text=True)
-    assert process.returncode == 0
+    subprocess.run(cmd.split(), check=True, capture_output=True, text=True)
     expected = HERE / comparison_file
     assert filecmp.cmp(output, expected)

--- a/tests/vspec/test_no_expand/test_no_expand.py
+++ b/tests/vspec/test_no_expand/test_no_expand.py
@@ -9,84 +9,72 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import pytest
-import os
+
+from pathlib import Path
+import subprocess
+import filecmp
+
+HERE = Path(__file__).resolve().parent
+TEST_UNITS = HERE / ".." / "test_units.yaml"
 
 
-# #################### Helper methods #############################
+@pytest.mark.parametrize(
+    "format, output_file, comparison_file, is_error_expected",
+    [
+        ("json", "out.json", "expected.json", False),
+        ("yaml", "out.yaml", "expected.yaml", False),
+        ("csv", "out.csv", "expected.csv", False),
+        ("protobuf", "out.proto", "expected.proto", True),
+        ("ddsidl", "out.idl", "expected.idl", True),
+        ("franca", "out.fidl", "expected.fidl", True),
+        ("graphql", "out.graphql", "expected.graphql", True),
+    ],
+)
+def test_no_expand(
+    format, output_file, comparison_file, is_error_expected: bool, tmp_path
+):
+    spec = HERE / "test.vspec"
+    output = tmp_path / output_file
+    cmd = f"vspec2{format} --no-expand"
+    if format == "json":
+        cmd += " --json-pretty"
+    cmd += f" -u {TEST_UNITS} {spec} {output}"
 
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
-
-
-@pytest.mark.parametrize("format, output_file, comparison_file, is_error_expected", [
-    ('json', 'out.json', 'expected.json', False),
-    ('yaml', 'out.yaml', 'expected.yaml', False),
-    ('csv', 'out.csv', 'expected.csv', False),
-    ('protobuf', 'out.proto', 'expected.proto', True),
-    ('ddsidl', 'out.idl', 'expected.idl', True),
-    ('franca', 'out.fidl', 'expected.fidl', True),
-    ('graphql', 'out.graphql', 'expected.graphql', True)])
-def test_no_expand(format, output_file, comparison_file, is_error_expected: bool, change_test_dir):
-
-    args = ["vspec2" + format, "--no-expand"]
-    if format == 'json':
-        args.append('--json-pretty')
-    args.extend(["-u", "../test_units.yaml",
-                 "test.vspec", output_file, "1>", "out.txt", "2>&1"])
-    test_str = " ".join(args)
-
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    assert os.WIFEXITED(result)
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
     if is_error_expected:
-        assert os.WEXITSTATUS(result) != 0
+        assert process.returncode != 0
     else:
-        assert os.WEXITSTATUS(result) == 0
+        assert process.returncode == 0
 
     # For exporters not supporting "no-expand" an error shall be given
-    test_str = 'grep \"error: unrecognized arguments: --no-expand\" out.txt > /dev/null'
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
+    expected = HERE / comparison_file
     if is_error_expected:
-        assert os.WEXITSTATUS(result) == 0
+        assert "error: unrecognized arguments: --no-expand" in process.stderr
     else:
-        assert os.WEXITSTATUS(result) == 1
-        test_str = f"diff {output_file} {comparison_file}"
-        result = os.system(test_str)
-        os.system("rm -f out.txt")
-        assert os.WIFEXITED(result)
-        assert os.WEXITSTATUS(result) == 0
+        assert filecmp.cmp(output, expected)
 
-    os.system(f"rm -f {output_file}")
 
 # Overlay tests, just showing for JSON
-
-
-@pytest.mark.parametrize("no_expand, comparison_file", [
-    (False, 'expected_overlay_expand.json'),
-    (True, 'expected_overlay_no_expand.json')])
-def test_json_overlay(no_expand, comparison_file, change_test_dir):
+@pytest.mark.parametrize(
+    "no_expand, comparison_file",
+    [
+        (False, "expected_overlay_expand.json"),
+        (True, "expected_overlay_no_expand.json"),
+    ],
+)
+def test_json_overlay(no_expand, comparison_file, tmp_path):
     """Test with overlay and expansion (for reference/comparison)"""
-    args = ["vspec2json"]
 
+    overlay = HERE / "overlay.vspec"
+    spec = HERE / "test.vspec"
+    output = tmp_path / "out.json"
+
+    cmd = "vspec2json"
     if no_expand:
-        args.append('--no-expand')
+        cmd += " --no-expand"
+    cmd += f" --json-pretty -u {TEST_UNITS} {spec} -o {overlay} {output}"
 
-    args.extend(["--json-pretty", "-u", "../test_units.yaml",
-                 "test.vspec", "-o", "overlay.vspec", "out.json", "1>", "out.txt", "2>&1"])
-    test_str = " ".join(args)
-
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-    test_str = f"diff out.json {comparison_file}"
-    result = os.system(test_str)
-    os.system("rm -f out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-    os.system("rm -f out.json")
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
+    assert process.returncode == 0
+    expected = HERE / comparison_file
+    assert filecmp.cmp(output, expected)

--- a/tests/vspec/test_overlay/test_overlay.py
+++ b/tests/vspec/test_overlay/test_overlay.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2022 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the
@@ -26,10 +24,7 @@ def run_overlay(overlay_prefix, tmp_path):
     cmd = (
         f"vspec2json --json-pretty -u {TEST_UNITS} -e dbc {spec} -o {overlay} {output}"
     )
-    process = subprocess.run(cmd.split())
-
-    assert process.returncode == 0
-
+    subprocess.run(cmd.split(), check=True)
     expected = HERE / f"expected_{overlay_prefix}.json"
     assert filecmp.cmp(output, expected)
 

--- a/tests/vspec/test_overlay/test_overlay.py
+++ b/tests/vspec/test_overlay/test_overlay.py
@@ -7,78 +7,67 @@
 # https://www.mozilla.org/en-US/MPL/2.0/
 #
 # SPDX-License-Identifier: MPL-2.0
-
-import pytest
 import os
+from pathlib import Path
+import subprocess
+import filecmp
 
+HERE = Path(__file__).resolve().parent
+TEST_UNITS = HERE / ".." / "test_units.yaml"
 
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
 
 # Only running json exporter, overlay-functionality should be independent
 # of selected exporter
+def run_overlay(overlay_prefix, tmp_path):
+    spec = HERE / "test.vspec"
+    overlay_name = f"overlay_{overlay_prefix}.vspec"
+    overlay = HERE / overlay_name
+    output = tmp_path / "out.json"
+    cmd = (
+        f"vspec2json --json-pretty -u {TEST_UNITS} -e dbc {spec} -o {overlay} {output}"
+    )
+    process = subprocess.run(cmd.split())
+
+    assert process.returncode == 0
+
+    expected = HERE / f"expected_{overlay_prefix}.json"
+    assert filecmp.cmp(output, expected)
 
 
-def run_overlay(overlay_prefix):
-    test_str = "vspec2json --json-pretty -u ../test_units.yaml -e dbc test.vspec -o overlay_" + \
-        overlay_prefix + ".vspec out.json > out.txt"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-    test_str = "diff out.json expected_" + overlay_prefix + ".json"
-    result = os.system(test_str)
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+def test_explicit_overlay(tmp_path):
+    run_overlay("explicit_branches", tmp_path)
 
 
-def test_explicit_overlay(change_test_dir):
-    run_overlay("explicit_branches")
+def test_implicit_overlay(tmp_path):
+    run_overlay("implicit_branches", tmp_path)
 
 
-def test_implicit_overlay(change_test_dir):
-    run_overlay("implicit_branches")
+def test_no_datatype(tmp_path):
+    run_overlay("no_datatype", tmp_path)
 
 
-def test_no_datatype(change_test_dir):
-    run_overlay("no_datatype")
+def test_no_type(tmp_path):
+    run_overlay("no_type", tmp_path)
 
 
-def test_no_type(change_test_dir):
-    run_overlay("no_type")
+def test_overlay_error(tmp_path):
+    overlay = HERE / "overlay_error.vspec"
+    output = tmp_path / "out.json"
+    spec = HERE / "test.vspec"
+    cmd = f"vspec2json --json-pretty -u {TEST_UNITS} -o {overlay} {spec} {output}"
+    env = os.environ.copy()
+    env["COLUMNS"] = "300"
+    process = subprocess.run(cmd.split(), capture_output=True, text=True, env=env)
+    assert process.returncode != 0
+    assert "need to have a datatype declared" in process.stdout
 
 
-def test_overlay_error(change_test_dir):
+def test_overlay_branch_error(tmp_path):
+    overlay = HERE / "overlay_implicit_branch_no_description.vspec"
+    output = tmp_path / "out.json"
+    spec = HERE / "test.vspec"
+    cmd = f"vspec2json --json-pretty -u {TEST_UNITS} -o {overlay} {spec} {output}"
 
-    test_str = "vspec2json --json-pretty -u ../test_units.yaml -o overlay_error.vspec " + \
-               "test.vspec out.json 1> out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    # failure expected
-    assert os.WEXITSTATUS(result) != 0
-
-    test_str = 'grep \"need to have a datatype\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-
-def test_overlay_branch_error(change_test_dir):
-    test_str = "vspec2json -e dbc --json-pretty -u ../test_units.yaml test.vspec " + \
-               "-o overlay_implicit_branch_no_description.vspec out.json 1> out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    # failure expected
-    assert os.WEXITSTATUS(result) != 0
-
-    test_str = 'grep \"Invalid VSS element AB, must have description\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
+    assert process.returncode != 0
+    assert "Invalid VSS element AB, must have description" in process.stdout

--- a/tests/vspec/test_overlay_on_instance/test_overlay_on_instance.py
+++ b/tests/vspec/test_overlay_on_instance/test_overlay_on_instance.py
@@ -8,47 +8,39 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-import pytest
-import os
+from pathlib import Path
+import subprocess
+import filecmp
 
+HERE = Path(__file__).resolve().parent
+TEST_UNITS = HERE / ".." / "test_units.yaml"
 
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
 
 # Only running json exporter, overlay-functionality should be independent of selected exporter
+def test_expanded_overlay(tmp_path):
+    spec = HERE / "test.vspec"
+    overlay1 = HERE / "overlay_1.vspec"
+    overlay2 = HERE / "overlay_2.vspec"
+    output = tmp_path / "out.json"
+    cmd = f"vspec2json -e my_id --json-pretty -u {TEST_UNITS} {spec} -o {overlay1} -o {overlay2} {output}"
+    process = subprocess.run(cmd.split())
+    assert process.returncode == 0
+
+    expected = HERE / "expected.json"
+    assert filecmp.cmp(output, expected)
 
 
-def test_expanded_overlay(change_test_dir):
-    test_str = "vspec2json  -e my_id --json-pretty -u ../test_units.yaml test.vspec " + \
-               "-o overlay_1.vspec -o overlay_2.vspec out.json > out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-    test_str = "diff out.json expected.json"
-    result = os.system(test_str)
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-
-def test_expanded_overlay_no_type_datatype(change_test_dir):
+def test_expanded_overlay_no_type_datatype(tmp_path):
     """
     This test shows current limitation on type/datatype lookup.
     We cannot do lookup on expanded names containing instances.
     That would require quite some more advanced lookup considering instance declarations.
     Not impossible, but more complex.
     """
-    test_str = "vspec2json  -e my_id --json-pretty -u ../test_units.yaml test.vspec " + \
-               "-o overlay_no_type_datatype.vspec  out.json > out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) != 0
-
-    test_str = 'grep \"No type specified for A.B.Row1.Left.C\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+    spec = HERE / "test.vspec"
+    overlay = HERE / "overlay_no_type_datatype.vspec"
+    output = tmp_path / "out.json"
+    cmd = f"vspec2json -e my_id --json-pretty -u {TEST_UNITS} {spec} -o {overlay} {output}"
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
+    assert process.returncode != 0
+    assert "No type specified for A.B.Row1.Left.C" in process.stdout

--- a/tests/vspec/test_overlay_on_instance/test_overlay_on_instance.py
+++ b/tests/vspec/test_overlay_on_instance/test_overlay_on_instance.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2023 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the
@@ -23,8 +21,7 @@ def test_expanded_overlay(tmp_path):
     overlay2 = HERE / "overlay_2.vspec"
     output = tmp_path / "out.json"
     cmd = f"vspec2json -e my_id --json-pretty -u {TEST_UNITS} {spec} -o {overlay1} -o {overlay2} {output}"
-    process = subprocess.run(cmd.split())
-    assert process.returncode == 0
+    subprocess.run(cmd.split(), check=True)
 
     expected = HERE / "expected.json"
     assert filecmp.cmp(output, expected)

--- a/tests/vspec/test_overlay_struct/test_overlay_struct.py
+++ b/tests/vspec/test_overlay_struct/test_overlay_struct.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2022 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the
@@ -43,8 +41,7 @@ def test_overlay_struct(format, signals_out, expected_signal, tmp_path):
         cmd += " --json-pretty"
     cmd += f" -vt {struct1} -vt {struct2} -u {TEST_UNITS} -o {overlay} {spec} {output}"
 
-    process = subprocess.run(cmd.split(), cwd=tmp_path)
-    assert process.returncode == 0
+    subprocess.run(cmd.split(), cwd=tmp_path, check=True)
     expected = HERE / expected_signal
     assert filecmp.cmp(output, expected)
 
@@ -69,8 +66,6 @@ def test_overlay_struct_using_struct(format, signals_out, expected_signal, tmp_p
     spec = HERE / "test.vspec"
     output = tmp_path / signals_out
     cmd = f"vspec2{format} --json-pretty -vt {struct1} -vt {struct2} -u {TEST_UNITS} {spec} -o {overlay} {output}"
-    process = subprocess.run(cmd.split())
-    assert process.returncode == 0
-
+    subprocess.run(cmd.split(), check=True)
     expected = HERE / expected_signal
     assert filecmp.cmp(output, expected)

--- a/tests/vspec/test_overlay_struct_array/test_overlay_struct_array.py
+++ b/tests/vspec/test_overlay_struct_array/test_overlay_struct_array.py
@@ -9,50 +9,45 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import pytest
-import os
 
 
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
+from pathlib import Path
+import subprocess
+import filecmp
+
+HERE = Path(__file__).resolve().parent
+TEST_UNITS = HERE / ".." / "test_units.yaml"
 
 
 # First test case on all supported exportes
-
-@pytest.mark.parametrize("format,signals_out, expected_signal", [
-    ('json', 'out.json', 'expected.json'),
-    ('yaml', 'out.yaml', 'expected.yaml'),
-    ('csv', 'out.csv', 'expected.csv'),
-    ('protobuf', 'out.proto', 'expected.proto')])
-def test_overlay_struct_array(format, signals_out, expected_signal, change_test_dir):
+@pytest.mark.parametrize(
+    "format,signals_out, expected_signal",
+    [
+        ("json", "out.json", "expected.json"),
+        ("yaml", "out.yaml", "expected.yaml"),
+        ("csv", "out.csv", "expected.csv"),
+        ("protobuf", "out.proto", "expected.proto"),
+    ],
+)
+def test_overlay_struct_array(format, signals_out, expected_signal, tmp_path):
     """
     Test that data types provided in vspec format are converted correctly
     """
-    args = ["vspec2" + format]
-    if format == 'json':
-        args.append('--json-pretty')
-    args.extend(["-vt", "struct1.vspec", "-u", "../test_units.yaml",
-                 "test.vspec", "-o", "overlay.vspec", signals_out, "1>", "out.txt", "2>&1"])
-    test_str = " ".join(args)
+    struct = HERE / "struct1.vspec"
+    spec = HERE / "test.vspec"
+    overlay = HERE / "overlay.vspec"
+    output = tmp_path / signals_out
+    cmd = f"vspec2{format}"
+    if format == "json":
+        cmd += " --json-pretty"
+    cmd += f" -vt {struct} -u {TEST_UNITS} {spec} -o {overlay} {output}"
+    process = subprocess.run(cmd.split(), cwd=tmp_path)
+    assert process.returncode == 0
 
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+    expected = HERE / expected_signal
+    assert filecmp.cmp(output, expected)
 
-    test_str = f"diff {signals_out} {expected_signal}"
-    result = os.system(test_str)
-    os.system("rm -f out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-    os.system(f"rm -f {signals_out}")
-
-    if format == 'protobuf':
-        test_str = "diff Types/Types.proto expected_types.proto"
-        result = os.system(test_str)
-        os.system("rm -f out.txt")
-        assert os.WIFEXITED(result)
-        assert os.WEXITSTATUS(result) == 0
-        os.system("rm -rf Types")
+    if format == "protobuf":
+        types_proto = tmp_path / "Types" / "Types.proto"
+        expected = HERE / "expected_types.proto"
+        assert filecmp.cmp(types_proto, expected)

--- a/tests/vspec/test_overlay_struct_array/test_overlay_struct_array.py
+++ b/tests/vspec/test_overlay_struct_array/test_overlay_struct_array.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2023 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the
@@ -41,8 +39,7 @@ def test_overlay_struct_array(format, signals_out, expected_signal, tmp_path):
     if format == "json":
         cmd += " --json-pretty"
     cmd += f" -vt {struct} -u {TEST_UNITS} {spec} -o {overlay} {output}"
-    process = subprocess.run(cmd.split(), cwd=tmp_path)
-    assert process.returncode == 0
+    subprocess.run(cmd.split(), cwd=tmp_path, check=True)
 
     expected = HERE / expected_signal
     assert filecmp.cmp(output, expected)

--- a/tests/vspec/test_strict/test_strict.py
+++ b/tests/vspec/test_strict/test_strict.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2024 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the
@@ -33,9 +31,7 @@ def test_not_strict(vspec_file: str, tmp_path):
     env = os.environ.copy()
     env["COLUMNS"] = "200"
     process = subprocess.run(
-        cmd.split(), capture_output=True, text=True, env=env)
-    assert process.returncode == 0
-    print(process.stdout)
+        cmd.split(), capture_output=True, text=True, env=env, check=True)
     assert "You asked for strict checking. Terminating" not in process.stdout
 
 
@@ -47,8 +43,7 @@ def test_strict_ok(vspec_file: str, tmp_path):
     env = os.environ.copy()
     env["COLUMNS"] = "200"
     process = subprocess.run(
-        cmd.split(), capture_output=True, text=True, env=env)
-    assert process.returncode == 0
+        cmd.split(), capture_output=True, text=True, env=env, check=True)
     assert "You asked for strict checking. Terminating" not in process.stdout
 
 

--- a/tests/vspec/test_strict/test_strict.py
+++ b/tests/vspec/test_strict/test_strict.py
@@ -10,68 +10,58 @@
 
 import pytest
 import os
+from pathlib import Path
+import subprocess
+
+HERE = Path(__file__).resolve().parent
+TEST_UNITS = HERE / ".." / "test_units.yaml"
 
 
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
+@pytest.mark.parametrize(
+    "vspec_file",
+    [
+        "correct.vspec",
+        "correct_boolean.vspec",
+        "faulty_case.vspec",
+        "faulty_name_boolean.vspec",
+    ],
+)
+def test_not_strict(vspec_file: str, tmp_path):
+    spec = HERE / vspec_file
+    output = tmp_path / "out.json"
+    cmd = f"vspec2json --json-pretty -u {TEST_UNITS} {spec} {output}"
+    env = os.environ.copy()
+    env["COLUMNS"] = "200"
+    process = subprocess.run(
+        cmd.split(), capture_output=True, text=True, env=env)
+    assert process.returncode == 0
+    print(process.stdout)
+    assert "You asked for strict checking. Terminating" not in process.stdout
 
 
-@pytest.mark.parametrize("vspec_file", [
-    "correct.vspec",
-    "correct_boolean.vspec",
-    "faulty_case.vspec",
-    "faulty_name_boolean.vspec"
-    ])
-def test_not_strict(vspec_file: str, change_test_dir):
-    test_str = "vspec2json --json-pretty -u ../test_units.yaml " + vspec_file + \
-               " out.json > out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-    test_str = 'grep \"You asked for strict checking. Terminating\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) != 0
+@pytest.mark.parametrize("vspec_file", ["correct.vspec", "correct_boolean.vspec"])
+def test_strict_ok(vspec_file: str, tmp_path):
+    spec = HERE / vspec_file
+    output = tmp_path / "out.json"
+    cmd = f"vspec2json --json-pretty -s -u {TEST_UNITS} {spec} {output}"
+    env = os.environ.copy()
+    env["COLUMNS"] = "200"
+    process = subprocess.run(
+        cmd.split(), capture_output=True, text=True, env=env)
+    assert process.returncode == 0
+    assert "You asked for strict checking. Terminating" not in process.stdout
 
 
-@pytest.mark.parametrize("vspec_file", [
-    "correct.vspec",
-    "correct_boolean.vspec"
-    ])
-def test_strict_ok(vspec_file: str, change_test_dir):
-    test_str = "vspec2json --json-pretty -s -u ../test_units.yaml " + vspec_file + \
-               " out.json > out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-    test_str = 'grep \"You asked for strict checking. Terminating\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) != 0
-
-
-@pytest.mark.parametrize("vspec_file", [
-    "faulty_case.vspec",
-    "faulty_name_boolean.vspec"
-    ])
-def test_strict_error(vspec_file: str, change_test_dir):
-    test_str = "vspec2json --json-pretty -s -u ../test_units.yaml " + vspec_file + \
-               " out.json > out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) != 0
-
-    test_str = 'grep \"You asked for strict checking. Terminating.\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+@pytest.mark.parametrize(
+    "vspec_file", ["faulty_case.vspec", "faulty_name_boolean.vspec"]
+)
+def test_strict_error(vspec_file: str, tmp_path):
+    spec = HERE / vspec_file
+    output = tmp_path / "out.json"
+    cmd = f"vspec2json --json-pretty -s -u {TEST_UNITS} {spec} {output}"
+    env = os.environ.copy()
+    env["COLUMNS"] = "200"
+    process = subprocess.run(
+        cmd.split(), capture_output=True, text=True, env=env)
+    assert process.returncode != 0
+    assert "You asked for strict checking. Terminating" in process.stdout

--- a/tests/vspec/test_struct_as_root/test_struct_as_root.py
+++ b/tests/vspec/test_struct_as_root/test_struct_as_root.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2023 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the

--- a/tests/vspec/test_struct_as_root/test_struct_as_root.py
+++ b/tests/vspec/test_struct_as_root/test_struct_as_root.py
@@ -8,27 +8,18 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-import pytest
-import os
+from pathlib import Path
+import subprocess
+
+HERE = Path(__file__).resolve().parent
+TEST_UNITS = HERE / ".." / "test_units.yaml"
 
 
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
-
-
-def test_struct_as_root(change_test_dir):
-    test_str = "vspec2csv -vt struct1.vspec" + \
-               " -u ../test_units.yaml test.vspec out.csv > out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    # failure expected
-    assert os.WEXITSTATUS(result) != 0
-
-    test_str = 'grep \"Root node Struct1 is not of branch type\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+def test_struct_as_root(tmp_path):
+    struct = HERE / "struct1.vspec"
+    spec = HERE / "test.vspec"
+    output = tmp_path / "out.csv"
+    cmd = f"vspec2csv -vt {struct} -u {TEST_UNITS} {spec} {output}"
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
+    assert process.returncode != 0
+    assert "Root node Struct1 is not of branch type" in process.stdout

--- a/tests/vspec/test_structs/test_commandline.py
+++ b/tests/vspec/test_structs/test_commandline.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2022 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the

--- a/tests/vspec/test_structs/test_data_type_parsing.py
+++ b/tests/vspec/test_structs/test_data_type_parsing.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2023 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the
@@ -67,9 +65,7 @@ def test_data_types_export_single_file(
     if format == "json":
         cmd += " --json-pretty"
     cmd += f" -vt {type_file} -u {TEST_UNITS} {vspec} {output}"
-    process = subprocess.run(cmd.split())
-    assert process.returncode == 0
-
+    subprocess.run(cmd.split(), check=True)
     expected_output = HERE / expected_signal
     assert filecmp.cmp(output, expected_output)
 
@@ -121,9 +117,7 @@ def test_data_types_export_multi_file(
     if format == "json":
         cmd += " --json-pretty"
     cmd += f" -vt {type_file} -u {TEST_UNITS} -ot {types_output} {vspec} {output}"
-    process = subprocess.run(cmd.split())
-    assert process.returncode == 0
-
+    subprocess.run(cmd.split(), check=True)
     expected_signal = HERE / expected_signal
     expected_data_types = HERE / expected_data_types
     assert filecmp.cmp(output, expected_signal)
@@ -183,8 +177,7 @@ def test_data_types_export_to_proto(
         f" {signal_vspec_file} {actual_signal_file}"
     )
 
-    process = subprocess.run(cmd.split(), cwd=tmp_path)
-    assert process.returncode == 0
+    subprocess.run(cmd.split(), cwd=tmp_path, check=True)
 
     expected_proto_files = expected_type_files + [expected_signal_file]
     actual_proto_files = actual_type_files + [actual_signal_file]

--- a/tests/vspec/test_structs/test_data_type_parsing.py
+++ b/tests/vspec/test_structs/test_data_type_parsing.py
@@ -12,251 +12,325 @@ import pytest
 import os
 import filecmp
 from pathlib import Path
+import subprocess
 
 HERE = Path(__file__).resolve().parent
 VSS_TOOLS_ROOT = (HERE / ".." / ".." / "..").absolute()
-
-os.environ["COLUMNS"] = "200"
-
-
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
+TEST_UNITS = HERE / ".." / "test_units.yaml"
 
 
-@pytest.mark.parametrize("format, signals_out, expected_signal, type_file", [
-    ('json', 'signals-out.json', 'expected-signals-types.json', 'VehicleDataTypes.vspec'),
-    ('json', 'signals-out.json', 'expected-signals-types.json',
-     'VehicleDataTypesFlat.vspec'),
-    ('yaml', 'signals-out.yaml', 'expected-signals-types.yaml', 'VehicleDataTypes.vspec'),
-    ('csv', 'signals-out.csv', 'expected-signals-types.csv', 'VehicleDataTypes.vspec'),
-    ('ddsidl', 'signals-out.idl', 'expected-signals-types.idl', 'VehicleDataTypes.vspec')])
-def test_data_types_export_single_file(format, signals_out, expected_signal, type_file, change_test_dir):
+@pytest.mark.parametrize(
+    "format, signals_out, expected_signal, type_file",
+    [
+        (
+            "json",
+            "signals-out.json",
+            "expected-signals-types.json",
+            "VehicleDataTypes.vspec",
+        ),
+        (
+            "json",
+            "signals-out.json",
+            "expected-signals-types.json",
+            "VehicleDataTypesFlat.vspec",
+        ),
+        (
+            "yaml",
+            "signals-out.yaml",
+            "expected-signals-types.yaml",
+            "VehicleDataTypes.vspec",
+        ),
+        (
+            "csv",
+            "signals-out.csv",
+            "expected-signals-types.csv",
+            "VehicleDataTypes.vspec",
+        ),
+        (
+            "ddsidl",
+            "signals-out.idl",
+            "expected-signals-types.idl",
+            "VehicleDataTypes.vspec",
+        ),
+    ],
+)
+def test_data_types_export_single_file(
+    format, signals_out, expected_signal, type_file, tmp_path
+):
     """
     Test that data types provided in vspec format are converted correctly
     """
-    args = ["vspec2" + format]
-    if format == 'json':
-        args.append('--json-pretty')
-    args.extend(["-vt", type_file, "-u", "../test_units.yaml",
-                 "test.vspec", signals_out, "1>", "out.txt", "2>&1"])
-    test_str = " ".join(args)
+    type_file = HERE / type_file
+    vspec = HERE / "test.vspec"
+    output = tmp_path / signals_out
+    cmd = f"vspec2{format}"
+    if format == "json":
+        cmd += " --json-pretty"
+    cmd += f" -vt {type_file} -u {TEST_UNITS} {vspec} {output}"
+    process = subprocess.run(cmd.split())
+    assert process.returncode == 0
 
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-    test_str = f"diff {signals_out} {expected_signal}"
-    assert filecmp.cmp(signals_out, expected_signal)
-
-    os.system("rm -f out.txt")
-    os.system(f"rm -f {signals_out}")
+    expected_output = HERE / expected_signal
+    assert filecmp.cmp(output, expected_output)
 
 
-@pytest.mark.parametrize("format,signals_out, data_types_out,expected_signal,expected_data_types", [
-    ('json', 'signals-out.json', 'VehicleDataTypes.json',
-     'expected-signals.json', 'expected.json'),
-    ('csv',  'signals-out.csv',  'VehicleDataTypes.csv',
-     'expected-signals.csv',  'expected.csv'),
-    ('yaml',  'signals-out.yaml',  'VehicleDataTypes.yaml',  'expected-signals.yaml',  'expected.yaml')])
-def test_data_types_export_multi_file(format, signals_out, data_types_out,
-                                      expected_signal, expected_data_types, change_test_dir):
+@pytest.mark.parametrize(
+    "format,signals_out, data_types_out,expected_signal,expected_data_types",
+    [
+        (
+            "json",
+            "signals-out.json",
+            "VehicleDataTypes.json",
+            "expected-signals.json",
+            "expected.json",
+        ),
+        (
+            "csv",
+            "signals-out.csv",
+            "VehicleDataTypes.csv",
+            "expected-signals.csv",
+            "expected.csv",
+        ),
+        (
+            "yaml",
+            "signals-out.yaml",
+            "VehicleDataTypes.yaml",
+            "expected-signals.yaml",
+            "expected.yaml",
+        ),
+    ],
+)
+def test_data_types_export_multi_file(
+    format,
+    signals_out,
+    data_types_out,
+    expected_signal,
+    expected_data_types,
+    tmp_path,
+):
     """
     Test that data types provided in vspec format are converted correctly
     Note that DDSIDL does not support -ot
     """
-    args = ["vspec2" + format]
-    if format == 'json':
-        args.append('--json-pretty')
-    args.extend(["-vt", "VehicleDataTypes.vspec", "-u", "../test_units.yaml", "-ot", data_types_out,
-                 "test.vspec", signals_out, "1>", "out.txt", "2>&1"])
-    test_str = " ".join(args)
 
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+    type_file = HERE / "VehicleDataTypes.vspec"
+    vspec = HERE / "test.vspec"
+    output = tmp_path / signals_out
+    types_output = tmp_path / data_types_out
+    cmd = f"vspec2{format}"
+    if format == "json":
+        cmd += " --json-pretty"
+    cmd += f" -vt {type_file} -u {TEST_UNITS} -ot {types_output} {vspec} {output}"
+    process = subprocess.run(cmd.split())
+    assert process.returncode == 0
 
-    test_str = f"diff {data_types_out} {expected_data_types}"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-    assert filecmp.cmp(signals_out, expected_signal)
-    os.system("rm -f out.txt")
-    os.system(f"rm -f {signals_out} {data_types_out}")
+    expected_signal = HERE / expected_signal
+    expected_data_types = HERE / expected_data_types
+    assert filecmp.cmp(output, expected_signal)
+    assert filecmp.cmp(types_output, expected_data_types)
 
 
 @pytest.mark.parametrize(
     "signal_vspec_file,type_vspec_file,expected_signal_file,actual_signal_file,expected_type_files,"
     "actual_type_files",
-    [('test.vspec', 'VehicleDataTypes.vspec', 'ExpectedSignals.proto', 'ActualSignals.proto',
-      ['VehicleDataTypes/TestBranch1/ExpectedTestBranch1.proto'],
-      ['VehicleDataTypes/TestBranch1/TestBranch1.proto']),
-     ('test2.vspec', 'VehicleDataTypes2.vspec', 'ExpectedSignals2.proto', 'ActualSignals.proto',
-      ['VehicleDataTypes/TestBranch2/ExpectedTestBranch2.proto',
-       'VehicleDataTypes/TestBranch3/ExpectedTestBranch3.proto'],
-      ['VehicleDataTypes/TestBranch2/TestBranch2.proto',
-       'VehicleDataTypes/TestBranch3/TestBranch3.proto'])])
-def test_data_types_export_to_proto(signal_vspec_file, type_vspec_file, expected_signal_file,
-                                    actual_signal_file, expected_type_files, actual_type_files,
-                                    change_test_dir):
+    [
+        (
+            "test.vspec",
+            "VehicleDataTypes.vspec",
+            "ExpectedSignals.proto",
+            "ActualSignals.proto",
+            ["VehicleDataTypes/TestBranch1/ExpectedTestBranch1.proto"],
+            ["VehicleDataTypes/TestBranch1/TestBranch1.proto"],
+        ),
+        (
+            "test2.vspec",
+            "VehicleDataTypes2.vspec",
+            "ExpectedSignals2.proto",
+            "ActualSignals.proto",
+            [
+                "VehicleDataTypes/TestBranch2/ExpectedTestBranch2.proto",
+                "VehicleDataTypes/TestBranch3/ExpectedTestBranch3.proto",
+            ],
+            [
+                "VehicleDataTypes/TestBranch2/TestBranch2.proto",
+                "VehicleDataTypes/TestBranch3/TestBranch3.proto",
+            ],
+        ),
+    ],
+)
+def test_data_types_export_to_proto(
+    signal_vspec_file,
+    type_vspec_file,
+    expected_signal_file,
+    actual_signal_file,
+    expected_type_files,
+    actual_type_files,
+    tmp_path,
+):
     """
     Test that data types provided in vspec format are converted correctly to protobuf
     """
+    signal_vspec_file = HERE / signal_vspec_file
+    type_vspec_file = HERE / type_vspec_file
+    expected_signal_file = HERE / expected_signal_file
+    expected_type_files = [HERE / f for f in expected_type_files]
+    actual_signal_file = tmp_path / actual_signal_file
+    actual_type_files = [tmp_path / f for f in actual_type_files]
+    data_types_out = tmp_path / "unused.proto"
 
-    data_types_out = Path.cwd() / "unused.proto"
-    args = ["vspec2protobuf",
-            "-vt", type_vspec_file, "-u", "../test_units.yaml",
-            "-ot", str(data_types_out), signal_vspec_file, actual_signal_file, "1>", "out.txt", "2>&1"]
-    test_str = " ".join(args)
+    cmd = (
+        f"vspec2protobuf -vt {type_vspec_file} -u {TEST_UNITS} -ot {data_types_out}"
+        f" {signal_vspec_file} {actual_signal_file}"
+    )
 
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+    process = subprocess.run(cmd.split(), cwd=tmp_path)
+    assert process.returncode == 0
 
     expected_proto_files = expected_type_files + [expected_signal_file]
     actual_proto_files = actual_type_files + [actual_signal_file]
 
-    os.system("rm -f out.txt")
-    for (expected_file, actual_file) in zip(expected_proto_files, actual_proto_files):
-        test_str = f"diff {expected_file} {actual_file}"
-        result = os.system(test_str)
-        assert os.WIFEXITED(result)
-        assert os.WEXITSTATUS(result) == 0
+    for expected_file, actual_file in zip(expected_proto_files, actual_proto_files):
+        assert filecmp.cmp(expected_file, actual_file)
 
     for proto_file in actual_proto_files:
-        proto_compile_cmd = f"protoc {proto_file} --cpp_out=. 1>proto.out 2>&1"
-        result = os.system(proto_compile_cmd)
-        os.system("cat proto.out")
-        assert os.WIFEXITED(result)
-        assert os.WEXITSTATUS(result) == 0
-    # clean up
-    for proto_file in actual_proto_files:
-        proto_stem = Path(proto_file).stem
-        proto_path = Path(os.path.dirname(proto_file))
-        os.system(f"rm -f {proto_file} proto.out")
-        os.system(
-            f"rm -f {proto_path}/{proto_stem}.pb.cc {proto_path}/{proto_stem}.pb.h")
+        proto_compile_cmd = f"protoc {proto_file} --cpp_out=. -I {tmp_path}"
+        process = subprocess.run(proto_compile_cmd.split(), cwd=tmp_path)
+        assert process.returncode == 0
 
 
-@pytest.mark.parametrize("types_file,error_msg", [
-    ('VehicleDataTypesInvalidStructWithQualifiedName.vspec',
-     '2 data type reference errors detected'),
-    ('VehicleDataTypesWithCircularRefs.vspec',
-     '4 data type reference errors detected'),
-    ('VehicleDataTypesInvalidStruct.vspec', 'Data type not found. Data Type: NestedStruct1')])
+@pytest.mark.parametrize(
+    "types_file,error_msg",
+    [
+        (
+            "VehicleDataTypesInvalidStructWithQualifiedName.vspec",
+            "2 data type reference errors detected",
+        ),
+        (
+            "VehicleDataTypesWithCircularRefs.vspec",
+            "4 data type reference errors detected",
+        ),
+        (
+            "VehicleDataTypesInvalidStruct.vspec",
+            "Data type not found. Data Type: NestedStruct1",
+        ),
+    ],
+)
 def test_data_types_invalid_reference_in_data_type_tree(
-        types_file, error_msg, change_test_dir):
+    types_file, error_msg, tmp_path
+):
     """
     Test that errors are surfaced when data type name references are invalid within the data type tree
     """
-    test_str = " ".join(["vspec2json", "-u", "../test_units.yaml",
-                         "--json-pretty", "-vt",
-                         types_file, "-ot", "VehicleDataTypes.json", "test.vspec", "out.json", "1>", "out.txt", "2>&1"])
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) != 0
-
-    test_str = f'grep \"{error_msg}\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f VehicleDataTypes.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+    types_file = HERE / types_file
+    output_types = tmp_path / "VehicleDataTypes.vspec"
+    vspec = HERE / "test.vspec"
+    output = tmp_path / "out.json"
+    cmd = f"vspec2json -u {TEST_UNITS} --json-pretty -vt {types_file} -ot {output_types} {vspec} {output}"
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
+    assert process.returncode != 0
+    assert error_msg in process.stdout
 
 
-@pytest.mark.parametrize("types_file,error_msg", [
-    ('VehicleDataTypesInvalidStructWithOrphanProperties.vspec',
-     'Orphan property detected. y_property is not defined under a struct')])
-def test_data_types_orphan_properties(
-        types_file, error_msg, change_test_dir):
+@pytest.mark.parametrize(
+    "types_file,error_msg",
+    [
+        (
+            "VehicleDataTypesInvalidStructWithOrphanProperties.vspec",
+            "Orphan property detected. y_property is not defined under a struct",
+        )
+    ],
+)
+def test_data_types_orphan_properties(types_file, error_msg, tmp_path):
     """
     Test that errors are surfaced when a property is not defined under a struct
     """
-    test_str = " ".join(["vspec2json",  "-u", "../test_units.yaml",
-                         "--json-pretty", "-vt",
-                         types_file, "-ot", "VehicleDataTypes.json", "test.vspec", "out.json", "1>", "out.txt", "2>&1"])
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) != 0
+    types_file = HERE / types_file
+    types_out = tmp_path / "VehicleDataTypes.vspec"
+    vspec = HERE / "test.vspec"
+    out = tmp_path / "out.json"
 
-    test_str = f'grep \"{error_msg}\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system('cat out.txt')
-    os.system("rm -f VehicleDataTypes.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+    cmd = f"vspec2json -u {TEST_UNITS} --json-pretty -vt {types_file} -ot {types_out} {vspec} {out}"
+    env = os.environ.copy()
+    env["COLUMNS"] = "200"
+    process = subprocess.run(
+        cmd.split(), capture_output=True, text=True, env=env)
+    assert process.returncode != 0
+    assert error_msg in process.stdout
 
 
-def test_data_types_invalid_reference_in_signal_tree(change_test_dir):
+def test_data_types_invalid_reference_in_signal_tree(tmp_path):
     """
     Test that errors are surfaced when data type name references are invalid in the signal tree
     """
-    test_str = " ".join(["vspec2json", "-u", "../test_units.yaml",
-                         "--json-pretty", "-vt",
-                         "VehicleDataTypes.vspec", "-ot", "VehicleDataTypes.json", "test-invalid-datatypes.vspec",
-                         "out.json", "1>", "out.txt", "2>&1"])
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) != 0
+    types_file = HERE / "VehicleDataTypes.vspec"
+    types_out = tmp_path / "VehicleDataTypes.json"
+    vspec = HERE / "test-invalid-datatypes.vspec"
+    out = tmp_path / "out.json"
 
-    error_msg = ('Following types were referenced in signals but have not been defined: '
-                 'VehicleDataTypes.TestBranch1.ParentStruct1, VehicleDataTypes.TestBranch1.NestedStruct1')
-    test_str = f'grep \"{error_msg}\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f VehicleDataTypes.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+    cmd = f"vspec2json -u {TEST_UNITS} --json-pretty -vt {types_file} -ot {types_out} {vspec} {out}"
+    env = os.environ.copy()
+    env["COLUMNS"] = "200"
+    process = subprocess.run(
+        cmd.split(), capture_output=True, text=True, env=env)
+    assert process.returncode != 0
+
+    error_msg = (
+        "Following types were referenced in signals but have not been defined: "
+        "VehicleDataTypes.TestBranch1.ParentStruct1, VehicleDataTypes.TestBranch1.NestedStruct1"
+    )
+    assert error_msg in process.stdout
 
 
-def test_error_when_no_user_defined_data_types_are_provided(change_test_dir):
+def test_error_when_no_user_defined_data_types_are_provided(tmp_path):
     """
     Test that error message is provided when user-defined types are specified
     in the signal tree but no data type tree is provided.
     """
-    test_str = " ".join(["vspec2json", "-u", "../test_units.yaml",
-                         "--json-pretty", "test.vspec", "out.json", "1>", "out.txt", "2>&1"])
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) != 0
+    vspec = HERE / "test.vspec"
+    out = tmp_path / "out.json"
+    cmd = f"vspec2json -u {TEST_UNITS} --json-pretty {vspec} {out}"
+    env = os.environ.copy()
+    env["COLUMNS"] = "200"
+    process = subprocess.run(
+        cmd.split(), capture_output=True, text=True, env=env)
+    assert process.returncode != 0
 
-    error_msg = ('Following types were referenced in signals but have not been defined: '
-                 'VehicleDataTypes.TestBranch1.ParentStruct, VehicleDataTypes.TestBranch1.NestedStruct')
-    test_str = f'grep \"{error_msg}\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f VehicleDataTypes.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+    error_msg = (
+        "Following types were referenced in signals but have not been defined: "
+        "VehicleDataTypes.TestBranch1.ParentStruct, VehicleDataTypes.TestBranch1.NestedStruct"
+    )
+    assert error_msg in process.stdout
 
 
-@pytest.mark.parametrize("vspec_file,types_file,error_msg", [
-    ('test.vspec', 'VehicleDataTypesStructWithDataType.vspec',
-     'cannot have datatype, only allowed for signal and property'),
-    ('test.vspec', 'VehicleDataTypesStructWithUnit.vspec',
-     'cannot have unit'),
-    ('test_with_unit_on_struct_signal.vspec', 'VehicleDataTypes.vspec',
-     'Unit specified for item not using standard datatype')])
-def test_faulty_use_of_standard_attributes(
-        vspec_file, types_file, error_msg, change_test_dir):
+@pytest.mark.parametrize(
+    "vspec_file,types_file,error_msg",
+    [
+        (
+            "test.vspec",
+            "VehicleDataTypesStructWithDataType.vspec",
+            "cannot have datatype, only allowed for signal and property",
+        ),
+        ("test.vspec", "VehicleDataTypesStructWithUnit.vspec", "cannot have unit"),
+        (
+            "test_with_unit_on_struct_signal.vspec",
+            "VehicleDataTypes.vspec",
+            "Unit specified for item not using standard datatype",
+        ),
+    ],
+)
+def test_faulty_use_of_standard_attributes(vspec_file, types_file, error_msg, tmp_path):
     """
     Test faulty use of datatype and unit for structs
     """
-    test_str = " ".join(["vspec2json", "-u", "../test_units.yaml",
-                         "--json-pretty", "-vt", types_file, "-ot", "VehicleDataTypes.json", vspec_file,
-                         "out.json", "1>", "out.txt", "2>&1"])
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) != 0
+    types_file = HERE / types_file
+    types_out = tmp_path / "VehicleDataTypes.json"
+    vspec_file = HERE / vspec_file
+    out = tmp_path / "out.json"
 
-    test_str = f'grep \"{error_msg}\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f VehicleDataTypes.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+    cmd = f"vspec2json -u {TEST_UNITS} --json-pretty -vt {types_file} -ot {types_out} {vspec_file} {out}"
+    env = os.environ.copy()
+    env["COLUMNS"] = "200"
+    process = subprocess.run(
+        cmd.split(), capture_output=True, text=True, env=env)
+    assert process.returncode != 0
+    assert error_msg in process.stdout

--- a/tests/vspec/test_type_error/test_type_error.py
+++ b/tests/vspec/test_type_error/test_type_error.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2023 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the

--- a/tests/vspec/test_type_error/test_type_error.py
+++ b/tests/vspec/test_type_error/test_type_error.py
@@ -9,72 +9,66 @@
 # SPDX-License-Identifier: MPL-2.0
 
 import pytest
-import os
+from pathlib import Path
+import subprocess
+
+HERE = Path(__file__).resolve().parent
+VSS_TOOLS_ROOT = (HERE / ".." / ".." / "..").absolute()
+TEST_UNITS = HERE / ".." / "test_units.yaml"
 
 
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
+@pytest.mark.parametrize(
+    "vspec_file, types_file, types_out_file, overlay_file",
+    [
+        ("no_type_branch.vspec", None, None, None),
+        ("no_type_signal.vspec", None, None, None),
+        ("correct.vspec", None, None, "no_type_overlay.vspec"),
+        ("correct.vspec", "no_type_struct.vspec", "ot.json", None),
+        ("correct.vspec", "no_type_property.vspec", "ot.json", None),
+    ],
+)
+def test_description_error(
+    vspec_file: str, types_file, types_out_file, overlay_file, tmp_path
+):
+    vspec_file = HERE / vspec_file
+    out = tmp_path / "out.json"
+
+    cmd = f"vspec2json --json-pretty -u {TEST_UNITS}"
+    if types_file:
+        cmd += f" -vt {HERE / types_file}"
+    if types_out_file:
+        cmd += f" -ot {tmp_path / types_out_file}"
+    if overlay_file:
+        cmd += f" -o {HERE / overlay_file}"
+    cmd += f" {vspec_file} {out}"
+
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
+    assert process.returncode != 0
+    assert "No type specified" in process.stdout
 
 
-@pytest.mark.parametrize("vspec_file, type_str", [
-    ("no_type_branch.vspec", ""),
-    ("no_type_signal.vspec", ""),
-    ("correct.vspec", "-o no_type_overlay.vspec"),
-    ("correct.vspec", "-vt no_type_struct.vspec -ot ot.json"),
-    ("correct.vspec", "-vt no_type_property.vspec -ot ot.json")
-    ])
-def test_description_error(vspec_file: str, type_str: str, change_test_dir):
-    test_str = "vspec2json --json-pretty -u ../test_units.yaml " + type_str + " " + \
-               vspec_file + " out.json > out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    # failure expected
-    assert os.WEXITSTATUS(result) != 0
-
-    test_str = 'grep \"No type specified\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+@pytest.mark.parametrize(
+    "vspec_file", [("branch_wrong_case.vspec"), ("sensor_wrong_case.vspec")]
+)
+def type_case_sensitive(vspec_file: str, tmp_path):
+    vspec_file = HERE / vspec_file
+    out = tmp_path / "out.json"
+    cmd = f"vspec2json --json-pretty {vspec_file} {out}"
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
+    assert process.returncode != 0
+    assert "Unknown type" in process.stdout
 
 
-@pytest.mark.parametrize("vspec_file", [
-    ("branch_wrong_case.vspec"),
-    ("sensor_wrong_case.vspec")
-    ])
-def type_case_sensitive(vspec_file: str, change_test_dir):
-    test_str = "vspec2json --json-pretty " + \
-               vspec_file + " out.json > out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    # failure expected
-    assert os.WEXITSTATUS(result) != 0
-
-    test_str = 'grep \"Unknown type\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-
-@pytest.mark.parametrize("vspec_file", [
-    ("branch_in_signal.vspec"),
-    ])
-def test_scope_error(vspec_file: str,  change_test_dir):
-    test_str = "vspec2json --json-pretty -u ../test_units.yaml " + \
-               vspec_file + " out.json > out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    # failure expected
-    assert os.WEXITSTATUS(result) != 0
-
-    test_str = 'grep \"VSS Node A.UInt8 cannot have children\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
+@pytest.mark.parametrize(
+    "vspec_file",
+    [
+        ("branch_in_signal.vspec"),
+    ],
+)
+def test_scope_error(vspec_file: str, tmp_path):
+    vspec_file = HERE / vspec_file
+    out = tmp_path / "out.json"
+    cmd = f"vspec2json --json-pretty -u {TEST_UNITS} {vspec_file} {out}"
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
+    assert process.returncode != 0
+    assert "VSS Node A.UInt8 cannot have children" in process.stdout

--- a/tests/vspec/test_types_with_uuid/test_uuid.py
+++ b/tests/vspec/test_types_with_uuid/test_uuid.py
@@ -8,70 +8,58 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-import pytest
-import os
+from pathlib import Path
+import subprocess
+import filecmp
+
+HERE = Path(__file__).resolve().parent
+TEST_UNITS = HERE / ".." / "test_units.yaml"
 
 
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
+def run_exporter(exporter, argument, compare_suffix, tmp_path):
+    vspec = HERE / "test.vspec"
+    out = tmp_path / f"out.{exporter}"
+    cmd = f"vspec2{exporter}{argument} -u {TEST_UNITS} {vspec} {out}"
+    process = subprocess.run(cmd.split())
+    assert process.returncode == 0
+
+    expected = HERE / f"expected_{compare_suffix}.{exporter}"
+    assert filecmp.cmp(out, expected)
 
 
-def run_exporter(exporter, argument, compare_suffix):
-    test_str = "vspec2" + exporter + argument + \
-        " -u ../test_units.yaml test.vspec out." + exporter + " 1> out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-    test_str = "diff out." + exporter + " expected_" + compare_suffix + "." + exporter
-    result = os.system(test_str)
-    os.system("rm -f out." + exporter + " out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-
-def test_uuid(change_test_dir):
-
+def test_uuid(tmp_path):
     # Run all "supported" exporters that supports uuid, i.e. not those in contrib
     # Exception is "binary", as it is assumed output may vary depending on
     # target
     exporters = ["json", "ddsidl", "csv", "yaml", "franca"]
     for exporter in exporters:
-        run_exporter(exporter, " --uuid", "uuid")
-        run_exporter(exporter, "", "no_uuid")
+        run_exporter(exporter, " --uuid", "uuid", tmp_path)
+        run_exporter(exporter, "", "no_uuid", tmp_path)
 
 
-def run_error_test(tool, argument, arg_error_expected: bool):
-    test_str = tool + " " + argument + " -u ../test_units.yaml test.vspec out.json 1> out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
+def run_error_test(tool, argument, arg_error_expected: bool, tmp_path):
+    vspec = HERE / "test.vspec"
+    out = tmp_path / "out.json"
+    cmd = f"{tool} {argument} -u {TEST_UNITS} {vspec} {out}"
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
     if arg_error_expected:
-        assert os.WEXITSTATUS(result) != 0
+        assert process.returncode != 0
+        assert "error: unrecognized arguments" in process.stderr
     else:
-        assert os.WEXITSTATUS(result) == 0
-    test_str = 'grep \"error: unrecognized arguments\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    if arg_error_expected:
-        assert os.WEXITSTATUS(result) == 0
-    else:
-        assert os.WEXITSTATUS(result) != 0
+        assert process.returncode == 0
 
 
-def test_obsolete_arg(change_test_dir):
+def test_obsolete_arg(tmp_path):
     """
     Check that obsolete argument --no-uuid results in error
     """
-    run_error_test("vspec2json", "", False)
-    run_error_test("vspec2json", "--uuid", False)
-    run_error_test("vspec2json", "--no-uuid", True)
+    run_error_test("vspec2json", "", False, tmp_path)
+    run_error_test("vspec2json", "--uuid", False, tmp_path)
+    run_error_test("vspec2json", "--no-uuid", True, tmp_path)
 
 
-def test_uuid_unsupported(change_test_dir):
+def test_uuid_unsupported(tmp_path):
     """
     Test that we get an error if using --uuid for tools not supporting it
     """
-    run_error_test("vspec2graphql", "--uuid", True)
+    run_error_test("vspec2graphql", "--uuid", True, tmp_path)

--- a/tests/vspec/test_types_with_uuid/test_uuid.py
+++ b/tests/vspec/test_types_with_uuid/test_uuid.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2022 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the
@@ -20,9 +18,7 @@ def run_exporter(exporter, argument, compare_suffix, tmp_path):
     vspec = HERE / "test.vspec"
     out = tmp_path / f"out.{exporter}"
     cmd = f"vspec2{exporter}{argument} -u {TEST_UNITS} {vspec} {out}"
-    process = subprocess.run(cmd.split())
-    assert process.returncode == 0
-
+    subprocess.run(cmd.split(), check=True)
     expected = HERE / f"expected_{compare_suffix}.{exporter}"
     assert filecmp.cmp(out, expected)
 

--- a/tests/vspec/test_units/test_units.py
+++ b/tests/vspec/test_units/test_units.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2022 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the
@@ -31,9 +29,8 @@ def run_unit(
     env = os.environ.copy()
     env["COLUMNS"] = "200"
     process = subprocess.run(
-        cmd.split(), capture_output=True, text=True, cwd=HERE, env=env
+        cmd.split(), capture_output=True, text=True, cwd=HERE, env=env, check=True
     )
-    assert process.returncode == 0
     assert filecmp.cmp(HERE / expected_file, out)
 
     if grep_present and grep_string:

--- a/tests/vspec/test_units/test_units.py
+++ b/tests/vspec/test_units/test_units.py
@@ -7,170 +7,216 @@
 # https://www.mozilla.org/en-US/MPL/2.0/
 #
 # SPDX-License-Identifier: MPL-2.0
-
-import pytest
 import os
 from typing import Optional
+from pathlib import Path
+import subprocess
+import filecmp
+
+HERE = Path(__file__).resolve().parent
+TEST_UNITS = HERE / ".." / "test_units.yaml"
 
 
-# #################### Helper methods #############################
+def run_unit(
+    tmp_path,
+    vspec_file,
+    unit_argument,
+    expected_file,
+    quantity_argument="",
+    grep_present: bool = True,
+    grep_string: Optional[str] = None,
+):
+    out = tmp_path / "out.json"
+    cmd = f"vspec2json --json-pretty {vspec_file} {unit_argument} {quantity_argument} {out}"
+    env = os.environ.copy()
+    env["COLUMNS"] = "200"
+    process = subprocess.run(
+        cmd.split(), capture_output=True, text=True, cwd=HERE, env=env
+    )
+    assert process.returncode == 0
+    assert filecmp.cmp(HERE / expected_file, out)
 
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
-
-
-def run_unit(vspec_file, unit_argument, expected_file, quantity_argument="",
-             grep_present: bool = True, grep_string: Optional[str] = None):
-    test_str = "vspec2json --json-pretty " + \
-        vspec_file + " " + unit_argument + " " + quantity_argument + " out.json > out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-    test_str = "diff out.json " + expected_file
-    result = os.system(test_str)
-    os.system("rm -f out.json")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-    # Verify expected quantity
-
-    if grep_string is not None:
-        test_str = 'grep \"' + grep_string + '\" out.txt > /dev/null'
-        result = os.system(test_str)
-        assert os.WIFEXITED(result)
-        if grep_present:
-            assert os.WEXITSTATUS(result) == 0
-        else:
-            assert os.WEXITSTATUS(result) == 1
-
-    os.system("rm -f out.txt")
+    if grep_present and grep_string:
+        assert grep_string in process.stdout
 
 
-def run_unit_error(vspec_file, unit_argument, grep_error, quantity_argument=""):
-    test_str = "vspec2json --json-pretty " + \
-        vspec_file + " " + unit_argument + " " + quantity_argument + " out.json > out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    # failure expected
-    assert os.WEXITSTATUS(result) != 0
-
-    test_str = 'grep \"' + grep_error + '\" out.txt > /dev/null'
-    result = os.system(test_str)
-    os.system("cat out.txt")
-    os.system("rm -f out.json out.txt")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-# #################### Tests #############################
+def run_unit_error(
+    tmp_path, vspec_file, unit_argument, grep_error, quantity_argument=""
+):
+    out = tmp_path / "out.json"
+    cmd = f"vspec2json --json-pretty {vspec_file} {unit_argument} {quantity_argument} {out}"
+    process = subprocess.run(
+        cmd.split(), capture_output=True, text=True, cwd=HERE)
+    assert process.returncode != 0
+    if grep_error:
+        assert grep_error in process.stdout or grep_error in process.stderr
 
 
-# Short form
-
-def test_single_u(change_test_dir):
-    run_unit("signals_with_special_units.vspec", "-u units_all.yaml", "expected_special.json")
+def test_single_u(tmp_path):
+    run_unit(
+        tmp_path,
+        "signals_with_special_units.vspec",
+        "-u units_all.yaml",
+        "expected_special.json",
+    )
 
 
 # Short form multiple files
-def test_multiple_u(change_test_dir):
+def test_multiple_u(tmp_path):
     run_unit(
+        tmp_path,
         "signals_with_special_units.vspec",
         "-u units_hogshead.yaml -u units_puncheon.yaml",
-        "expected_special.json")
+        "expected_special.json",
+    )
 
 
 # Short form duplication should not matter
-def test_multiple_duplication(change_test_dir):
-    run_unit("signals_with_special_units.vspec", "-u units_all.yaml -u units_all.yaml", "expected_special.json")
+def test_multiple_duplication(tmp_path):
+    run_unit(
+        tmp_path,
+        "signals_with_special_units.vspec",
+        "-u units_all.yaml -u units_all.yaml",
+        "expected_special.json",
+    )
+
 
 # Long form
 
 
-def test_single_unit_files(change_test_dir):
-    run_unit("signals_with_special_units.vspec", "--unit-file units_all.yaml", "expected_special.json")
+def test_single_unit_files(tmp_path):
+    run_unit(
+        tmp_path,
+        "signals_with_special_units.vspec",
+        "--unit-file units_all.yaml",
+        "expected_special.json",
+    )
+
 
 # Long form multiple files
 
 
-def test_multiple_unit_files(change_test_dir):
+def test_multiple_unit_files(tmp_path):
     run_unit(
+        tmp_path,
         "signals_with_special_units.vspec",
         "--unit-file units_hogshead.yaml --unit-file units_puncheon.yaml",
-        "expected_special.json")
+        "expected_special.json",
+    )
+
 
 # Special units not defined
 
 
-def test_unit_error_no_unit_file(change_test_dir):
-    run_unit_error("signals_with_special_units.vspec", "", "No units defined")
+def test_unit_error_no_unit_file(tmp_path):
+    run_unit_error(tmp_path, "signals_with_special_units.vspec",
+                   "", "No units defined")
+
 
 # Not all units defined
 
 
-def test_unit_error_unit_file_incomplete(change_test_dir):
-    run_unit_error("signals_with_special_units.vspec", "-u units_hogshead.yaml", "Unknown unit")
+def test_unit_error_unit_file_incomplete(tmp_path):
+    run_unit_error(
+        tmp_path,
+        "signals_with_special_units.vspec",
+        "-u units_hogshead.yaml",
+        "Unknown unit",
+    )
+
 
 # File not found
 
 
-def test_unit_error_missing_file(change_test_dir):
-    run_unit_error("signals_with_special_units.vspec", "-u file_that_does_not_exist.yaml", "FileNotFoundError")
+def test_unit_error_missing_file(tmp_path):
+    run_unit_error(
+        tmp_path,
+        "signals_with_special_units.vspec",
+        "-u file_that_does_not_exist.yaml",
+        "FileNotFoundError",
+    )
 
 
-def test_unit_on_branch(change_test_dir):
-    run_unit_error("unit_on_branch.vspec", "-u units_all.yaml", "cannot have unit")
+def test_unit_on_branch(tmp_path):
+    run_unit_error(
+        tmp_path, "unit_on_branch.vspec", "-u units_all.yaml", "cannot have unit"
+    )
 
 
 # Quantity tests
-def test_implicit_quantity(change_test_dir):
+
+
+def test_implicit_quantity(tmp_path):
     run_unit(
+        tmp_path,
         "signals_with_special_units.vspec",
         "--unit-file units_all.yaml",
         "expected_special.json",
-        "", False, "has not been defined")
+        "",
+        False,
+        "has not been defined",
+    )
 
 
-def test_explicit_quantity(change_test_dir):
+def test_explicit_quantity(tmp_path):
     run_unit(
+        tmp_path,
         "signals_with_special_units.vspec",
         "--unit-file units_all.yaml",
         "expected_special.json",
-        "-q quantities.yaml", False, "has not been defined")
+        "-q quantities.yaml",
+        False,
+        "has not been defined",
+    )
 
 
-def test_explicit_quantity_2(change_test_dir):
+def test_explicit_quantity_2(tmp_path):
     run_unit(
+        tmp_path,
         "signals_with_special_units.vspec",
         "--unit-file units_all.yaml",
         "expected_special.json",
-        "--quantity-file quantities.yaml", False, "has not been defined")
+        "--quantity-file quantities.yaml",
+        False,
+        "has not been defined",
+    )
 
 
-def test_explicit_quantity_warning(change_test_dir):
+def test_explicit_quantity_warning(tmp_path):
     """
     We should get two warnings as the quantity file contain "volym", not "volume"
     """
     run_unit(
+        tmp_path,
         "signals_with_special_units.vspec",
         "--unit-file units_all.yaml",
         "expected_special.json",
-        "-q quantity_volym.yaml", True, "Quantity volume used by unit puncheon has not been defined")
+        "-q quantity_volym.yaml",
+        True,
+        "Quantity volume used by unit puncheon has not been defined",
+    )
 
 
-def test_quantity_redefinition(change_test_dir):
+def test_quantity_redefinition(tmp_path):
     run_unit(
+        tmp_path,
         "signals_with_special_units.vspec",
         "--unit-file units_all.yaml",
         "expected_special.json",
-        "-q quantity_volym.yaml -q quantity_volym.yaml", True, "Redefinition of quantity volym")
+        "-q quantity_volym.yaml -q quantity_volym.yaml",
+        True,
+        "Redefinition of quantity volym",
+    )
 
 
-def test_quantity_err_no_def(change_test_dir):
+def test_quantity_err_no_def(tmp_path):
     """
     Test scenario when definition is not given
     """
-    run_unit_error("signals_with_special_units.vspec", "-u units_all.yaml",
-                   "No definition found for quantity volume",
-                   "-q quantities_no_def.yaml")
+    run_unit_error(
+        tmp_path,
+        "signals_with_special_units.vspec",
+        "-u units_all.yaml",
+        "No definition found for quantity volume",
+        "-q quantities_no_def.yaml",
+    )

--- a/tests/vspec/test_units_no_quantity/test_units_no_quantity.py
+++ b/tests/vspec/test_units_no_quantity/test_units_no_quantity.py
@@ -7,78 +7,129 @@
 # https://www.mozilla.org/en-US/MPL/2.0/
 #
 # SPDX-License-Identifier: MPL-2.0
-
-import pytest
 import os
 from typing import Optional
+from pathlib import Path
+import subprocess
+import filecmp
+
+HERE = Path(__file__).resolve().parent
+TEST_UNITS = HERE / ".." / "test_units.yaml"
 
 
-# #################### Helper methods #############################
+def run_unit(
+    tmp_path,
+    vspec_file,
+    unit_argument,
+    expected_file,
+    quantity_argument="",
+    grep_present: bool = True,
+    grep_string: Optional[str] = None,
+):
+    out = tmp_path / "out.json"
+    cmd = f"vspec2json --json-pretty {vspec_file} {unit_argument} {quantity_argument} {out}"
+    env = os.environ.copy()
+    env["COLUMNS"] = "200"
+    process = subprocess.run(
+        cmd.split(), capture_output=True, text=True, cwd=HERE, env=env)
+    assert process.returncode == 0
+    assert filecmp.cmp(out, HERE / expected_file)
 
-@pytest.fixture
-def change_test_dir(request, monkeypatch):
-    # To make sure we run from test directory
-    monkeypatch.chdir(request.fspath.dirname)
-
-
-def run_unit(vspec_file, unit_argument, expected_file, quantity_argument="",
-             grep_present: bool = True, grep_string: Optional[str] = None):
-    test_str = "vspec2json --json-pretty " + \
-        vspec_file + " " + unit_argument + " " + quantity_argument + " out.json > out.txt 2>&1"
-    result = os.system(test_str)
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-    test_str = "diff out.json " + expected_file
-    result = os.system(test_str)
-    os.system("rm -f out.json")
-    assert os.WIFEXITED(result)
-    assert os.WEXITSTATUS(result) == 0
-
-    # Verify expected quntity
-
-    if grep_string is not None:
-        test_str = 'grep \"' + grep_string + '\" out.txt > /dev/null'
-        result = os.system(test_str)
-        assert os.WIFEXITED(result)
-        if grep_present:
-            assert os.WEXITSTATUS(result) == 0
-        else:
-            assert os.WEXITSTATUS(result) == 1
-
-    os.system("rm -f out.txt")
+    if grep_string and grep_present:
+        assert grep_string in process.stdout or grep_string in process.stderr
 
 
-# #################### Tests #############################
-
-def test_default_unit_no_quantity_warning(change_test_dir):
+def test_default_unit_no_quantity_warning(tmp_path):
     """
     If no quantity file is found it shall only inform about that
     """
-    run_unit("test.vspec", "-u ../test_units.yaml", "expected.json", "", True,
-             "No quantities defined")
-    run_unit("test.vspec", "-u ../test_units.yaml", "expected.json", "", False,
-             "Quantity length used by unit km has not been defined")
-    run_unit("test.vspec", "-u ../test_units.yaml", "expected.json", "", False,
-             "Quantity temperature used by unit celsius has not been defined")
+    run_unit(
+        tmp_path,
+        "test.vspec",
+        "-u ../test_units.yaml",
+        "expected.json",
+        "",
+        True,
+        "No quantities defined",
+    )
+    run_unit(
+        tmp_path,
+        "test.vspec",
+        "-u ../test_units.yaml",
+        "expected.json",
+        "",
+        False,
+        "Quantity length used by unit km has not been defined",
+    )
+    run_unit(
+        tmp_path,
+        "test.vspec",
+        "-u ../test_units.yaml",
+        "expected.json",
+        "",
+        False,
+        "Quantity temperature used by unit celsius has not been defined",
+    )
 
 
-def test_default_unit_quantities_missing(change_test_dir):
+def test_default_unit_quantities_missing(tmp_path):
     """
     If quantity file found it shall inform about missing quantities (once for each)
     """
-    run_unit("test.vspec", "-u ../test_units.yaml", "expected.json", "-q test_quantities.yaml", False,
-             "No quantities defined")
-    run_unit("test.vspec", "-u ../test_units.yaml", "expected.json", "-q test_quantities.yaml", True,
-             "Quantity length used by unit km has not been defined")
-    run_unit("test.vspec", "-u ../test_units.yaml", "expected.json", "-q test_quantities.yaml", True,
-             "Quantity temperature used by unit celsius has not been defined")
+    run_unit(
+        tmp_path,
+        "test.vspec",
+        "-u ../test_units.yaml",
+        "expected.json",
+        "-q test_quantities.yaml",
+        False,
+        "No quantities defined",
+    )
+    run_unit(
+        tmp_path,
+        "test.vspec",
+        "-u ../test_units.yaml",
+        "expected.json",
+        "-q test_quantities.yaml",
+        True,
+        "Quantity length used by unit km has not been defined",
+    )
+    run_unit(
+        tmp_path,
+        "test.vspec",
+        "-u ../test_units.yaml",
+        "expected.json",
+        "-q test_quantities.yaml",
+        True,
+        "Quantity temperature used by unit celsius has not been defined",
+    )
 
 
-def test_default_unit_quantities_ok(change_test_dir):
-    run_unit("test.vspec", "-u ../test_units.yaml", "expected.json", "-q ../test_quantities.yaml", False,
-             "No quantities defined")
-    run_unit("test.vspec", "-u ../test_units.yaml", "expected.json", "-q ../test_quantities.yaml", False,
-             "Quantity length used by unit km has not been defined")
-    run_unit("test.vspec", "-u ../test_units.yaml", "expected.json", "-q ../test_quantities.yaml", False,
-             "Quantity temperature used by unit celsius has not been defined")
+def test_default_unit_quantities_ok(tmp_path):
+    run_unit(
+        tmp_path,
+        "test.vspec",
+        "-u ../test_units.yaml",
+        "expected.json",
+        "-q ../test_quantities.yaml",
+        False,
+        "No quantities defined",
+    )
+    run_unit(
+        tmp_path,
+        "test.vspec",
+        "-u ../test_units.yaml",
+        "expected.json",
+        "-q ../test_quantities.yaml",
+        False,
+        "Quantity length used by unit km has not been defined",
+    )
+    run_unit(
+        tmp_path,
+        "test.vspec",
+        "-u ../test_units.yaml",
+        "expected.json",
+        "-q ../test_quantities.yaml",
+        False,
+        "Quantity temperature used by unit celsius has not been defined",
+    )

--- a/tests/vspec/test_units_no_quantity/test_units_no_quantity.py
+++ b/tests/vspec/test_units_no_quantity/test_units_no_quantity.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 # Copyright (c) 2023 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the
@@ -31,8 +29,7 @@ def run_unit(
     env = os.environ.copy()
     env["COLUMNS"] = "200"
     process = subprocess.run(
-        cmd.split(), capture_output=True, text=True, cwd=HERE, env=env)
-    assert process.returncode == 0
+        cmd.split(), capture_output=True, text=True, cwd=HERE, env=env, check=True)
     assert filecmp.cmp(out, HERE / expected_file)
 
     if grep_string and grep_present:


### PR DESCRIPTION
# About

Refactored tests mainly to make them independent of os specific tools and also to reduce complexity of cleaning up generated files:

- Not relying on os commands such as `grep`, `cat`, ...
- Using pytest's `tmp_path` and writing outputs to it instead of
  manually cleaning up artifacts
- Using `subprocess` instead of `os.system`
- Added `pytest-cov` and coverage infos as well as a coverage check > 90% in CI:

```
---------- coverage: platform darwin, python 3.11.9-final-0 ----------
Name                                                 Stmts   Miss  Cover   Missing
----------------------------------------------------------------------------------
src/vss_tools/__init__.py                                0      0   100%
src/vss_tools/vspec2binary.py                           11      1    91%   29
src/vss_tools/vspec2csv.py                              11      1    91%   29
src/vss_tools/vspec2ddsidl.py                           11      1    91%   29
src/vss_tools/vspec2franca.py                           11      1    91%   29
src/vss_tools/vspec2graphql.py                          11      1    91%   29
src/vss_tools/vspec2id.py                               11      1    91%   28
src/vss_tools/vspec2json.py                             11      1    91%   29
src/vss_tools/vspec2jsonschema.py                       11      1    91%   29
src/vss_tools/vspec2protobuf.py                         11      1    91%   29
src/vss_tools/vspec2yaml.py                             11      1    91%   29
src/vss_tools/vspec/__init__.py                        457     42    91%   33-36, 39, 65, 70, 95-96, 135-138, 167-169, 192, 206, 235, 254, 314, 648-655, 694, 707-714, 742, 752, 861-863, 900, 928, 964-965
src/vss_tools/vspec/loggingconfig.py                     4      0   100%
src/vss_tools/vspec/model/__init__.py                    0      0   100%
src/vss_tools/vspec/model/constants.py                 201      6    97%   106, 204-205, 227-231
src/vss_tools/vspec/model/exceptions.py                  9      1    89%   22
src/vss_tools/vspec/model/vsstree.py                   263     10    96%   111, 289-292, 383, 416, 478, 485, 564, 606-607
src/vss_tools/vspec/utils/__init__.py                    7      5    29%   16-23
src/vss_tools/vspec/utils/idgen_utils.py                25      0   100%
src/vss_tools/vspec/utils/stringstyle.py                 9      3    67%   16-18
src/vss_tools/vspec/utils/vss2id_val.py                 65      5    92%   134, 143-148, 158-159
src/vss_tools/vspec/vspec2vss_config.py                 10      0   100%
src/vss_tools/vspec/vspec2x.py                         106      4    96%   29-31, 174-175
src/vss_tools/vspec/vss2x.py                            11      1    91%   38
src/vss_tools/vspec/vssexporters/__init__.py             0      0   100%
src/vss_tools/vspec/vssexporters/vss2binary.py          88      7    92%   52, 94, 105, 109, 133-136
src/vss_tools/vspec/vssexporters/vss2csv.py             45      0   100%
src/vss_tools/vspec/vssexporters/vss2ddsidl.py         149     12    92%   67, 147-148, 160-162, 167, 176, 186, 237-238, 242
src/vss_tools/vspec/vssexporters/vss2franca.py          45      0   100%
src/vss_tools/vspec/vssexporters/vss2graphql.py         51      4    92%   105-109
src/vss_tools/vspec/vssexporters/vss2id.py              76      2    97%   120, 185
src/vss_tools/vspec/vssexporters/vss2json.py            69      1    99%   63
src/vss_tools/vspec/vssexporters/vss2jsonschema.py      79     31    61%   68, 71, 74-98, 101, 106, 109, 134-135, 142-145
src/vss_tools/vspec/vssexporters/vss2protobuf.py       117     14    88%   143, 147, 149-165
src/vss_tools/vspec/vssexporters/vss2yaml.py            70      3    96%   68-70
----------------------------------------------------------------------------------
TOTAL                                                 2066    161    92%
```