### PR TITLE
🐛 Fixed null values from input vspecs being removed

### DIFF
--- a/vspec/__init__.py
+++ b/vspec/__init__.py
@@ -150,20 +150,6 @@ def load_flat_model(file_name, prefix, include_paths, tree_type: VSSTreeType):
         mapping = yaml.constructor.Constructor.construct_mapping(
             loader, node, deep=deep)
 
-        # Replace
-        # { 'Vehicle.Speed': { 'datatype': 'boolean', 'type': 'sensor' }}
-        # with
-        # { '$name$': 'Vehicle.Speed', 'datatype': 'boolean', 'type': 'sensor' }
-
-        for key, val in list(mapping.items()):
-            if key[0] == '$':
-                continue
-
-            if val is None:
-                mapping['$name$'] = key
-                del mapping[key]
-                break
-
         # Add line number and file name to element.
         if node.__line__ is not None:
             mapping['$line$'] = node.__line__


### PR DESCRIPTION
# About

That commented case does not really apply to what `mapping` actually contains.

However, the code that manipulates the mapping is problematic.

Example:
```yaml
Vehicle:
  type: branch
  description: Vehicle
  foo: ~
  bar: ~
```

Expected export result (of course with allowing those additional fields):
```yaml
Vehicle:
  bar: null
  description: Vehicle
  foo: null
  type: branch
```

Output of current `4.2`:
```yaml
Vehicle:
  bar: null
  description: Vehicle
  type: branch
```