### PR TITLE
Removing uuid feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ It includes changes that are included in released version, but also changes plan
 *This document only contain changes introduced in VSS-Tools 3.0 or later!*
 
 
-## Planned changes for VSS-Tools 6.0
+## Implemented changes for VSS-Tools 6.0
 
 ### Change in UUID handling.
 
@@ -16,6 +16,8 @@ the legacy uuid functionality.
 
 * The parameters `--uuid`/`--no-uuid` are now removed.
 
+Columns (or similar) for UUID in generated output has also been removed.
+An exception is binary output which still contain a byte for UUID, however always 0.
 
 ## VSS-Tools 5.0
 

--- a/docs/ddsidl.md
+++ b/docs/ddsidl.md
@@ -48,12 +48,12 @@ Below elements are considered only if the switch `--all-idl-features` is supplie
 ### Input VSS block with "arraysize" attribute
 | VSS    | DDS-IDL         |
 |--------|----------------|
-| <pre>Safety.SpeedLimit:<br>    datatype : float[]<br>    arraysize: 5<br>    type: actuator<br>    unit: m/s<br>    description: Maximum allowed speed of the vehicle</pre>  | <pre>struct SpeedLimit{<br>string uuid;<br>sequence&lt;float&gt; value;<br>}<br></pre>          |
+| <pre>Safety.SpeedLimit:<br>    datatype : float[]<br>    arraysize: 5<br>    type: actuator<br>    unit: m/s<br>    description: Maximum allowed speed of the vehicle</pre>  | <pre>struct SpeedLimit{<br>sequence&lt;float&gt; value;<br>}<br></pre>          |
 ### Input VSS block with "allowed" attribute
 
 | VSS    | DDS-IDL         |
 |--------|----------------|
-| <pre>Direction:<br> datatype:string<br> type: actuator<br> allowed: ['FORWARD','BACKWARD']<br> description: Driving direction of the vehicle</pre>  | <pre>module Direction_M {<br>enum DirectionValues{FORWARD,BACKWARD};<br>};<br>struct Direction<br>{<br>string uuid;<br>DirectionValues value;<br>};</pre>
+| <pre>Direction:<br> datatype:string<br> type: actuator<br> allowed: ['FORWARD','BACKWARD']<br> description: Driving direction of the vehicle</pre>  | <pre>module Direction_M {<br>enum DirectionValues{FORWARD,BACKWARD};<br>};<br>struct Direction<br>{<br>DirectionValues value;<br>};</pre>
 
 To comply with DDS-IDL rules and limitations in IDL compilers VSS string literals that start with a digit will get a `d` as prefix.
 

--- a/docs/id.md
+++ b/docs/id.md
@@ -25,7 +25,6 @@ identifiers.
 │                                                               [default: no-strict]                         │
 │    --aborts               -a  [unknown-attribute|name-style]  Abort on selected option. The '--strict'     │
 │                                                               option enables all of them.                  │
-│    --uuid/--no-uuid                                           Whether to add UUIDs. [default: no-uuid]     │
 │    --expand/--no-expand                                       Whether to expand the tree.                  │
 │                                                               [default: expand]                            │
 │    --overlays             -l  FILE                            Overlay files to apply on top of the vspec.  │

