### PR TITLE
Fix SAMM regressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,12 +24,6 @@ var/
 .installed.cfg
 *.egg
 
-# PyInstaller
-#  Usually these files are written by a python script from a template
-#  before PyInstaller builds the exe, so as to inject date/other infos into it.
-*.manifest
-*.spec
-
 # Installer logs
 pip-log.txt
 pip-delete-this-directory.txt

--- a/src/vss_tools/exporters/samm/__init__.py
+++ b/src/vss_tools/exporters/samm/__init__.py
@@ -36,13 +36,13 @@ def __setup_environment(output_namespace, vspec_version, split_depth: int) -> No
     cfg.init(output_namespace, vspec_version, split_depth)
 
     global VSSConcepts
-    VSSConcepts = importlib.import_module("vss_tools.vspec.exporters.samm.helpers.samm_concepts").VSSConcepts
+    VSSConcepts = importlib.import_module("vss_tools.exporters.samm.helpers.samm_concepts").VSSConcepts
 
     global vss_helper
-    vss_helper = importlib.import_module("vss_tools.vspec.exporters.samm.helpers.vss_helper")
+    vss_helper = importlib.import_module("vss_tools.exporters.samm.helpers.vss_helper")
 
     global ttl_helper
-    ttl_helper = importlib.import_module("vss_tools.vspec.exporters.samm.helpers.ttl_helper")
+    ttl_helper = importlib.import_module("vss_tools.exporters.samm.helpers.ttl_helper")
 
 
 # TODO: Currently this is a workaround to read the Vehicle.VersionVSS, which is provided from COVESA/VSS

