### PR TITLE
fix: _post_attach needs to update fqns recursively

### DIFF
--- a/src/vss_tools/tree.py
+++ b/src/vss_tools/tree.py
@@ -88,8 +88,13 @@ class VSSNode(Node):  # type: ignore[misc]
         Updating the data fqn when getting reattached.
         We need the fqn in the data for validation purposes.
         """
-        log.debug(f"Got attached to parent='{parent.get_fqn()}', new fqn='{self.get_fqn()}'")
+        log.debug(f"Got attached to parent='{parent.get_fqn()}'")
+        self._update_fqn()
+
+    def _update_fqn(self) -> None:
         self.data.fqn = self.get_fqn(SEPARATOR)
+        for child in self.children:
+            child._update_fqn()
 
     def _post_detach(self, parent: VSSNode):
         log.debug(f"'{self.get_fqn()}', detached from parent='{parent.get_fqn()}'")

--- a/tests/test_vss_node.py
+++ b/tests/test_vss_node.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2025 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+from vss_tools.tree import VSSNode
+
+
+def test_fqn() -> None:
+    foo_bar_baz = VSSNode(
+        "baz",
+        None,
+        {"type": "sensor", "description": "foo.bar.baz", "datatype": "int8"},
+    )
+
+    foo_bar = VSSNode(
+        "bar",
+        None,
+        {"type": "branch", "description": "foo.bar"},
+        children=[foo_bar_baz],
+    )
+
+    _ = VSSNode("foo", None, {"type": "branch", "description": "foo"}, children=[foo_bar])
+
+    assert foo_bar_baz.name == "baz"
+    assert foo_bar_baz.get_fqn() == "foo.bar.baz"
+    assert foo_bar_baz.data.fqn == "foo.bar.baz"


### PR DESCRIPTION
The `_post_attach()` method changed the fqn for the node being attached to a different parent.
However, it also means that all fqns of all children need to be updated as well