--- a/docs/vspec.md
+++ b/docs/vspec.md
@@ -81,16 +81,6 @@ Terminates parsing, when the name of a signal does not follow [VSS Naming Conven
 ### --strict/--no-strict
 Enables `--aborts unknown-attribute` and `--aborts name-style`
 
-### --uuid/--no-uuid
-Request the exporter to output UUIDs. The UUID generated is an RFC 4122 Version 5 UUID created from the qualified name
-of the node and the UUID of the namespace `vehicle_signal_specification`.
-
-Note that not all exporters support that arugment
-
-> [!WARNING]
-> The UUID feature is deprecated and will be removed in VSS-tools 6.0.
-> If you need identifiers consider using [vspec id exporter](id.md)
-
 ### --expand/--no-expand
 
 By default all tools expand instance information so that instance information like "Row1" become a branch just like
@@ -359,7 +349,6 @@ Lets the exporter generate _all_ extended metadata attributes found in the model
 | deprecation   | x-deprecation |
 | aggregate     | x-aggregate   |
 | comment       | x-comment     |
-| uuid          | x-uuid        |
 
 Not that strict JSON schema validators might not accept jsonschemas with such extra, non-standard entries.
 
@@ -381,12 +370,6 @@ If the paramter is set it will pretty-print the JSON output, otherwise you will 
 
 ### --extended-all-attributes
 Lets the exporter generate _all_ extended metadata attributes found in the model. By default the exporter is generating only those given by the `-e`/`--extended-attributes` parameter.
-
-## DDS-IDL exporter notes
-The DDS-IDL exporter never generates uuid, i.e. the `--uuid` option has no effect.
-
-## Graphql exporter notes
-The Graphql exporter never generates uuid, i.e. the `--uuid` option has no effect.
 
 ### --all-idl-features
 Will also generate non-payload const attributes such as unit/datatype. Default is not to generate them/comment them out because at least Cyclone DDS and FastDDS do not support const. For more information check the [DDS-IDL exporter docs](ddsidl.md).

--- a/src/vss_tools/cli_options.py
+++ b/src/vss_tools/cli_options.py
@@ -72,8 +72,6 @@ aborts_opt = option(
     show_choices=True,
 )
 
-uuid_opt = option("--uuid/--no-uuid", help="Whether to add UUIDs.", show_default=True, default=False)
-
 expand_opt = option(
     "--expand/--no-expand",
     default=True,

--- a/src/vss_tools/exporters/apigear.py
+++ b/src/vss_tools/exporters/apigear.py
@@ -445,7 +445,6 @@ def export_apigear(
 @clo.extended_attributes_opt
 @clo.strict_opt
 @clo.aborts_opt
-@clo.uuid_opt
 @clo.overlays_opt
 @clo.quantities_opt
 @clo.units_opt
@@ -482,7 +481,6 @@ def cli(
     extended_attributes: tuple[str],
     strict: bool,
     aborts: tuple[str],
-    uuid: bool,
     overlays: tuple[Path],
     quantities: tuple[Path],
     units: tuple[Path],
@@ -502,7 +500,6 @@ def cli(
         aborts=aborts,
         strict=strict,
         extended_attributes=extended_attributes,
-        uuid=uuid,
         quantities=quantities,
         units=units,
         types=types,

--- a/src/vss_tools/exporters/binary.py
+++ b/src/vss_tools/exporters/binary.py
@@ -19,7 +19,7 @@
 # The order of fields (where each field is composed of
 # fieldlength + fielddata) is:
 #
-# name (vsspath), type, uuid, description, datatype, min, max, unit,
+# name (vsspath), type, description, datatype, min, max, unit,
 # allowed, default, validate
 #
 # if a field is not present (e.g. min, max, unit, allowed, default, validate),
@@ -73,16 +73,13 @@ def create_l16v_string(s: str) -> bytes:
     return pack
 
 
-def export_node(node: VSSNode, generate_uuid, f: BinaryIO):
+def export_node(node: VSSNode, f: BinaryIO):
     data = node.get_vss_data().as_dict()
 
     f.write(create_l8v_string(node.name))
     f.write(create_l8v_string(data.get("type", "")))
-    if node.uuid is None:
-        log.debug(("No UUID for node %s", node.name))
-        f.write(struct.pack("B", 0))
-    else:
-        f.write(create_l8v_string(node.uuid))
+    # Keeping UUID field in output for now (always 0)
+    f.write(struct.pack("B", 0))
 
     f.write(create_l16v_string(data.get("description", "")))
     f.write(create_l8v_string(data.get("datatype", "")))
@@ -101,7 +98,7 @@ def export_node(node: VSSNode, generate_uuid, f: BinaryIO):
     f.write(struct.pack("B", len(node.children)))
 
     for child in node.children:
-        export_node(child, generate_uuid, f)
+        export_node(child, f)
 
 
 @click.command()
@@ -111,7 +108,6 @@ def export_node(node: VSSNode, generate_uuid, f: BinaryIO):
 @clo.extended_attributes_opt
 @clo.strict_opt
 @clo.aborts_opt
-@clo.uuid_opt
 @clo.overlays_opt
 @clo.quantities_opt
 @clo.units_opt
@@ -122,7 +118,6 @@ def cli(
     extended_attributes: tuple[str],
     strict: bool,
     aborts: tuple[str],
-    uuid: bool,
     overlays: tuple[Path],
     quantities: tuple[Path],
     units: tuple[Path],
@@ -137,12 +132,11 @@ def cli(
         aborts=aborts,
         strict=strict,
         extended_attributes=extended_attributes,
-        uuid=uuid,
         quantities=quantities,
         units=units,
         overlays=overlays,
     )
     log.info("Generating binary output...")
     with open(str(output), "wb") as f:
-        export_node(tree, uuid, f)
+        export_node(tree, f)
     log.info("Binary output generated in %s", output)

--- a/src/vss_tools/exporters/ddsidl.py
+++ b/src/vss_tools/exporters/ddsidl.py
@@ -187,7 +187,7 @@ dataTypesMap_covesa_dds = {
 }
 
 
-def export_node(node: VSSNode, generate_uuid: bool, generate_all_idl_features: bool) -> None:
+def export_node(node: VSSNode, generate_all_idl_features: bool) -> None:
     """
     This method is used to traverse VSS node and to create corresponding DDS IDL buffer string
     """
@@ -199,7 +199,7 @@ def export_node(node: VSSNode, generate_uuid: bool, generate_all_idl_features: b
         idl_file_buffer.append("module " + getAllowedName(node.name))
         idl_file_buffer.append("{")
         for child in node.children:
-            export_node(child, generate_uuid, generate_all_idl_features)
+            export_node(child, generate_all_idl_features)
         idl_file_buffer.append("};")
         idl_file_buffer.append("")
     else:
@@ -233,8 +233,6 @@ def export_node(node: VSSNode, generate_uuid: bool, generate_all_idl_features: b
 
         idl_file_buffer.append("struct " + getAllowedName(node.name))
         idl_file_buffer.append("{")
-        if generate_uuid:
-            idl_file_buffer.append("string uuid;")
         # fetching value of datatype and obtaining the equivalent DDS type
         try:
             if datatype:
@@ -372,11 +370,11 @@ class StructExporter(object):
         self.str_buf += suffix
 
 
-def export_idl(file, root, generate_uuids=True, generate_all_idl_features=False):
+def export_idl(file, root, generate_all_idl_features=False):
     """This method is used to traverse through the root VSS node to build
     -> DDS IDL equivalent string buffer and to serialize it acccordingly into a file
     """
-    export_node(root, generate_uuids, generate_all_idl_features)
+    export_node(root, generate_all_idl_features)
     file.write("\n".join(idl_file_buffer))
     log.info("IDL file generated at location : " + file.name)
 
@@ -388,7 +386,6 @@ def export_idl(file, root, generate_uuids=True, generate_all_idl_features=False)
 @clo.extended_attributes_opt
 @clo.strict_opt
 @clo.aborts_opt
-@clo.uuid_opt
 @clo.overlays_opt
 @clo.quantities_opt
 @clo.units_opt
@@ -405,7 +402,6 @@ def cli(
     extended_attributes: tuple[str],
     strict: bool,
     aborts: tuple[str],
-    uuid: bool,
     overlays: tuple[Path],
     quantities: tuple[Path],
     units: tuple[Path],
@@ -421,7 +417,6 @@ def cli(
         aborts=aborts,
         strict=strict,
         extended_attributes=extended_attributes,
-        uuid=uuid,
         quantities=quantities,
         units=units,
         types=types,
@@ -438,6 +433,5 @@ def cli(
         export_idl(
             idl_out,
             tree,
-            uuid,
             all_idl_features,
         )

--- a/src/vss_tools/exporters/franca.py
+++ b/src/vss_tools/exporters/franca.py
@@ -48,7 +48,7 @@ const SignalSpec[] signal_spec = [
 
 
 # Write the data lines
-def print_franca_content(file: TextIOWrapper, root: VSSNode, with_uuid: bool) -> None:
+def print_franca_content(file: TextIOWrapper, root: VSSNode) -> None:
     output = ""
     node: VSSNode
     for node in PreOrderIter(root):
@@ -64,8 +64,6 @@ def print_franca_content(file: TextIOWrapper, root: VSSNode, with_uuid: bool) ->
             datatype = getattr(data, "datatype", None)
             if datatype:
                 output += f',\n\tdatatype: "{datatype}"'
-            if with_uuid:
-                output += f',\n\tuuid: "{node.uuid}"'
             unit = getattr(data, "unit", None)
             if unit:
                 output += f',\n\tunit: "{unit}"'
@@ -89,7 +87,6 @@ def print_franca_content(file: TextIOWrapper, root: VSSNode, with_uuid: bool) ->
 @clo.extended_attributes_opt
 @clo.strict_opt
 @clo.aborts_opt
-@clo.uuid_opt
 @clo.overlays_opt
 @clo.quantities_opt
 @clo.units_opt
@@ -101,7 +98,6 @@ def cli(
     extended_attributes: tuple[str],
     strict: bool,
     aborts: tuple[str],
-    uuid: bool,
     overlays: tuple[Path],
     quantities: tuple[Path],
     units: tuple[Path],
@@ -117,12 +113,11 @@ def cli(
         aborts=aborts,
         strict=strict,
         extended_attributes=extended_attributes,
-        uuid=uuid,
         quantities=quantities,
         units=units,
         overlays=overlays,
     )
     with open(output, "w") as f:
         print_franca_header(f, franca_vss_version)
-        print_franca_content(f, tree, uuid)
+        print_franca_content(f, tree)
         f.write("\n]")

--- a/src/vss_tools/exporters/id.py
+++ b/src/vss_tools/exporters/id.py
@@ -140,7 +140,6 @@ def export_node(data: dict[str, Any], node: VSSNode, id_counter, strict_mode: bo
 @clo.extended_attributes_opt
 @clo.strict_opt
 @clo.aborts_opt
-@clo.uuid_opt
 @clo.expand_opt
 @clo.overlays_opt
 @clo.quantities_opt
@@ -164,7 +163,6 @@ def cli(
     extended_attributes: tuple[str],
     strict: bool,
     aborts: tuple[str],
-    uuid: bool,
     expand: bool,
     overlays: tuple[Path],
     quantities: tuple[Path],
@@ -183,7 +181,6 @@ def cli(
         aborts=aborts,
         strict=strict,
         extended_attributes=extended_attributes,
-        uuid=uuid,
         quantities=quantities,
         units=units,
         types=types,
@@ -207,7 +204,6 @@ def cli(
             aborts=aborts,
             strict=strict,
             extended_attributes=extended_attributes,
-            uuid=uuid,
             quantities=quantities,
             units=units,
             types=types,

--- a/src/vss_tools/exporters/json.py
+++ b/src/vss_tools/exporters/json.py
@@ -22,8 +22,6 @@ from vss_tools.tree import VSSNode
 
 def get_data(node: VSSNode, with_extra_attributes: bool = True, extended_attributes: tuple[str, ...] = ()):
     data = node.data.as_dict(with_extra_attributes, extended_attributes=extended_attributes)
-    if node.uuid:
-        data["uuid"] = node.uuid
     if len(node.children) > 0:
         data["children"] = {}
     for child in node.children:
@@ -38,7 +36,6 @@ def get_data(node: VSSNode, with_extra_attributes: bool = True, extended_attribu
 @clo.extended_attributes_opt
 @clo.strict_opt
 @clo.aborts_opt
-@clo.uuid_opt
 @clo.expand_opt
 @clo.overlays_opt
 @clo.quantities_opt
@@ -54,7 +51,6 @@ def cli(
     extended_attributes: tuple[str],
     strict: bool,
     aborts: tuple[str],
-    uuid: bool,
     expand: bool,
     overlays: tuple[Path],
     quantities: tuple[Path],
@@ -73,7 +69,6 @@ def cli(
         aborts=aborts,
         strict=strict,
         extended_attributes=extended_attributes,
-        uuid=uuid,
         quantities=quantities,
         units=units,
         types=types,

--- a/src/vss_tools/exporters/jsonschema.py
+++ b/src/vss_tools/exporters/jsonschema.py
@@ -52,7 +52,6 @@ type_map = {
 def export_node(
     json_dict,
     node: VSSNode,
-    print_uuid: bool,
     all_extended_attributes: bool,
     no_additional_properties: bool,
     require_all_properties: bool,
@@ -108,9 +107,6 @@ def export_node(
         if data.comment:
             json_dict[node.name]["x-comment"] = data.comment
 
-        if print_uuid:
-            json_dict[node.name]["x-uuid"] = node.uuid
-
     for field in data.get_extra_attributes():
         json_dict[node.name][field] = getattr(data, field)
 
@@ -125,7 +121,6 @@ def export_node(
             export_node(
                 json_dict[node.name]["properties"],
                 child,
-                print_uuid,
                 all_extended_attributes,
                 no_additional_properties,
                 require_all_properties,
@@ -139,7 +134,6 @@ def export_node(
 @clo.extended_attributes_opt
 @clo.strict_opt
 @clo.aborts_opt
-@clo.uuid_opt
 @clo.expand_opt
 @clo.overlays_opt
 @clo.quantities_opt
@@ -164,7 +158,6 @@ def cli(
     extended_attributes: tuple[str],
     strict: bool,
     aborts: tuple[str],
-    uuid: bool,
     expand: bool,
     overlays: tuple[Path],
     quantities: tuple[Path],
@@ -184,7 +177,6 @@ def cli(
         aborts=aborts,
         strict=strict,
         extended_attributes=extended_attributes,
-        uuid=uuid,
         quantities=quantities,
         units=units,
         types=types,
@@ -201,7 +193,6 @@ def cli(
     export_node(
         signals_json_schema,
         tree,
-        uuid,
         extend_all_attributes,
         no_additional_properties,
         require_all_properties,
@@ -213,7 +204,6 @@ def cli(
         export_node(
             data_types_json_schema,
             datatype_tree,
-            uuid,
             extend_all_attributes,
             no_additional_properties,
             require_all_properties,

--- a/src/vss_tools/exporters/samm/__init__.py
+++ b/src/vss_tools/exporters/samm/__init__.py
@@ -153,7 +153,6 @@ Path to or name for the target folder, where generated aspect models (.ttl files
 @clo.extended_attributes_opt
 @clo.strict_opt
 @clo.aborts_opt
-@clo.uuid_opt
 @clo.overlays_opt
 @clo.quantities_opt
 @clo.units_opt
@@ -166,7 +165,6 @@ def cli(
     extended_attributes: tuple[str],
     strict: bool,
     aborts: tuple[str],
-    uuid: bool,
     overlays: tuple[Path],
     quantities: tuple[Path],
     units: tuple[Path],
@@ -191,7 +189,7 @@ def cli(
     #       Just keep in mind that this might lead to some additional logic,
     #       to make sure that each case is handled correctly.
     vss_tree, datatype_tree = get_trees(
-        vspec, include_dirs, aborts, strict, extended_attributes, uuid, quantities, units, types, overlays, False
+        vspec, include_dirs, aborts, strict, extended_attributes, quantities, units, types, overlays, False
     )
 
     # Get the VSS version from the vss_tree::VersionVSS

--- a/src/vss_tools/exporters/tree.py
+++ b/src/vss_tools/exporters/tree.py
@@ -39,7 +39,6 @@ def get_rendered_tree(tree: VSSNode, attributes: tuple[str]) -> str:
 @clo.extended_attributes_opt
 @clo.strict_opt
 @clo.aborts_opt
-@clo.uuid_opt
 @clo.expand_opt
 @clo.overlays_opt
 @clo.quantities_opt
@@ -52,7 +51,6 @@ def cli(
     extended_attributes: tuple[str],
     strict: bool,
     aborts: tuple[str],
-    uuid: bool,
     expand: bool,
     overlays: tuple[Path],
     quantities: tuple[Path],
@@ -70,7 +68,6 @@ def cli(
         aborts=aborts,
         strict=strict,
         extended_attributes=extended_attributes,
-        uuid=uuid,
         quantities=quantities,
         units=units,
         types=types,

--- a/src/vss_tools/exporters/yaml.py
+++ b/src/vss_tools/exporters/yaml.py
@@ -54,7 +54,6 @@ class NoAliasDumper(yaml.SafeDumper):
 @clo.extended_attributes_opt
 @clo.strict_opt
 @clo.aborts_opt
-@clo.uuid_opt
 @clo.expand_opt
 @clo.overlays_opt
 @clo.quantities_opt
@@ -69,7 +68,6 @@ def cli(
     extended_attributes: tuple[str],
     strict: bool,
     aborts: tuple[str],
-    uuid: bool,
     expand: bool,
     overlays: tuple[Path],
     quantities: tuple[Path],
@@ -87,7 +85,6 @@ def cli(
         aborts=aborts,
         strict=strict,
         extended_attributes=extended_attributes,
-        uuid=uuid,
         quantities=quantities,
         units=units,
         types=types,

--- a/src/vss_tools/main.py
+++ b/src/vss_tools/main.py
@@ -188,7 +188,6 @@ def get_trees(
     aborts: tuple[str, ...] = (),
     strict: bool = False,
     extended_attributes: tuple[str, ...] = (),
-    uuid: bool = False,
     quantities: tuple[Path, ...] = (),
     units: tuple[Path, ...] = (),
     types: tuple[Path, ...] = (),
@@ -227,10 +226,6 @@ def get_trees(
 
     if expand:
         root.expand_instances()
-
-    if uuid:
-        log.warning("UUID support is deprecated and will be removed in VSS-tools 6.0")
-        root.add_uuids()
 
     try:
         root.resolve()

--- a/src/vss_tools/tree.py
+++ b/src/vss_tools/tree.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 import re
-import uuid
 from copy import deepcopy
 from typing import Any
 
@@ -63,7 +62,6 @@ class VSSNode(Node):  # type: ignore[misc]
     def __init__(self, name: str, fqn: str | None, data: dict[str, Any], **kwargs: Any) -> None:
         super().__init__(name, **kwargs)
         self.data = get_vss_raw(data, fqn)
-        self.uuid: str | None = None
 
     def copy(self) -> VSSNode:
         node = VSSNode(
@@ -141,13 +139,6 @@ class VSSNode(Node):  # type: ignore[misc]
                 match.merge(child)
             else:
                 child.parent = self
-
-    def add_uuids(self) -> None:
-        VSS_NAMESPACE = "vehicle_signal_specification"
-        namespace_uuid = uuid.uuid5(uuid.NAMESPACE_OID, VSS_NAMESPACE)
-        node: VSSNode
-        for node in PreOrderIter(self):
-            node.uuid = uuid.uuid5(namespace_uuid, node.get_fqn()).hex
 
     def get_instance_nodes(self) -> tuple[VSSNode, ...]:
         return findall(
@@ -317,8 +308,6 @@ class VSSNode(Node):  # type: ignore[misc]
         for node in PreOrderIter(self):
             key = node.get_fqn()
             data[key] = node.data.as_dict(with_extra_attributes, extended_attributes=extended_attributes)
-            if node.uuid:
-                data[key]["uuid"] = node.uuid
         return data
 
 


### PR DESCRIPTION
This would be the last step in removing the old UUID functionality. I have generally tried to remove UUID support in all tools, i.e. fields/columns with UUID are removed. One exception though - I am keeping the UUID byte for binary output as I believes tools using that format (VISSR) could have difficult handling a changd format.

What I would like to bring up in a VSS meeting

- Are we (finally) ready to do this?
- Would the changes in this PR be problematic for anyone (we can like currently for binary keep a column/field even if value always remain zero/null/empty)
