### PR TITLE
fix: removed min/max array limitation

### DIFF
--- a/src/vss_tools/model.py
+++ b/src/vss_tools/model.py
@@ -213,8 +213,6 @@ class VSSDataDatatype(VSSData):
                 Datatypes.is_subtype_of(self.datatype, Datatypes.NUMERIC[0])
             except DatatypesException:
                 raise ValueError(f"Cannot define min/max for datatype '{self.datatype}'")
-            if is_array(self.datatype):
-                raise ValueError("Cannot define min/max for array datatypes")
             if self.min:
                 assert Datatypes.is_datatype(self.min, self.datatype), f"min '{self.min}' is not an '{self.datatype}'"
             if self.max:
@@ -222,11 +220,16 @@ class VSSDataDatatype(VSSData):
         return self
 
     def check_default_min_max(self) -> Self:
-        if self.default:
-            if self.min and self.default < self.min:
-                raise ValueError(f"'default' smaller than 'min': {self.default}<{self.min}")
-            if self.max and self.default > self.max:
-                raise ValueError(f"'default' greater than 'max': {self.default}>{self.min}")
+        if not self.default:
+            return self
+        values = [self.default]
+        if isinstance(self.default, list):
+            values = self.default
+        for v in values:
+            if self.min and v < self.min:
+                raise ValueError(f"'default' smaller than 'min': {v}<{self.min}")
+            if self.max and v > self.max:
+                raise ValueError(f"'default' greater than 'max': {v}>{self.min}")
         return self
 
     def check_type_default_consistency(self) -> Self:

--- a/src/vss_tools/model.py
+++ b/src/vss_tools/model.py
@@ -225,11 +225,15 @@ class VSSDataDatatype(VSSData):
         values = [self.default]
         if isinstance(self.default, list):
             values = self.default
+
+        epsilon = 1e-6
         for v in values:
-            if self.min and v < self.min:
+            if self.min or self.max:
+                v = round(v, 6)
+            if self.min and v < self.min - epsilon:
                 raise ValueError(f"'default' smaller than 'min': {v}<{self.min}")
-            if self.max and v > self.max:
-                raise ValueError(f"'default' greater than 'max': {v}>{self.min}")
+            if self.max and v > self.max + epsilon:
+                raise ValueError(f"'default' greater than 'max': {v}>{self.max}")
         return self
 
     def check_type_default_consistency(self) -> Self:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2023 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+from typing import Any
+
+import pydantic
+import pytest
+from vss_tools.model import VSSDataDatatype
+
+
+@pytest.mark.parametrize(
+    "data, ok",
+    [
+        ({"datatype": "foo"}, False),
+        ({"datatype": "int8"}, True),
+        ({"datatype": "int8", "arraysize": 1}, False),
+        ({"datatype": "int8[]", "arraysize": 1}, True),
+        ({"datatype": "int8", "min": -300}, False),
+        ({"datatype": "int8", "min": "foo"}, False),
+        ({"datatype": "int8", "min": -100}, True),
+        ({"datatype": "uint8", "max": -2}, False),
+        ({"datatype": "uint8", "max": 100}, True),
+        ({"datatype": "string", "max": 100}, False),
+        ({"datatype": "uint8", "max": 100, "default": 110}, False),
+        ({"datatype": "uint8", "max": 100, "default": 90}, True),
+        ({"datatype": "uint8", "min": 10, "default": 5}, False),
+        ({"datatype": "uint8", "min": 10, "default": 10}, True),
+        ({"datatype": "uint8", "default": 300}, False),
+        ({"datatype": "uint8", "default": 200}, True),
+        ({"datatype": "boolean", "default": True}, True),
+        ({"datatype": "uint8[]", "arraysize": 1, "default": [1, 2]}, False),
+        ({"datatype": "uint8[]", "arraysize": 2, "default": [1, 2]}, True),
+        ({"datatype": "uint8", "allowed": [1, 2, 3], "default": 4}, False),
+        ({"datatype": "uint8", "allowed": [1, 2, 3], "default": 3}, True),
+        ({"datatype": "uint8", "allowed": [1, "foo"]}, False),
+        ({"datatype": "uint8", "allowed": [1, 2]}, True),
+        ({"datatype": "uint8", "allowed": [1, 2, 3], "min": 3}, False),
+        ({"datatype": "uint8", "allowed": [1, 2, 3], "max": 3}, False),
+        ({"datatype": "uint8", "pattern": "xy"}, False),
+        ({"datatype": "string", "pattern": "xy"}, True),
+        ({"datatype": "string", "pattern": "x.*", "default": "ay"}, False),
+        ({"datatype": "string", "pattern": "x.*", "default": "xy"}, True),
+        ({"datatype": "string", "pattern": "x.*", "allowed": ["ay"]}, False),
+        ({"datatype": "string", "pattern": "x.*", "allowed": ["xy", "xz"]}, True),
+    ],
+)
+def test_vss_data_datatype(data: dict[str, Any], ok: bool) -> None:
+    data.update({"type": "attribute", "description": "test"})
+    data_ok = True
+    try:
+        VSSDataDatatype(**data)
+    except pydantic.ValidationError as e:
+        data_ok = False
+        print(e)
+
+    assert ok == data_ok


### PR DESCRIPTION
# About

Removed limitation of `min`/`max` being not valid for array datatypes.
Added support for checking `default` against `min`/`max` which means for arrays to check every value to be in the defined min max boundary

fixes #444