### PR TITLE
⚙️ Added `is_instance` to branch attributes

### DIFF
--- a/src/vss_tools/vspec/model.py
+++ b/src/vss_tools/vspec/model.py
@@ -30,7 +30,7 @@ from vss_tools.vspec.datatypes import (
     resolve_datatype,
 )
 
-EXPORT_EXCLUDE_ATTRIBUTES = ["delete", "instantiate", "fqn", "arraysize", "aggregate"]
+EXPORT_EXCLUDE_ATTRIBUTES = ["delete", "instantiate", "fqn", "arraysize", "aggregate", "is_instance"]
 
 
 class ModelException(Exception):
@@ -117,6 +117,7 @@ class VSSData(VSSRaw):
 class VSSDataBranch(VSSData):
     instances: Any = None
     aggregate: bool = False
+    is_instance: bool = False
 
     @field_validator("instances")
     @classmethod

--- a/src/vss_tools/vspec/tree.py
+++ b/src/vss_tools/vspec/tree.py
@@ -436,6 +436,8 @@ def expand_instance(
             node = template.copy()
             node.name = name
             node.data.instances = []  # type: ignore
+            if isinstance(node.data, VSSDataBranch):
+                node.data.is_instance = True
             node.parent = root
             nodes.append(node)
             node.children = []

--- a/tests/vspec/test_isinstance/test.vspec
+++ b/tests/vspec/test_isinstance/test.vspec
@@ -1,0 +1,13 @@
+Vehicle:
+  description: Vehicle
+  type: branch
+
+Vehicle.Door:
+  description: Door
+  type: branch
+  instances:
+  - Row[1,2]
+
+Vehicle.Door.Row1.Special:
+  description: Special
+  type: branch

--- a/tests/vspec/test_isinstance/test_isinstance.py
+++ b/tests/vspec/test_isinstance/test_isinstance.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2022 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+from pathlib import Path
+
+from vss_tools.vspec.main import get_trees
+
+HERE = Path(__file__).resolve().parent
+
+
+def test_exporters():
+    tree, _ = get_trees(
+        vspec=HERE / "test.vspec",
+    )
+    door = tree.children[0]
+    row1 = door.children[0]
+    assert row1.data.is_instance
+    door.children[1]
+    assert row1.data.is_instance
+    special = row1.children[0]
+    assert not special.data.is_instance


### PR DESCRIPTION
The info might be of interest to exporters and I think it makes sense to have that info in the internal tree

Related: https://github.com/COVESA/vehicle_signal_specification/issues/749

Example:
```yaml
Vehicle:
  type: branch
  description: Vehicle

Vehicle.Door:
  description: Door
  type: branch
  instances:
  - Row[1,2]

Vehicle.Door.Row1.Window:
  type: branch
  description: Window
```

`vspec export tree -s test.vspec.yaml --attr is_instance`:
```
Vehicle
is_instance=False
└── Door
    is_instance=False
    ├── Row1
    │   is_instance=True
    │   └── Window
    │       is_instance=False
    └── Row2
        is_instance=True
```