--- a/tests/vspec/test_datatypes/expected.samm/com.covesa.vss.spec/1.0.0/A.ttl
+++ b/tests/vspec/test_datatypes/expected.samm/com.covesa.vss.spec/1.0.0/A.ttl
@@ -1,0 +1,179 @@
+@prefix : <urn:samm:com.covesa.vss.spec:1.0.0#> .
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:A a samm:Aspect ;
+    samm:events () ;
+    samm:operations () ;
+    samm:preferredName "A"@en ;
+    samm:properties ( :a ) .
+
+:a a samm:Property ;
+    samm:characteristic :ACharacteristic ;
+    samm:preferredName "A"@en .
+
+:double a samm:Property ;
+    samm:characteristic :DoubleCharacteristic ;
+    samm:preferredName "Double"@en .
+
+:float a samm:Property ;
+    samm:characteristic :FloatCharacteristic ;
+    samm:preferredName "Float"@en .
+
+:int16 a samm:Property ;
+    samm:characteristic :Int16Characteristic ;
+    samm:preferredName "Int16"@en .
+
+:int32 a samm:Property ;
+    samm:characteristic :Int32Characteristic ;
+    samm:preferredName "Int32"@en .
+
+:int64 a samm:Property ;
+    samm:characteristic :Int64Characteristic ;
+    samm:preferredName "Int64"@en .
+
+:int8 a samm:Property ;
+    samm:characteristic :Int8Characteristic ;
+    samm:preferredName "Int8"@en .
+
+:isBoolean a samm:Property ;
+    samm:characteristic :IsBooleanCharacteristic ;
+    samm:preferredName "Is Boolean"@en .
+
+:uInt16 a samm:Property ;
+    samm:characteristic :UInt16Characteristic ;
+    samm:preferredName "U Int16"@en .
+
+:uInt32 a samm:Property ;
+    samm:characteristic :UInt32Characteristic ;
+    samm:preferredName "U Int32"@en .
+
+:uInt64 a samm:Property ;
+    samm:characteristic :UInt64Characteristic ;
+    samm:preferredName "U Int64"@en .
+
+:uInt8 a samm:Property ;
+    samm:characteristic :UInt8Characteristic ;
+    samm:preferredName "U Int8"@en .
+
+:ACharacteristic a samm:Characteristic ;
+    samm:dataType :AEntity ;
+    samm:description """
+VSS path    : A
+
+Description: Branch A."""@en ;
+    samm:name "ACharacteristic" .
+
+:AEntity a samm:Entity ;
+    samm:properties ( [ samm:property :uInt8; samm:payloadName "uInt8" ] [ samm:property :int8; samm:payloadName "int8" ] [ samm:property :uInt16; samm:payloadName "uInt16" ] [ samm:property :int16; samm:payloadName "int16" ] [ samm:property :uInt32; samm:payloadName "uInt32" ] [ samm:property :int32; samm:payloadName "int32" ] [ samm:property :uInt64; samm:payloadName "uInt64" ] [ samm:property :int64; samm:payloadName "int64" ] [ samm:property :isBoolean; samm:payloadName "isBoolean" ] [ samm:property :float; samm:payloadName "float" ] [ samm:property :double; samm:payloadName "double" ] ) .
+
+:DoubleCharacteristic a samm-c:Measurement ;
+    samm-c:unit unit:kilometre ;
+    samm:dataType xsd:double ;
+    samm:description """
+VSS path    : A.Double
+
+Description: A double.
+
+Unit             : km"""@en .
+
+:FloatCharacteristic a samm-c:Measurement ;
+    samm-c:unit unit:kilometre ;
+    samm:dataType xsd:float ;
+    samm:description """
+VSS path    : A.Float
+
+Description: A float.
+
+Unit             : km"""@en .
+
+:Int16Characteristic a samm-c:Measurement ;
+    samm-c:unit unit:kilometre ;
+    samm:dataType xsd:short ;
+    samm:description """
+VSS path    : A.Int16
+
+Description: An int16.
+
+Unit             : km"""@en .
+
+:Int32Characteristic a samm-c:Measurement ;
+    samm-c:unit unit:kilometre ;
+    samm:dataType xsd:int ;
+    samm:description """
+VSS path    : A.Int32
+
+Description: An int32
+
+Unit             : km"""@en .
+
+:Int64Characteristic a samm-c:Measurement ;
+    samm-c:unit unit:kilometre ;
+    samm:dataType xsd:long ;
+    samm:description """
+VSS path    : A.Int64
+
+Description: An int64
+
+Unit             : km"""@en .
+
+:Int8Characteristic a samm-c:Measurement ;
+    samm-c:unit unit:kilometre ;
+    samm:dataType xsd:byte ;
+    samm:description """
+VSS path    : A.Int8
+
+Description: An int8.
+
+Unit             : km"""@en .
+
+:IsBooleanCharacteristic a samm:Characteristic ;
+    samm:dataType xsd:boolean ;
+    samm:description """
+VSS path    : A.IsBoolean
+
+Description: A boolean"""@en .
+
+:UInt16Characteristic a samm-c:Measurement ;
+    samm-c:unit unit:kilometre ;
+    samm:dataType xsd:unsignedShort ;
+    samm:description """
+VSS path    : A.UInt16
+
+Description: A uint16.
+
+Unit             : km"""@en .
+
+:UInt32Characteristic a samm-c:Measurement ;
+    samm-c:unit unit:kilometre ;
+    samm:dataType xsd:unsignedShort ;
+    samm:description """
+VSS path    : A.UInt32
+
+Description: A uint32.
+
+Unit             : km"""@en .
+
+:UInt64Characteristic a samm-c:Measurement ;
+    samm-c:unit unit:kilometre ;
+    samm:dataType xsd:unsignedLong ;
+    samm:description """
+VSS path    : A.UInt64
+
+Description: A uint64.
+
+Unit             : km"""@en .
+
+:UInt8Characteristic a samm-c:Measurement ;
+    samm-c:unit unit:kilometre ;
+    samm:dataType xsd:unsignedByte ;
+    samm:description """
+VSS path    : A.UInt8
+
+Description: A uint8.
+
+Unit             : km"""@en .
+
+

--- a/tests/vspec/test_generic.py
+++ b/tests/vspec/test_generic.py
@@ -16,13 +16,14 @@ import pytest
 HERE = Path(__file__).resolve().parent
 TEST_UNITS = HERE / "test_units.yaml"
 TEST_QUANT = HERE / "test_quantities.yaml"
+DEFAULT_TEST_FILE = "test.vspec"
 
 
 def default_directories() -> list:
     directories = []
     for path in HERE.iterdir():
         if path.is_dir():
