### PR TITLE
Updating to 5.0a0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "vss-tools"
 homepage="https://github.com/COVESA/vss-tools"
 description='COVESA Vehicle Signal Specification tooling.'
 authors = ["COVESA VSS <covesa-dev@covesa.global>"]
-version = "4.2.0"
+version = "5.0a0"
 license = "Mozilla Public License 2.0"
 readme = ["README.md", "README-PYPI.md"]
 


### PR DESCRIPTION
Intended for creating a pypi alpha release for testing purposes, if someone wants to use the new `vspec` CLI without building from source.

I have locally created a PyPI release 5.0a1 based on this one and uploaded to pypi. Install by:

`pip install --pre vss-tools`

