### PR TITLE
Improve documentation/test of -e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,11 @@ From now on, if new units are needed for the VSS catalog they shall be added to 
 
 ## Implemented changes, to be released as part of VSS-Tools 5.0
 
+### Major restructure of repository structure and CLI
+
+The vss-tools repository content structure and CLI has changed significantly
+For more information see [vspec documentation](docs/vspec.md)
+
 ### Struct support in vspec2ddsidl
 
 The vspec2ddsidl tool now supports structs

--- a/docs/vspec.md
+++ b/docs/vspec.md
@@ -85,6 +85,10 @@ By default all tools expand instance information so that instance information li
 any other branch. If this argument is used and the exporter supports it no expansion will take place.
 Instead instance information will be kept as additional information for the branch.
 
+### -e, --extended-attributes
+
+See section on [overlays](vspec2x.md#handling-of-overlays-and-extensions) below
+
 ## Handling of Data Types
 
 COVESA supports a number of pre-defined types, see [VSS documentation](https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/data_types/).
@@ -306,11 +310,16 @@ Warning: Attribute(s) quality, source in element Speed not a core or known exten
 You asked for strict checking. Terminating.
 ```
 
-You can whitelist extended metadata attributes using the `-e` parameter:
+You can whitelist extended metadata attributes using the `-e` / `--extended-attributes` argument.
 
 ```bash
-vspec export json -I spec spec/VehicleSignalSpecification.vspec -e quality -e source -l overlay.vspec --output test.json
+vspec export json -I spec -s spec/VehicleSignalSpecification.vspec -e quality -e source -l overlay.vspec -o test.json
+vspec export json -I spec --vspec spec/VehicleSignalSpecification.vspec --extended-attributes quality --extended-attributes source --overlays overlay.vspec --output test.json
 ```
+
+> [!NOTE]
+> A comma separated list of attributes can no longer be used to specify extended attributes!
+> Instead of using for example `-e a1,a2` you must use `-e a1 -e a2`!
 
 In this case the expectation is, that the generated output will contain the whitelisted extended metadata attributes, if the exporter supports them.
 

--- a/src/vss_tools/vspec/cli_options.py
+++ b/src/vss_tools/vspec/cli_options.py
@@ -10,6 +10,16 @@ import rich_click as click
 from rich_click import option
 from pathlib import Path
 
+
+def no_colon_type(value):
+    """
+    Give error if comma is used in the argument
+    """
+    if "," in value:
+        raise click.BadParameter("Comma (',') not allowed")
+    return value
+
+
 log_level_opt = click.option(
     "--log-level",
     type=click.Choice(
@@ -39,6 +49,7 @@ extended_attributes_opt = option(
     "-e",
     multiple=True,
     help="Whitelisted extended attributes",
+    type=no_colon_type,
 )
 
 strict_opt = option(

--- a/tests/vspec/test_extended/test.vspec
+++ b/tests/vspec/test_extended/test.vspec
@@ -1,0 +1,19 @@
+# Copyright (c) 2024 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+A:
+  type: branch
+  description: Branch A.
+
+A.SignalA:
+  datatype: int8
+  type: sensor
+  unit: km
+  description: This is the first signal.
+  e1: First extension
+  e2: Second extension
+  e3: Third extension

--- a/tests/vspec/test_extended/test_extended.py
+++ b/tests/vspec/test_extended/test_extended.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2024 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import pytest
+import os
+from pathlib import Path
+import subprocess
+
+HERE = Path(__file__).resolve().parent
+TEST_UNITS = HERE / ".." / "test_units.yaml"
+TEST_FILE = HERE / "test.vspec"
+KNOWN_PREFIX = "Known extended attributes: "
+WARNING_PREFIX = "Attribute(s) "
+WARNING_SUFFIX = " in element SignalA not a core"
+
+
+@pytest.mark.parametrize(
+    "extended_args, known_extended, extended_warning",
+    [
+        ("", None, "e1, e2, e3"),
+        ("-e e1", "e1", "e2, e3"),
+        ("-e e1 -e e1", "e1, e1", "e2, e3"),  # Duplicated items presented as is
+        ("-e e1 -e e2", "e1, e2", "e3"),
+        ("-e e1 -e e2 -e e3", "e1, e2, e3", None),
+        ("-e e1 -e e2 -e e3 -e e2", "e1, e2, e3, e2", None),
+        ("-e e1 -e e2 -e e3 -e e4", "e1, e2, e3, e4", None),  # also ones that are not used (e4) are presented
+
+        # Some cases like above but using full name
+        ("--extended-attributes e1 --extended-attributes e2", "e1, e2", "e3"),
+        ("--extended-attributes e1 -e e2", "e1, e2", "e3"),
+        ("-e e1 --extended-attributes e2", "e1, e2", "e3"),
+    ],
+)
+def test_extended_ok(
+    extended_args: str, known_extended: str | None, extended_warning: str | None,
+    tmp_path
+):
+
+    output = tmp_path / "out.json"
+    cmd = (
+        f"vspec export json --pretty -u {TEST_UNITS} {extended_args} -s {TEST_FILE} -o {output}"
+    )
+
+    # Make sure there is no line break that affects compare
+    os.environ["COLUMNS"] = "120"
+
+    process = subprocess.run(cmd.split(), capture_output=True, check=True, text=True)
+    print(process.stdout)
+
+    if known_extended is not None:
+        check_str = KNOWN_PREFIX+known_extended+" "
+        assert check_str in process.stdout
+    else:
+        assert KNOWN_PREFIX not in process.stdout
+
+    if extended_warning:
+        assert (WARNING_PREFIX + extended_warning + WARNING_SUFFIX) in process.stdout
+    else:
+        assert WARNING_SUFFIX not in process.stdout
+
+
+@pytest.mark.parametrize(
+    "extended_args",
+    [
+        ("-e e1,e2"),
+        ("-e e1,e2,e3"),
+        ("-e e1,e2 -e e3"),
+
+        # Some cases like above but using full name
+        ("--extended-attributes e1,e2"),
+    ],
+)
+def test_extended_error(
+    extended_args: str,
+    tmp_path
+):
+
+    output = tmp_path / "out.json"
+    cmd = (
+        f"vspec export json --pretty -u {TEST_UNITS} {extended_args} -s {TEST_FILE} -o {output}"
+    )
+
+    # Make sure there is no line break that affects compare
+    os.environ["COLUMNS"] = "120"
+
+    process = subprocess.run(cmd.split(), stdout=subprocess.PIPE, text=True, stderr=subprocess.STDOUT)
+    assert process.returncode != 0
+    assert "not allowed" in process.stdout


### PR DESCRIPTION
Recent change for CLI change how `-e` must be used, like:

- Old: `-e a1,a2`
- New: `-e a1 -e a2`

As this is a backward incompatible change it might be good to give a warning. This PR assumes valid extra arguments ever contain a comma, and adds some tests