-            if list(path.rglob("*.vspec")):
+            if list(path.rglob(DEFAULT_TEST_FILE)):
                 # Exclude directories with custom made python file
                 if not list(path.rglob("*.py")):
                     directories.append(path)
@@ -35,21 +36,25 @@ def idfn(directory: pathlib.PosixPath):
 
 
 def run_exporter(directory, exporter, tmp_path):
-    vspec = directory / "test.vspec"
+    vspec = directory / DEFAULT_TEST_FILE
     types = directory / "types.vspec"
     output = tmp_path / f"out.{exporter}"
     expected = directory / f"expected.{exporter}"
     if not expected.exists():
+        # If you want find directory/exporter combinations not yet covered enable the assert
+        # assert False, f"Folder {expected} not found"
         return
     cmd = f"vspec export {exporter} -u {TEST_UNITS} -q {TEST_QUANT} --vspec {vspec} "
     if types.exists():
         cmd += f" --types {types}"
     if exporter in ["apigear"]:
         cmd += f" --output-dir {output}"
+    elif exporter in ["samm"]:
+        cmd += f" --target-folder {output}"
     else:
         cmd += f" --output {output}"
     subprocess.run(cmd.split(), check=True)
-    if exporter in ["apigear"]:
+    if exporter in ["apigear", "samm"]:
         dcmp = filecmp.dircmp(output, expected)
         assert not (dcmp.diff_files or dcmp.left_only or dcmp.right_only)
     else:
@@ -60,7 +65,7 @@ def run_exporter(directory, exporter, tmp_path):
 def test_exporters(directory, tmp_path):
     # Run all "supported" exporters, i.e. not those in contrib
     # Exception is "binary", as it is assumed output may vary depending on target
-    exporters = ["apigear", "json", "jsonschema", "ddsidl", "csv", "yaml", "franca", "graphql", "go"]
+    exporters = ["apigear", "json", "jsonschema", "ddsidl", "csv", "yaml", "franca", "graphql", "go", "samm"]
 
     for exporter in exporters:
         run_exporter(directory, exporter, tmp_path)

--- a/tests/vspec/test_instances/expected.go
+++ b/tests/vspec/test_instances/expected.go
@@ -1,0 +1,16 @@
+package vss
+
+type A struct {
+	B B
+}
+type B struct {
+	Row1 BI1
+	Row2 BI1
+}
+type BI1 struct {
+	Left BI2
+	Right BI2
+}
+type BI2 struct {
+	C int8
+}

--- a/tests/vspec/test_instances/expected.samm/com.covesa.vss.spec/1.0.0/A.ttl
+++ b/tests/vspec/test_instances/expected.samm/com.covesa.vss.spec/1.0.0/A.ttl
@@ -1,0 +1,25 @@
+@prefix : <urn:samm:com.covesa.vss.spec:1.0.0#> .
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+
+:A a samm:Aspect ;
+    samm:events () ;
+    samm:operations () ;
+    samm:preferredName "A"@en ;
+    samm:properties ( :a ) .
+
+:a a samm:Property ;
+    samm:characteristic :ACharacteristic ;
+    samm:preferredName "A"@en .
+
+:ACharacteristic a samm:Characteristic ;
+    samm:dataType :AEntity ;
+    samm:description """
+VSS path    : A
+
+Description: Branch A."""@en ;
+    samm:name "ACharacteristic" .
+
+:AEntity a samm:Entity ;
+    samm:properties ( [ samm:property :b; samm:payloadName "b" ] ) .
+
+

