### PR TITLE
Fix usage of default

### DIFF
--- a/src/vss_tools/model.py
+++ b/src/vss_tools/model.py
@@ -198,6 +198,14 @@ class VSSDataDatatype(VSSData):
         is consistent with the given datatype
         """
         if self.default is not None:
+            if Datatypes.get_type(self.datatype) is None:
+                # Default for custom datatypes only allowed for the special case that the datatype is an array
+                # and the default value is []
+                # See rules at https://github.com/COVESA/vehicle_signal_specification/blob/master/docs-gen/content/rule_set/data_entry/data_types_struct.md#default-values # noqa: E501
+                assert (
+                    self.datatype.endswith("[]") and not self.default
+                ), f"Default values not allowed for user defined type '{self.datatype}'"
+
             if is_array(self.datatype):
                 assert isinstance(
                     self.default, list

--- a/tests/vspec/test_faulty_vspec_format/test_faulty_vspec_format.py
+++ b/tests/vspec/test_faulty_vspec_format/test_faulty_vspec_format.py
@@ -26,7 +26,8 @@ TEST_QUANT = HERE / ".." / "test_quantities.yaml"
 def test_error(tmp_path, filename, error):
     spec = HERE / filename
     output = tmp_path / "out.json"
-    cmd = f"vspec export json -u {TEST_UNITS} -q {TEST_QUANT} --vspec {spec} --output {output}"
+    log = tmp_path / "log.txt"
+    cmd = f"vspec --log-file {log} export json -u {TEST_UNITS} -q {TEST_QUANT} --vspec {spec} --output {output}"
     process = subprocess.run(cmd.split(), capture_output=True, text=True)
     assert process.returncode != 0
-    assert error in process.stdout
+    assert error in log.read_text() or error in process.stderr

--- a/tests/vspec/test_structs/test_data_type_parsing.py
+++ b/tests/vspec/test_structs/test_data_type_parsing.py
@@ -364,18 +364,17 @@ def test_error_default_for_struct(tmp_path, file):
     vspec = HERE / file
     types_file = HERE / "VehicleDataTypes.vspec"
     out = tmp_path / "out.json"
+    log = tmp_path / "log.txt"
     cmd = (
-        f"vspec export json -u {TEST_UNITS} -q {TEST_QUANT} --pretty --vspec {vspec} "
+        f"vspec --log-file {log} export json -u {TEST_UNITS} -q {TEST_QUANT} --pretty --vspec {vspec} "
         f"--output {out} --types {types_file}"
     )
-    env = os.environ.copy()
-    env["COLUMNS"] = "200"
-    process = subprocess.run(cmd.split(), capture_output=True, text=True, env=env)
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
     assert process.returncode != 0
 
     # Only checking first of type name to be able to handle both test cases
     error_msg = "Default values not allowed for user defined type 'VehicleDataTypes.TestBranch1.ParentStruct"
-    assert error_msg in process.stdout
+    assert error_msg in log.read_text() or error_msg in process.stderr
 
 
 def test_error_default_for_struct_array_empty(tmp_path):
@@ -385,11 +384,10 @@ def test_error_default_for_struct_array_empty(tmp_path):
     vspec = HERE / "test_struct_default_array_empty.vspec"
     types_file = HERE / "VehicleDataTypes.vspec"
     out = tmp_path / "out.json"
+    log = tmp_path / "log.txt"
     cmd = (
-        f"vspec export json -u {TEST_UNITS} -q {TEST_QUANT} --pretty --vspec {vspec} "
+        f"vspec --log-file {log} export json -u {TEST_UNITS} -q {TEST_QUANT} --pretty --vspec {vspec} "
         + f"--output {out} --types {types_file}"
     )
-    env = os.environ.copy()
-    env["COLUMNS"] = "200"
-    process = subprocess.run(cmd.split(), capture_output=True, text=True, env=env)
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
     assert process.returncode == 0

--- a/tests/vspec/test_structs/test_data_type_parsing.py
+++ b/tests/vspec/test_structs/test_data_type_parsing.py
@@ -354,3 +354,42 @@ def test_data_types_for_multiple_apigear_templates(tmp_path):
     expected_output = HERE / "out.apigear"
     dcmp = filecmp.dircmp(out, expected_output)
     assert not (dcmp.diff_files or dcmp.left_only or dcmp.right_only)
+
+
+@pytest.mark.parametrize("file", ["test_struct_default.vspec", "test_struct_default_array.vspec"])
+def test_error_default_for_struct(tmp_path, file):
+    """
+    Test that we get an error if trying to use default for struct
+    """
+    vspec = HERE / file
+    types_file = HERE / "VehicleDataTypes.vspec"
+    out = tmp_path / "out.json"
+    cmd = (
+        f"vspec export json -u {TEST_UNITS} -q {TEST_QUANT} --pretty --vspec {vspec} "
+        f"--output {out} --types {types_file}"
+    )
+    env = os.environ.copy()
+    env["COLUMNS"] = "200"
+    process = subprocess.run(cmd.split(), capture_output=True, text=True, env=env)
+    assert process.returncode != 0
+
+    # Only checking first of type name to be able to handle both test cases
+    error_msg = "Default values not allowed for user defined type 'VehicleDataTypes.TestBranch1.ParentStruct"
+    assert error_msg in process.stdout
+
+
+def test_error_default_for_struct_array_empty(tmp_path):
+    """
+    Test that we get an error if trying to use default for struct
+    """
+    vspec = HERE / "test_struct_default_array_empty.vspec"
+    types_file = HERE / "VehicleDataTypes.vspec"
+    out = tmp_path / "out.json"
+    cmd = (
+        f"vspec export json -u {TEST_UNITS} -q {TEST_QUANT} --pretty --vspec {vspec} "
+        + f"--output {out} --types {types_file}"
+    )
+    env = os.environ.copy()
+    env["COLUMNS"] = "200"
+    process = subprocess.run(cmd.split(), capture_output=True, text=True, env=env)
+    assert process.returncode == 0

--- a/tests/vspec/test_structs/test_struct_default.vspec
+++ b/tests/vspec/test_structs/test_struct_default.vspec
@@ -1,0 +1,12 @@
+#
+A:
+  type: branch
+  description: Branch A.
+
+
+A.ParentStructSensor:
+  datatype: VehicleDataTypes.TestBranch1.ParentStruct
+  type: sensor
+  default: "No we do not allow default"
+  description: A rich sensor with user-defined data type.
+  comment: "See https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/data_types_struct/index.html#default-values"

--- a/tests/vspec/test_structs/test_struct_default_array.vspec
+++ b/tests/vspec/test_structs/test_struct_default_array.vspec
@@ -1,0 +1,13 @@
+#
+A:
+  type: branch
+  description: Branch A.
+
+# Default allowed for array type if default is empty
+
+A.ParentStructSensor:
+  datatype: VehicleDataTypes.TestBranch1.ParentStruct[]
+  type: sensor
+  default: "Only empty array allowed here"
+  description: A rich sensor with user-defined data type.
+  comment: "See https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/data_types_struct/index.html#default-values"

--- a/tests/vspec/test_structs/test_struct_default_array_empty.vspec
+++ b/tests/vspec/test_structs/test_struct_default_array_empty.vspec
@@ -1,0 +1,13 @@
+#
+A:
+  type: branch
+  description: Branch A.
+
+# Default allowed for array type if default is empty
+
+A.ParentStructSensor:
+  datatype: VehicleDataTypes.TestBranch1.ParentStruct[]
+  type: sensor
+  default: []
+  description: A rich sensor with user-defined data type.
+  comment: "See https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/data_types_struct/index.html#default-values"


### PR DESCRIPTION
This comes from a discussion on using default for structs. As of today we state in https://covesa.github.io/vehicle_signal_specification/rule_set/data_entry/data_types_struct/index.html#default-values that we do not support them, except for one special case.

This PR adds a check that matches that.


Side note: @UlfBj may propose a change to allow default for struct types. If so we will need to refactor the code that checks default to either:

- Accept anything
- Check that it has whatever format we specify it should have (json?)