### PR TITLE
feat: allowing redefinition of units and quantities

### DIFF
--- a/tests/vspec/test_units/test_units.py
+++ b/tests/vspec/test_units/test_units.py
@@ -92,8 +92,8 @@ def test_multiple_duplication(tmp_path):
         "expected_special.json",
         None,
         True,
-        "redefinition of 'puncheon'",
-        True,
+        "overwriting definition of 'puncheon'",
+        False,
     )
 
 
@@ -215,7 +215,7 @@ def test_quantity_redefinition(tmp_path):
         "expected_special.json",
         ["quantity_volym.yaml", "quantity_volym.yaml"],
         True,
-        "redefinition of 'volym'",
+        "overwriting definition of 'volym'",
         True,
     )
 


### PR DESCRIPTION
# About

Right now we are not allowing users to overwrite units and quantity definitions.
However, it probably is more flexible to allow users to do that if they want.

It is already allowed to pass more than one unit and quantity file.
This change enables users to overwrite existing unit and quantity definitions with their own (maybe extended) one.

# Example

## Files

model.yaml
```yaml
Vehicle:
  type: branch
  description: Vehicle

Vehicle.ProductionDate:
  type: attribute
  description: ProductionDate
  datatype: string
  unit: unix-time
```

quantities.yaml
```yaml
datetime:
  definition: Specific point in time
  remark: This quantity is not described in ISO 80000.
  comment: Example usage of this quantity could be ISO 8601 string representation of date and time, or UNIX timestamp
```

units.yaml
```yaml
unix-time:
  definition: Number of non-leap seconds which have passed since 00:00:00 UTC on Thursday, 1 January 1970
  unit: UNIX Timestamp
  quantity: datetime
  allowed-datatypes: ["uint32", "uint64", "int64"]
```

units_overlay.yaml
```yaml
unix-time:
  definition: Number of non-leap seconds which have passed since 00:00:00 UTC on Thursday, 1 January 1970
  unit: UNIX Timestamp
  quantity: datetime
  allowed-datatypes: ["uint32", "uint64", "int64", "string"]
```

## Invocation

Without overlay:
```bash
vspec export tree -s test.vspec -u units.yaml -q quantities.yaml
```
Result:
<img width="944" alt="image" src="https://github.com/user-attachments/assets/18f2db4a-9617-43fc-acaa-83b34e6b64e6" />

With overlay:
```bash
vspec export tree -s test.vspec -u units.yaml -q quantities.yaml -u units_overlay.yaml
```

<img width="944" alt="image" src="https://github.com/user-attachments/assets/37b2349d-3993-4e4b-abe5-df703c26c19e" />
