### PR TITLE
🐞 Exporting null values of given extended attributes

### DIFF
--- a/src/vss_tools/vspec/tree.py
+++ b/src/vss_tools/vspec/tree.py
@@ -307,7 +307,7 @@ class VSSNode(Node):  # type: ignore[misc]
             log.warning(f"Attributes, violations={len(violations)}")
         return violations
 
-    def as_flat_dict(self, with_extra_attributes: bool) -> dict[str, Any]:
+    def as_flat_dict(self, with_extra_attributes: bool, extended_attributes: tuple[str, ...] = ()) -> dict[str, Any]:
         """
         Generates a flat dict and whether to include
         user attributes or not
@@ -316,7 +316,7 @@ class VSSNode(Node):  # type: ignore[misc]
         node: VSSNode
         for node in PreOrderIter(self):
             key = node.get_fqn()
-            data[key] = node.data.as_dict(with_extra_attributes)
+            data[key] = node.data.as_dict(with_extra_attributes, extended_attributes=extended_attributes)
             if node.uuid:
                 data[key]["uuid"] = node.uuid
         return data

--- a/src/vss_tools/vspec/vssexporters/vss2json.py
+++ b/src/vss_tools/vspec/vssexporters/vss2json.py
@@ -20,8 +20,8 @@ from vss_tools.vspec.main import get_trees
 from vss_tools.vspec.tree import VSSNode
 
 
-def get_data(node: VSSNode, with_extra_attributes: bool = True):
-    data = node.data.as_dict(with_extra_attributes)
+def get_data(node: VSSNode, with_extra_attributes: bool = True, extended_attributes: tuple[str, ...] = ()):
+    data = node.data.as_dict(with_extra_attributes, extended_attributes=extended_attributes)
     if node.uuid:
         data["uuid"] = node.uuid
     if len(node.children) > 0:
@@ -85,7 +85,7 @@ def cli(
     if pretty:
         indent = 2
 
-    signals_data = {tree.name: get_data(tree, extend_all_attributes)}
+    signals_data = {tree.name: get_data(tree, extend_all_attributes, extended_attributes)}
 
     if datatype_tree:
         types_data: dict[str, Any] = {datatype_tree.name: get_data(datatype_tree, extend_all_attributes)}

--- a/src/vss_tools/vspec/vssexporters/vss2yaml.py
+++ b/src/vss_tools/vspec/vssexporters/vss2yaml.py
@@ -95,10 +95,10 @@ def cli(
         expand=expand,
     )
     log.info("Generating YAML output...")
-    tree_data = tree.as_flat_dict(extend_all_attributes)
+    tree_data = tree.as_flat_dict(extend_all_attributes, extended_attributes)
 
     if datatype_tree:
-        datatype_tree_data = datatype_tree.as_flat_dict(extend_all_attributes)
+        datatype_tree_data = datatype_tree.as_flat_dict(extend_all_attributes, extended_attributes)
         if not types_output:
             log.info("Adding custom data types to signal dictionary")
             tree_data["ComplexDataTypes"] = datatype_tree_data

--- a/tests/vspec/test_null/expected.yaml
+++ b/tests/vspec/test_null/expected.yaml
@@ -1,0 +1,5 @@
+Vehicle:
+  bar: null
+  description: Vehicle
+  foo: null
+  type: branch

--- a/tests/vspec/test_null/test.vspec
+++ b/tests/vspec/test_null/test.vspec
@@ -1,0 +1,5 @@
+Vehicle:
+  description: Vehicle
+  type: branch
+  foo: null
+  bar: null

--- a/tests/vspec/test_null/test_null.py
+++ b/tests/vspec/test_null/test_null.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2022 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import subprocess
+from pathlib import Path
+
+import yaml
+
+HERE = Path(__file__).resolve().parent
+
+
+def run_exporter(exporter, tmp_path):
+    vspec = HERE / "test.vspec"
+    output = tmp_path / f"out.{exporter}"
+    expected = HERE / f"expected.{exporter}"
+    if not expected.exists():
+        return
+    cmd = f"vspec export {exporter} --vspec {vspec} --output {output} -e foo -e bar"
+    subprocess.run(cmd.split(), check=True)
+    with open(output) as f:
+        out_content = yaml.safe_load(f)
+    assert "foo" in out_content["Vehicle"]
+    assert "bar" in out_content["Vehicle"]
+    assert out_content["Vehicle"]["foo"] is None
+    assert out_content["Vehicle"]["bar"] is None
+
+
+def test_null(tmp_path):
+    exporters = ["yaml"]
+
+    for exporter in exporters:
+        run_exporter(exporter, tmp_path)


### PR DESCRIPTION
# About

Extended user attributes given with `-e` should always be exported, even if they contain `null` values. This was the case for the last release.
The recent core refactoring changed the behavior and filters all null values. Therefore this change here that handles extended attributes in a special way and not includes them.
This only concerns the `as_dict` method and methods using that (such as `as_flat_dict`). Exporters not using those methods have not been changed and might need to be updated aswell if users report problems.

Example vspec:
```yaml
Vehicle:
  type: branch
  description: Vehicle
  foo: ~
  bar: ~
```
Should result in the export (only when passing `-e foo -e bar`):
```yaml
Vehicle:
  bar: null
  description: Vehicle
  foo: null
  type: branch
```