--- a/tests/vspec/test_instances/expected.samm/com.covesa.vss.spec/1.0.0/B.ttl
+++ b/tests/vspec/test_instances/expected.samm/com.covesa.vss.spec/1.0.0/B.ttl
@@ -1,0 +1,78 @@
+@prefix : <urn:samm:com.covesa.vss.spec:1.0.0#> .
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix unit: <urn:samm:org.eclipse.esmf.samm:unit:2.1.0#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:B a samm:Aspect ;
+    samm:events () ;
+    samm:operations () ;
+    samm:preferredName "B"@en ;
+    samm:properties ( :b ) .
+
+:b a samm:Property ;
+    samm:characteristic :BInstanceSingleEntity ;
+    samm:preferredName "B"@en .
+
+:bRow1 a samm:Property ;
+    samm:characteristic :BRowSingleEntity ;
+    samm:preferredName "B Row1"@en .
+
+:bRow2 a samm:Property ;
+    samm:characteristic :BRowSingleEntity ;
+    samm:preferredName "B Row2"@en .
+
+:bRowLeft a samm:Property ;
+    samm:characteristic :BCharacteristic ;
+    samm:preferredName "B Row Left"@en .
+
+:bRowRight a samm:Property ;
+    samm:characteristic :BCharacteristic ;
+    samm:preferredName "B Row Right"@en .
+
+:c a samm:Property ;
+    samm:characteristic :CCharacteristic ;
+    samm:preferredName "C"@en .
+
+:BEntity a samm:Entity ;
+    samm:properties ( [ samm:property :c; samm:payloadName "c" ] ) .
+
+:BInstanceEntity a samm:Entity ;
+    samm:properties ( [ samm:property :bRow1; samm:optional true; samm:payloadName "row1" ] [ samm:property :bRow2; samm:optional true; samm:payloadName "row2" ] ) .
+
+:BInstanceSingleEntity a samm-c:SingleEntity ;
+    samm:dataType :BInstanceEntity ;
+    samm:name "BInstance" ;
+    samm:preferredName "B Instance"@en .
+
+:BRowEntity a samm:Entity ;
+    samm:properties ( [ samm:property :bRowLeft; samm:optional true; samm:payloadName "left" ] [ samm:property :bRowRight; samm:optional true; samm:payloadName "right" ] ) .
+
+:CCharacteristic a samm-c:Measurement ;
+    samm-c:unit unit:kilometre ;
+    samm:dataType xsd:byte ;
+    samm:description """
+VSS path    : A.B.C
+
+Description: This description will also exist multiple times.
+
+Comment   : As well as this comment.
+
+Unit             : km"""@en .
+
+:BCharacteristic a samm:Characteristic ;
+    samm:dataType :BEntity ;
+    samm:description """
+VSS path    : A.B
+
+Description: This description will be duplicated.
+
+Comment   : This comment will be duplicated"""@en ;
+    samm:name "BCharacteristic" .
+
+:BRowSingleEntity a samm-c:SingleEntity ;
+    samm:dataType :BRowEntity ;
+    samm:name "BRow" ;
+    samm:preferredName "B Row"@en .
+
+

