### PR TITLE
Use None as init value for node min/max

### DIFF
--- a/src/vss_tools/vspec/model/vsstree.py
+++ b/src/vss_tools/vspec/model/vsstree.py
@@ -79,8 +79,9 @@ class VSSNode(Node):
 
     unit: Optional[VSSUnit] = None
 
-    min = ""
-    max = ""
+    min: int | float | None = None
+    max: int | float | None = None
+
     allowed = ""
     instantiate = True
 

--- a/src/vss_tools/vspec/utils/idgen_utils.py
+++ b/src/vss_tools/vspec/utils/idgen_utils.py
@@ -13,8 +13,8 @@ def get_node_identifier_bytes(
     node_type: str,
     unit: str,
     allowed: str,
-    minimum: str,
-    maximum: str,
+    minimum: int | float | None,
+    maximum: int | float | None,
     strict_mode: bool,
 ) -> bytes:
     """Get a node identifier as bytes. Used as an input for hashing
@@ -36,8 +36,8 @@ def get_node_identifier_bytes(
         f"datatype: {data_type}, "
         f"type: {node_type}"
         f"allowed: {allowed}"
-        f"min: {minimum}"
-        f"max: {maximum}"
+        f"min: {minimum if minimum is not None else ''}"
+        f"max: {maximum if maximum is not None else ''}"
     ).encode()
 
     if strict_mode:
@@ -71,8 +71,8 @@ def fnv1_32_wrapper(name: str, source: dict, strict_mode: bool):
     """
     # Verify and assign values from source dictionary using source.get
     allowed: str = source.get("allowed", "")
-    minimum: str = source.get("min", "")
-    maximum: str = source.get("max", "")
+    minimum: int | float | None = source.get("min")
+    maximum: int | float | None = source.get("max")
     datatype: str = source.get("datatype", "")
     vsstype: str = source.get("type", "")
     unit: str = source.get("unit", "")

--- a/src/vss_tools/vspec/vssexporters/vss2binary.py
+++ b/src/vss_tools/vspec/vssexporters/vss2binary.py
@@ -78,11 +78,11 @@ def export_node(node, generate_uuid, out_file):
     b_nodedatatype = nodedatatype.encode('utf-8')
 
     # many optional attributes are initilized to "" in vsstree.py
-    if node.min != "":
+    if node.min is not None:
         nodemin = str(node.min)
     b_nodemin = nodemin.encode('utf-8')
 
-    if node.max != "":
+    if node.max is not None:
         nodemax = str(node.max)
     b_nodemax = nodemax.encode('utf-8')
 

