### PR TITLE
fix typo in vss2id.py

### DIFF
--- a/src/vss_tools/vspec/vssexporters/vss2id.py
+++ b/src/vss_tools/vspec/vssexporters/vss2id.py
@@ -166,7 +166,7 @@ class Vss2Id(Vss2X):
         @param signal_root: root of the signal tree
         @param print_uuid: Not used here but needed by main script
         """
-        log.info("Generating YAML output...")
+        log.info("Generating vspec output including static UIDs...")
 
         id_counter: int = 0
         signals_yaml_dict: Dict[str, str] = {}  # Use str for ID values


### PR DESCRIPTION
vss2id was logging "Generating YAML output" which was wrong, I updated it