--- a/tests/vspec/test_min_max/expected.samm/com.covesa.vss.spec/1.0.0/A.ttl
+++ b/tests/vspec/test_min_max/expected.samm/com.covesa.vss.spec/1.0.0/A.ttl
@@ -1,0 +1,291 @@
+@prefix : <urn:samm:com.covesa.vss.spec:1.0.0#> .
+@prefix samm: <urn:samm:org.eclipse.esmf.samm:meta-model:2.1.0#> .
+@prefix samm-c: <urn:samm:org.eclipse.esmf.samm:characteristic:2.1.0#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+:A a samm:Aspect ;
+    samm:events () ;
+    samm:operations () ;
+    samm:preferredName "A"@en ;
+    samm:properties ( :a ) .
+
+:a a samm:Property ;
+    samm:characteristic :ACharacteristic ;
+    samm:preferredName "A"@en .
+
+:floatMaxZero a samm:Property ;
+    samm:characteristic :FloatMaxZeroTrait ;
+    samm:preferredName "Float Max Zero"@en .
+
+:floatMaxZeroInt a samm:Property ;
+    samm:characteristic :FloatMaxZeroIntTrait ;
+    samm:preferredName "Float Max Zero Int"@en .
+
+:floatMinMax a samm:Property ;
+    samm:characteristic :FloatMinMaxTrait ;
+    samm:preferredName "Float Min Max"@en .
+
+:floatMinZero a samm:Property ;
+    samm:characteristic :FloatMinZeroTrait ;
+    samm:preferredName "Float Min Zero"@en .
+
+:floatMinZeroInt a samm:Property ;
+    samm:characteristic :FloatMinZeroIntTrait ;
+    samm:preferredName "Float Min Zero Int"@en .
+
+:floatNoMinMax a samm:Property ;
+    samm:characteristic :FloatNoMinMaxCharacteristic ;
+    samm:preferredName "Float No Min Max"@en .
+
+:floatOnlyMax a samm:Property ;
+    samm:characteristic :FloatOnlyMaxTrait ;
+    samm:preferredName "Float Only Max"@en .
+
+:floatOnlyMin a samm:Property ;
+    samm:characteristic :FloatOnlyMinTrait ;
+    samm:preferredName "Float Only Min"@en .
+
+:intMaxZero a samm:Property ;
+    samm:characteristic :IntMaxZeroTrait ;
+    samm:preferredName "Int Max Zero"@en .
+
+:intMinMax a samm:Property ;
+    samm:characteristic :IntMinMaxTrait ;
+    samm:preferredName "Int Min Max"@en .
+
+:intMinZero a samm:Property ;
+    samm:characteristic :IntMinZeroTrait ;
+    samm:preferredName "Int Min Zero"@en .
+
+:intNoMinMax a samm:Property ;
+    samm:characteristic :IntNoMinMaxCharacteristic ;
+    samm:preferredName "Int No Min Max"@en .
+
+:intOnlyMax a samm:Property ;
+    samm:characteristic :IntOnlyMaxTrait ;
+    samm:preferredName "Int Only Max"@en .
+
+:intOnlyMin a samm:Property ;
+    samm:characteristic :IntOnlyMinTrait ;
+    samm:preferredName "Int Only Min"@en .
+
+:ACharacteristic a samm:Characteristic ;
+    samm:dataType :AEntity ;
+    samm:description """
+VSS path    : A
+
+Description: Branch A."""@en ;
+    samm:name "ACharacteristic" .
+
+:AEntity a samm:Entity ;
+    samm:properties ( [ samm:property :intNoMinMax; samm:payloadName "intNoMinMax" ] [ samm:property :intOnlyMax; samm:payloadName "intOnlyMax" ] [ samm:property :intOnlyMin; samm:payloadName "intOnlyMin" ] [ samm:property :intMinMax; samm:payloadName "intMinMax" ] [ samm:property :intMaxZero; samm:payloadName "intMaxZero" ] [ samm:property :intMinZero; samm:payloadName "intMinZero" ] [ samm:property :floatNoMinMax; samm:payloadName "floatNoMinMax" ] [ samm:property :floatOnlyMax; samm:payloadName "floatOnlyMax" ] [ samm:property :floatOnlyMin; samm:payloadName "floatOnlyMin" ] [ samm:property :floatMinMax; samm:payloadName "floatMinMax" ] [ samm:property :floatMaxZero; samm:payloadName "floatMaxZero" ] [ samm:property :floatMinZero; samm:payloadName "floatMinZero" ] [ samm:property :floatMaxZeroInt; samm:payloadName "floatMaxZeroInt" ] [ samm:property :floatMinZeroInt; samm:payloadName "floatMinZeroInt" ] ) .
+
+:FloatMaxZeroBaseCharacteristic a samm:Characteristic ;
+    samm:dataType xsd:float ;
+    samm:description """
+VSS path    : A.FloatMaxZero
+
+Description: Max Zero."""@en .
+
+:FloatMaxZeroConstraint a samm-c:RangeConstraint ;
+    samm-c:maxValue "0.0"^^xsd:float ;
+    samm:name "FloatMaxZeroConstraint" .
+
+:FloatMaxZeroIntBaseCharacteristic a samm:Characteristic ;
+    samm:dataType xsd:float ;
+    samm:description """
+VSS path    : A.FloatMaxZeroInt
+
+Description: Max Zero."""@en .
+
+:FloatMaxZeroIntConstraint a samm-c:RangeConstraint ;
+    samm-c:maxValue "0"^^xsd:float ;
+    samm:name "FloatMaxZeroIntConstraint" .
+
+:FloatMaxZeroIntTrait a samm-c:Trait ;
+    samm-c:baseCharacteristic :FloatMaxZeroIntBaseCharacteristic ;
+    samm-c:constraint :FloatMaxZeroIntConstraint ;
+    samm:name "FloatMaxZeroIntTrait" .
+
+:FloatMaxZeroTrait a samm-c:Trait ;
+    samm-c:baseCharacteristic :FloatMaxZeroBaseCharacteristic ;
+    samm-c:constraint :FloatMaxZeroConstraint ;
+    samm:name "FloatMaxZeroTrait" .
+
+:FloatMinMaxBaseCharacteristic a samm:Characteristic ;
+    samm:dataType xsd:float ;
+    samm:description """
+VSS path    : A.FloatMinMax
+
+Description: Min & Max."""@en .
+
+:FloatMinMaxConstraint a samm-c:RangeConstraint ;
+    samm-c:maxValue "236723.4"^^xsd:float ;
+    samm-c:minValue "-165.56323"^^xsd:float ;
+    samm:name "FloatMinMaxConstraint" .
+
+:FloatMinMaxTrait a samm-c:Trait ;
+    samm-c:baseCharacteristic :FloatMinMaxBaseCharacteristic ;
+    samm-c:constraint :FloatMinMaxConstraint ;
+    samm:name "FloatMinMaxTrait" .
+
+:FloatMinZeroBaseCharacteristic a samm:Characteristic ;
+    samm:dataType xsd:float ;
+    samm:description """
+VSS path    : A.FloatMinZero
+
+Description: Min Zero."""@en .
+
+:FloatMinZeroConstraint a samm-c:RangeConstraint ;
+    samm-c:minValue "0.0"^^xsd:float ;
+    samm:name "FloatMinZeroConstraint" .
+
+:FloatMinZeroIntBaseCharacteristic a samm:Characteristic ;
+    samm:dataType xsd:float ;
+    samm:description """
+VSS path    : A.FloatMinZeroInt
+
+Description: Min Zero."""@en .
+
+:FloatMinZeroIntConstraint a samm-c:RangeConstraint ;
+    samm-c:minValue "0"^^xsd:float ;
+    samm:name "FloatMinZeroIntConstraint" .
+
+:FloatMinZeroIntTrait a samm-c:Trait ;
+    samm-c:baseCharacteristic :FloatMinZeroIntBaseCharacteristic ;
+    samm-c:constraint :FloatMinZeroIntConstraint ;
+    samm:name "FloatMinZeroIntTrait" .
+
+:FloatMinZeroTrait a samm-c:Trait ;
+    samm-c:baseCharacteristic :FloatMinZeroBaseCharacteristic ;
+    samm-c:constraint :FloatMinZeroConstraint ;
+    samm:name "FloatMinZeroTrait" .
+
+:FloatNoMinMaxCharacteristic a samm:Characteristic ;
+    samm:dataType xsd:float ;
+    samm:description """
+VSS path    : A.FloatNoMinMax
+
+Description: No Min Max."""@en .
+
+:FloatOnlyMaxBaseCharacteristic a samm:Characteristic ;
+    samm:dataType xsd:float ;
+    samm:description """
+VSS path    : A.FloatOnlyMax
+
+Description: Only Max."""@en .
+
+:FloatOnlyMaxConstraint a samm-c:RangeConstraint ;
+    samm-c:maxValue "32.3"^^xsd:float ;
+    samm:name "FloatOnlyMaxConstraint" .
+
+:FloatOnlyMaxTrait a samm-c:Trait ;
+    samm-c:baseCharacteristic :FloatOnlyMaxBaseCharacteristic ;
+    samm-c:constraint :FloatOnlyMaxConstraint ;
+    samm:name "FloatOnlyMaxTrait" .
+
+:FloatOnlyMinBaseCharacteristic a samm:Characteristic ;
+    samm:dataType xsd:float ;
+    samm:description """
+VSS path    : A.FloatOnlyMin
+
+Description: Only Min."""@en .
+
+:FloatOnlyMinConstraint a samm-c:RangeConstraint ;
+    samm-c:minValue "-2.5"^^xsd:float ;
+    samm:name "FloatOnlyMinConstraint" .
+
+:FloatOnlyMinTrait a samm-c:Trait ;
+    samm-c:baseCharacteristic :FloatOnlyMinBaseCharacteristic ;
+    samm-c:constraint :FloatOnlyMinConstraint ;
+    samm:name "FloatOnlyMinTrait" .
+
+:IntMaxZeroBaseCharacteristic a samm:Characteristic ;
+    samm:dataType xsd:byte ;
+    samm:description """
+VSS path    : A.IntMaxZero
+
+Description: Max Zero."""@en .
+
+:IntMaxZeroConstraint a samm-c:RangeConstraint ;
+    samm-c:maxValue "0"^^xsd:byte ;
+    samm:name "IntMaxZeroConstraint" .
+
+:IntMaxZeroTrait a samm-c:Trait ;
+    samm-c:baseCharacteristic :IntMaxZeroBaseCharacteristic ;
+    samm-c:constraint :IntMaxZeroConstraint ;
+    samm:name "IntMaxZeroTrait" .
+
+:IntMinMaxBaseCharacteristic a samm:Characteristic ;
+    samm:dataType xsd:byte ;
+    samm:description """
+VSS path    : A.IntMinMax
+
+Description: Min & Max."""@en .
+
+:IntMinMaxConstraint a samm-c:RangeConstraint ;
+    samm-c:maxValue "6"^^xsd:byte ;
+    samm-c:minValue "3"^^xsd:byte ;
+    samm:name "IntMinMaxConstraint" .
+
+:IntMinMaxTrait a samm-c:Trait ;
+    samm-c:baseCharacteristic :IntMinMaxBaseCharacteristic ;
+    samm-c:constraint :IntMinMaxConstraint ;
+    samm:name "IntMinMaxTrait" .
+
+:IntMinZeroBaseCharacteristic a samm:Characteristic ;
+    samm:dataType xsd:byte ;
+    samm:description """
+VSS path    : A.IntMinZero
+
+Description: Min Zero."""@en .
+
+:IntMinZeroConstraint a samm-c:RangeConstraint ;
+    samm-c:minValue "0"^^xsd:byte ;
+    samm:name "IntMinZeroConstraint" .
+
+:IntMinZeroTrait a samm-c:Trait ;
+    samm-c:baseCharacteristic :IntMinZeroBaseCharacteristic ;
+    samm-c:constraint :IntMinZeroConstraint ;
+    samm:name "IntMinZeroTrait" .
+
+:IntNoMinMaxCharacteristic a samm:Characteristic ;
+    samm:dataType xsd:byte ;
+    samm:description """
+VSS path    : A.IntNoMinMax
+
+Description: No Min Max."""@en .
+
+:IntOnlyMaxBaseCharacteristic a samm:Characteristic ;
+    samm:dataType xsd:byte ;
+    samm:description """
+VSS path    : A.IntOnlyMax
+
+Description: Only Max."""@en .
+
+:IntOnlyMaxConstraint a samm-c:RangeConstraint ;
+    samm-c:maxValue "32"^^xsd:byte ;
+    samm:name "IntOnlyMaxConstraint" .
+
+:IntOnlyMaxTrait a samm-c:Trait ;
+    samm-c:baseCharacteristic :IntOnlyMaxBaseCharacteristic ;
+    samm-c:constraint :IntOnlyMaxConstraint ;
+    samm:name "IntOnlyMaxTrait" .
+
+:IntOnlyMinBaseCharacteristic a samm:Characteristic ;
+    samm:dataType xsd:byte ;
+    samm:description """
+VSS path    : A.IntOnlyMin
+
+Description: Only Min."""@en .
+
+:IntOnlyMinConstraint a samm-c:RangeConstraint ;
+    samm-c:minValue "3"^^xsd:byte ;
+    samm:name "IntOnlyMinConstraint" .
+
+:IntOnlyMinTrait a samm-c:Trait ;
+    samm-c:baseCharacteristic :IntOnlyMinBaseCharacteristic ;
+    samm-c:constraint :IntOnlyMinConstraint ;
+    samm:name "IntOnlyMinTrait" .
+
+


### PR DESCRIPTION
Detected as VSS `master` branch (using vss-tools `master`) currently fails. Reason is recent rename in vss-tools and that we do not have any regression tests for SAMM