--- a/src/vss_tools/vspec/vssexporters/vss2csv.py
+++ b/src/vss_tools/vspec/vssexporters/vss2csv.py
@@ -39,6 +39,8 @@ def print_csv_header(file, uuid, entry_type: AnyStr, include_instance_column: bo
 def format_csv_line(csv_fields):
     formatted_csv_line = ""
     for csv_field in csv_fields:
+        if csv_field is None:
+            csv_field = ""
         formatted_csv_line = formatted_csv_line + '"' + str(csv_field).replace('"', '""') + '",'
     return formatted_csv_line[:-1] + '\n'
 

--- a/src/vss_tools/vspec/vssexporters/vss2ddsidl.py
+++ b/src/vss_tools/vspec/vssexporters/vss2ddsidl.py
@@ -152,9 +152,9 @@ def export_node(node, generate_uuid, generate_all_idl_features):
         except AttributeError:
             pass
 
-        if node.min != "":
+        if node.min is not None:
             min = str(node.min)
-        if node.max != "":
+        if node.max is not None:
             max = str(node.max)
         if node.default != "":
             defaultValue = node.default

--- a/src/vss_tools/vspec/vssexporters/vss2franca.py
+++ b/src/vss_tools/vspec/vssexporters/vss2franca.py
@@ -65,9 +65,9 @@ def print_franca_content(file, tree, uuid):
                 output += f",\n\tuuid: \"{tree_node.uuid}\""
             if tree_node.has_unit():
                 output += f",\n\tunit: \"{tree_node.get_unit()}\""
-            if tree_node.min:
+            if tree_node.min is not None:
                 output += f",\n\tmin: {tree_node.min}"
-            if tree_node.max:
+            if tree_node.max is not None:
                 output += f",\n\tmax: {tree_node.max}"
             if tree_node.allowed:
                 output += f",\n\tallowed: {tree_node.allowed}"

--- a/src/vss_tools/vspec/vssexporters/vss2json.py
+++ b/src/vss_tools/vspec/vssexporters/vss2json.py
@@ -30,9 +30,9 @@ def export_node(json_dict, node, config, print_uuid):
     json_dict[node.name]["type"] = str(node.type.value)
 
     # many optional attributes are initilized to "" in vsstree.py
-    if node.min != "":
+    if node.min is not None:
         json_dict[node.name]["min"] = node.min
-    if node.max != "":
+    if node.max is not None:
         json_dict[node.name]["max"] = node.max
     if node.allowed != "":
         json_dict[node.name]["allowed"] = node.allowed

--- a/src/vss_tools/vspec/vssexporters/vss2jsonschema.py
+++ b/src/vss_tools/vspec/vssexporters/vss2jsonschema.py
@@ -58,9 +58,9 @@ def export_node(json_dict, node, config, print_uuid):
         json_dict[node.name]["type"] = type_map[node.data_type_str]
 
     # many optional attributes are initialized to "" in vsstree.py
-    if node.min != "":
+    if node.min is not None:
         json_dict[node.name]["minimum"] = node.min
-    if node.max != "":
+    if node.max is not None:
         json_dict[node.name]["maximum"] = node.max
     if node.allowed != "":
         json_dict[node.name]["enum"] = node.allowed

--- a/src/vss_tools/vspec/vssexporters/vss2yaml.py
+++ b/src/vss_tools/vspec/vssexporters/vss2yaml.py
@@ -35,9 +35,9 @@ def export_node(yaml_dict, node, config, print_uuid):
         yaml_dict[node_path]["datatype"] = node.get_datatype()
 
     # many optional attributes are initilized to "" in vsstree.py
-    if node.min != "":
+    if node.min is not None:
         yaml_dict[node_path]["min"] = node.min
-    if node.max != "":
+    if node.max is not None:
         yaml_dict[node_path]["max"] = node.max
     if node.allowed != "":
         yaml_dict[node_path]["allowed"] = node.allowed

--- a/tests/vspec/test_min_max/expected.franca
+++ b/tests/vspec/test_min_max/expected.franca
@@ -46,12 +46,14 @@ const SignalSpec[] signal_spec = [
 {	name: "A.IntMaxZero",
 	type: "sensor",
 	description: "Max Zero.",
-	datatype: "int8"
+	datatype: "int8",
+	max: 0
 },
 {	name: "A.IntMinZero",
 	type: "sensor",
 	description: "Min Zero.",
-	datatype: "int8"
+	datatype: "int8",
+	min: 0
 },
 {	name: "A.FloatNoMinMax",
 	type: "sensor",
@@ -80,21 +82,25 @@ const SignalSpec[] signal_spec = [
 {	name: "A.FloatMaxZero",
 	type: "sensor",
 	description: "Max Zero.",
-	datatype: "float"
+	datatype: "float",
+	max: 0.0
 },
 {	name: "A.FloatMinZero",
 	type: "sensor",
 	description: "Min Zero.",
-	datatype: "float"
+	datatype: "float",
+	min: 0.0
 },
 {	name: "A.FloatMaxZeroInt",
 	type: "sensor",
 	description: "Max Zero.",
-	datatype: "float"
+	datatype: "float",
+	max: 0
 },
 {	name: "A.FloatMinZeroInt",
 	type: "sensor",
 	description: "Min Zero.",
-	datatype: "float"
+	datatype: "float",
+	min: 0
 }
 ]


### PR DESCRIPTION
Fixes #354 

We can see that the franca exporter was buggy I think.

I also think more values could be refactored from initializing them with `""` and go with `None` instead.
