### PR TITLE
📦 Creating nightly release on master push

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -1,0 +1,42 @@
+name: wheel
+
+on:
+  push:
+    branches: [master]
+
+env:
+  PYTHON_VERSION: "3.10.6"
+  CI: 1 # shall any script needs to know if it's running in the CI
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout vss-tools
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: pip
+      - name: Install poetry
+        uses: abatilo/actions-poetry@v2
+        with:
+          poetry-version: "1.8.3"
+      - name: Poetry build
+        run: poetry build
+      - name: Rename Wheel
+        run: |
+          set -e
+          cd dist
+          old_wheel_name=$(ls *.whl)
+          new_wheel_name=$(echo $old_wheel_name | sed -nr 's/(vss_tools)-([^-]*)-(.*)/\1-nightly-\3/p')
+          mv "$old_wheel_name" "$new_wheel_name"
+          echo "File renamed from $old_wheel_name to $new_wheel_name"
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: true
+          tag_name: nightly
+          files: dist/*.whl
+          fail_on_unmatched_files: true


### PR DESCRIPTION
Creating a gh-release tagged as `nightly` with `*.whl` added as asset on every master push.
Even it is not built nightly but on a master push, `nightly` represents best what the content is. The latest master branch as a wheel.
If we want to get a bit cleaner here I would vote for maintaining CHANGELOG.md on every PR and bumping the version in `pyproject.toml` accordingly based on the change that has been done. Then we can create real pre-releases for every version ending on master.

The latest nightly wheel can then be downloaded via:
```bash
curl -L https://github.com/COVESA/vss-tools/releases/download/nightly/vss_tools-nightly-py3-none-any.whl -O
```

![image](https://github.com/user-attachments/assets/dc6ce01b-72b9-4345-8428-456ae64cac87)
