### PR TITLE
Better error message for implicit branches

### DIFF
--- a/src/vss_tools/model.py
+++ b/src/vss_tools/model.py
@@ -109,7 +109,7 @@ class VSSRaw(BaseModel):
 class VSSData(VSSRaw):
     model_config = ConfigDict(extra="allow")
     type: NodeType
-    description: str
+    description: str = ""
     comment: str | None = None
     delete: bool = False
     deprecation: str | None = None
@@ -125,6 +125,18 @@ class VSSData(VSSRaw):
         pattern = r"^0x[0-9A-Fa-f]{8}$"
         assert bool(re.match(pattern, v)), f"'{v}' is not a valid 'constUID'"
         return v
+
+    @field_validator("description", mode="before")
+    @classmethod
+    def ensure_description(cls, value: Any) -> Any:
+        """Give better explanation for empty description."""
+
+        if value == "":
+            raise ValueError(
+                "all nodes in the final tree must have a description. "
+                "Implicit branches are not allowed in final tree!"
+            )
+        return value
 
 
 class VSSDataBranch(VSSData):

--- a/src/vss_tools/model.py
+++ b/src/vss_tools/model.py
@@ -126,17 +126,13 @@ class VSSData(VSSRaw):
         assert bool(re.match(pattern, v)), f"'{v}' is not a valid 'constUID'"
         return v
 
-    @field_validator("description", mode="before")
-    @classmethod
-    def ensure_description(cls, value: Any) -> Any:
+    @model_validator(mode="after")
+    def ensure_description(self) -> Self:
         """Give better explanation for empty description."""
-
-        if value == "":
-            raise ValueError(
-                "all nodes in the final tree must have a description. "
-                "Implicit branches are not allowed in final tree!"
-            )
-        return value
+        assert (
+            self.description != ""
+        ), "All nodes in the final tree must have a description. Implicit branches are not allowed in final tree!"
+        return self
 
 
 class VSSDataBranch(VSSData):

--- a/tests/vspec/test_description_error/test_description_error.py
+++ b/tests/vspec/test_description_error/test_description_error.py
@@ -40,5 +40,5 @@ def test_description_error(vspec_file: str, type_file: str, type_out_file: str, 
     assert process.returncode != 0
     log_content = log.read_text()
     print(log_content)
-    assert "'type': 'missing'" in log_content
+    assert "'type': 'value_error'" in log_content
     assert "1 model error(s):" in log_content

--- a/tests/vspec/test_description_error/test_description_error.py
+++ b/tests/vspec/test_description_error/test_description_error.py
@@ -40,5 +40,5 @@ def test_description_error(vspec_file: str, type_file: str, type_out_file: str, 
     assert process.returncode != 0
     log_content = log.read_text()
     print(log_content)
-    assert "'type': 'value_error'" in log_content
+    assert "'type': 'assertion_error'" in log_content
     assert "1 model error(s):" in log_content

--- a/tests/vspec/test_overlay/test_overlay.py
+++ b/tests/vspec/test_overlay/test_overlay.py
@@ -71,5 +71,5 @@ def test_overlay_branch_error(tmp_path):
     assert process.returncode != 0
     log_content = log.read_text()
     assert "'A.AB' has 1 model error(s)" in log_content
-    assert "'type': 'value_error'" in log_content
+    assert "'type': 'assertion_error'" in log_content
     assert "description" in log_content

--- a/tests/vspec/test_overlay/test_overlay.py
+++ b/tests/vspec/test_overlay/test_overlay.py
@@ -71,5 +71,5 @@ def test_overlay_branch_error(tmp_path):
     assert process.returncode != 0
     log_content = log.read_text()
     assert "'A.AB' has 1 model error(s)" in log_content
-    assert "'type': 'missing'" in log_content
+    assert "'type': 'value_error'" in log_content
     assert "description" in log_content


### PR DESCRIPTION
Fixes #407

This PR adds a custom check and error if description is empty, and mention implicit branches in overlays as a possible error reason.

```bash
$ vspec export csv -s test.vspec -u tests/vspec/test_units.yaml -q tests/vspec/test_quantities.yaml -o hej.csv
[12:08:33] INFO     Loaded 'VSSQuantity', file=/home/erik/vss-tools/tests/vspec/test_quantities.yaml, elements=6               units_quantities.py:34
           INFO     Loaded 'VSSUnit', file=/home/erik/vss-tools/tests/vspec/test_units.yaml, elements=7                        units_quantities.py:34
           INFO     VSpecs loaded, amount=1                                                                                              vspec.py:130
           CRITICAL 'A.B' has 1 model error(s):                                                                                           main.py:231
                    [                                                                                                                                
                        {                                                                                                                            
                            'type': 'value_error',                                                                                                   
                            'loc': ('description',),                                                                                                 
                            'msg': 'Value error, all nodes in the final tree must have a description. Implicit branches are not allowed              
                    in final tree!',                                                                                                                 
                            'input': ''                                                                                                              
                        }                                                                                                                            
                    ]               
```

Current output:

```bash       
$ vspec export csv -s test.vspec -u tests/vspec/test_units.yaml -q tests/vspec/test_quantities.yaml -o hej.csv
[12:08:46] INFO     Loaded 'VSSQuantity', file=/home/erik/vss-tools/tests/vspec/test_quantities.yaml, elements=6               units_quantities.py:34
           INFO     Loaded 'VSSUnit', file=/home/erik/vss-tools/tests/vspec/test_units.yaml, elements=7                        units_quantities.py:34
           INFO     VSpecs loaded, amount=1                                                                                              vspec.py:130
           CRITICAL 'A.B' has 1 model error(s):                                                                                           main.py:231
                    [                                                                                                                                
                        {                                                                                                                            
                            'type': 'missing',                                                                                                       
                            'loc': ('description',),                                                                                                 
                            'msg': 'Field required',                                                                                                 
                            'input': {'fqn': 'A.B', 'type': 'branch'}                                                                                
                        }                                                                                                                            
                    ]        
```
