### PR TITLE
Add entry for samm exporter in the vspec docs - help example.

### DIFF
--- a/docs/vspec.md
+++ b/docs/vspec.md
@@ -8,23 +8,24 @@ For the most up do date usage information, please call the tool help via:
 vspec export --help
 
  Usage: vspec export [OPTIONS] COMMAND [ARGS]...
-╭─ Options ──────────────────────────────────────────────────────────────────────────────────────────────╮
-│ --help                                              Show this message and exit.                        │
-╰────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Commands ─────────────────────────────────────────────────────────────────────────────────────────────╮
-│ apigear                           Export to ApiGear.                                                   │
-│ binary                            Export to Binary.                                                    │
-│ csv                               Export as CSV.                                                       │
-│ ddsidl                            Export as DDSIDL.                                                    │
-│ franca                            Export as Franca.                                                    │
-│ graphql                           Export as GraphQL.                                                   │
-│ id                                Export as IDs.                                                       │
-│ json                              Export as JSON.                                                      │
-│ jsonschema                        Export as a jsonschema.                                              │
-│ protobuf                          Export as protobuf.                                                  │
-│ yaml                              Export as YAML.                                                      │
-│ tree                              Export as Tree.                                                      │
-╰────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --help                                              Show this message and exit.                                      │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Commands ───────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ apigear       Export to ApiGear.                                                                                     │
+│ binary        Export to Binary.                                                                                      │
+│ csv           Export as CSV.                                                                                         │
+│ ddsidl        Export as DDSIDL.                                                                                      │
+│ franca        Export as Franca.                                                                                      │
+│ graphql       Export as GraphQL.                                                                                     │
+│ id            Export as IDs.                                                                                         │
+│ json          Export as JSON.                                                                                        │
+│ jsonschema    Export as a jsonschema.                                                                                │
+│ protobuf      Export as protobuf.                                                                                    │
+| samm          Export as Eclipse Semantic Modeling Framework (ESMF) - Semantic Aspect Meta Model (SAMM) - .ttl files. |
+│ yaml          Export as YAML.                                                                                        │
+│ tree          Export as Tree.                                                                                        │
+╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 

--- a/src/vss_tools/exporters/samm/__init__.py
+++ b/src/vss_tools/exporters/samm/__init__.py
@@ -176,7 +176,7 @@ def cli(
     split_depth,
 ) -> None:
     """
-    Export COVESA VSS to Eclipse Semantic Modeling Framework (ESMF) - Semantic Aspect Meta Model (SAMM) - .ttl files.
+    Export as Eclipse Semantic Modeling Framework (ESMF) - Semantic Aspect Meta Model (SAMM) - .ttl files.
     """
 
     log.info("Loading VSS Tree...\n")


### PR DESCRIPTION
Add missing entry for samm exporter to the example for vspec docs.

Update "help" message for the samm exporter to be in similar format to other exporter entries.