### PR TITLE
:sparkles: added strict exceptions config file

### DIFF
--- a/docs/vspec.md
+++ b/docs/vspec.md
@@ -29,7 +29,6 @@ vspec export --help
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
-
 A complete example call with the `json` exporter and its output could look like this:
 
 ```bash
@@ -45,6 +44,7 @@ vspec export json --vspec spec/VehicleSignalSpecification.vspec --output vss.jso
            INFO     Serializing compact JSON...                                                json.py:148
 
 ```
+
 ## Exporter Specific Documentation
 
 - [apigear](./apigear.md)
@@ -65,24 +65,29 @@ Please note that not all arguments are available for all exporters.
 That is either a technical limitation of the exported format or has just not implemented yet.
 
 ### --log-level
+
 Controls the verbosity of the output the tool generates. The default is "INFO" which
 will print things interesting for most users. If you want to hide those you can pass
 `--log-level WARNING` which will hide debug and info prints and will print warnings and errors.
 
 ### --log-file
+
 Also writes log messages into the given file. Note that the format used for writing into a file is slightly different.
 
 ### --aborts unknown-attribute
+
 Terminates parsing when an unknown attribute is encountered, that is an attribute that is not defined in the [VSS standard catalogue](https://covesa.github.io/vehicle_signal_specification/rule_set/), and not whitelisted using the extended attribute parameter `-e` (see below).
 
 > [!NOTE]
-> Here an *attribute* refers to VSS signal metadata such as "datatype", "min", "max",
+> Here an _attribute_ refers to VSS signal metadata such as "datatype", "min", "max",
 > ... and not to the VSS signal type attribute
 
 ### --aborts name-style
+
 Terminates parsing, when the name of a signal does not follow [VSS Naming Conventions](https://covesa.github.io/vehicle_signal_specification/rule_set/basics/#naming-conventions) for the VSS standard catalog.
 
 ### --strict/--no-strict
+
 Enables `--aborts unknown-attribute` and `--aborts name-style`
 
 ### --expand/--no-expand
@@ -94,6 +99,26 @@ Instead instance information will be kept as additional information for the bran
 ### -e, --extended-attributes
 
 See section on [overlays](vspec.md#handling-of-overlays-and-extensions) below
+
+### --strict-exceptions
+
+Specify a YAML file that contains exceptions to signals that violate strict rules (from `--strict` or `--abort`)
+
+The format is:
+
+```yaml
+Vehicle.Foo: # Allow all violations
+
+Vehicle.Bar: # Allow name violoations
+  - name-style
+
+Vehicle.Zed: # Allow unknown attribute violations
+  - unknown-attribute
+
+Vehicle.Yada: # Allow specific violations
+  - name-style
+  - unknown-attribute
+```
 
 ## Handling of Data Types
 
@@ -123,21 +148,22 @@ vspec export json --pretty --types VehicleDataTypes.vspec --types-output Vehicle
 
 Current status for exporters:
 
-* CSV, JSON, YAML, Protobuf: Supported!
-* All other exporters: Not supported!
+- CSV, JSON, YAML, Protobuf: Supported!
+- All other exporters: Not supported!
 
 The export format is similar to the export format of VSS signals. The below table illustrates the exporting of the new nodes introduced in the data type tree:
 
-| Data                     | CSV    | JSON | YAML |
-| ------------------------ | ------ | ---- | ---- |
-| Struct Node Attribute    | Column | Key  | Key  |
-| Property Node Attribute  | Column | Key  | Key  |
+| Data                    | CSV    | JSON | YAML |
+| ----------------------- | ------ | ---- | ---- |
+| Struct Node Attribute   | Column | Key  | Key  |
+| Property Node Attribute | Column | Key  | Key  |
 
 The YAML exporter maintains the file structure of the vspec file being exported.
 
 **NOTE:** For YAML and JSON, if a separate output file is not provided, the complex data types are exported under the key - `ComplexDataTypes`. See the snippets below for illustration.
 
 **CSV snippet**
+
 ```csv
 "Node","Type","DataType","Deprecated","Unit","Min","Max","Desc","Comment","Allowed","Default"
 "<BranchName>","branch","","<Deprecation>","","","","<Description>","<Comment>","",""
@@ -146,6 +172,7 @@ The YAML exporter maintains the file structure of the vspec file being exported.
 ```
 
 **JSON snippet (data types are exported to a separate file)**
+
 ```json
 {
   "VehicleDataTypes": {
@@ -174,6 +201,7 @@ The YAML exporter maintains the file structure of the vspec file being exported.
 ```
 
 **JSON snippet (signals and data types are exported to a single file)**
+
 ```json
 {
   "Vehicle": {
@@ -223,8 +251,8 @@ vspec export csv -I ./spec -u vss-tools/vspec/config.yaml -u vss-tools/vspec/ext
 
 When deciding which units to use the tooling use the following logic:
 
-* If `--units/-u <file>` is used then the specified unit files will be used. Default units will not be considered.
-* If `--units/-u` is not used the tool will check for a unit file in the same directory as the root `*.vspec` file.
+- If `--units/-u <file>` is used then the specified unit files will be used. Default units will not be considered.
+- If `--units/-u` is not used the tool will check for a unit file in the same directory as the root `*.vspec` file.
 
 See the [FAQ](../FAQ.md) for more information on how to define own units.
 
@@ -235,12 +263,13 @@ COVESA maintains a [quantity file](https://github.com/COVESA/vehicle_signal_spec
 
 When deciding which quantities to use the tooling use the following logic:
 
-* If `--quantities/-q <file>` is used then the specified quantity files will be used. Default quantities will not be considered.
-* If `--quantities/-q <file>` is not used the tool will check for a file called `quantities.yaml` in the same directory as the root `*.vspec` file.
+- If `--quantities/-q <file>` is used then the specified quantity files will be used. Default quantities will not be considered.
+- If `--quantities/-q <file>` is not used the tool will check for a file called `quantities.yaml` in the same directory as the root `*.vspec` file.
 
 As of today use of quantity files is optional, and tooling will only give a warning if a unit use a quantity not specified in a quantity file.
 
 ## Handling of overlays and extensions
+
 The generator framework allows composition of several overlays on top of a base vspec, to extend the model or overwrite certain metadata. Check [VSS documentation](https://covesa.github.io/vehicle_signal_specification/introduction/) on the concept of overlays.
 
 Overlays are in general injected before the VSS tree is expanded. Expansion is the process where branches with instances are transformed into multiple branches.
@@ -258,10 +287,10 @@ Vehicle.Cabin.Door.NewSignal:
 
 This will result in that the following new signals are created
 
-* `Vehicle.Cabin.Door.Row1.Left.NewSignal`
-* `Vehicle.Cabin.Door.Row1.Right.NewSignal`
-* `Vehicle.Cabin.Door.Row2.Left.NewSignal`
-* `Vehicle.Cabin.Door.Row2.Right.NewSignal`
+- `Vehicle.Cabin.Door.Row1.Left.NewSignal`
+- `Vehicle.Cabin.Door.Row1.Right.NewSignal`
+- `Vehicle.Cabin.Door.Row2.Left.NewSignal`
+- `Vehicle.Cabin.Door.Row2.Right.NewSignal`
 
 If you only want to add the new signal to one of the doors, then you can create an overlay like below.
 
@@ -279,9 +308,9 @@ signal and not expand it further. If using an overlay to redefine a specific sig
 (like `Vehicle.Cabin.Door.Row1.Left.IsChildLockActive`) has precedence over data specified for not yet extended signals
 (like `Vehicle.Cabin.Door.IsChildLockActive`).
 
-*Note: If using `--no-expand` together with overlays for specific instances then the result will be a combination*
-*of expanded and unexpanded paths. For the example above `Vehicle.Cabin.Door.Row1.Left.NewSignal` will be expanded*
-*but all other signals in `Vehicle.Cabin.Door` will remain unexpanded!*
+_Note: If using `--no-expand` together with overlays for specific instances then the result will be a combination_
+_of expanded and unexpanded paths. For the example above `Vehicle.Cabin.Door.Row1.Left.NewSignal` will be expanded_
+_but all other signals in `Vehicle.Cabin.Door` will remain unexpanded!_
 
 It is possible to use `-l` multiple times, e.g.
 
@@ -300,11 +329,11 @@ Vehicle:
   type: branch
 
 Vehicle.Speed:
-    quality: 100
-    source: "ecu0xAA"
+  quality: 100
+  source: "ecu0xAA"
 ```
 
-This will give a warning about unknown attributes, or even terminate the parsing when `--strict`  or `--aborts unknown-attribute` is used.
+This will give a warning about unknown attributes, or even terminate the parsing when `--strict` or `--aborts unknown-attribute` is used.
 
 ```bash
 vspec export json -I spec --vspec spec/VehicleSignalSpecification.vspec --strict -l overlay.vspec --output test.json
@@ -336,18 +365,21 @@ In this case the expectation is, that the generated output will contain the whit
 ## JSON exporter notes
 
 ### --extended-all-attributes
+
 Lets the exporter generate _all_ extended metadata attributes found in the model. By default the exporter is generating only those given by the `-e`/`--extended-attributes` parameter.
 
 ### --pretty
+
 If the parameter is set it will pretty-print the JSON output, otherwise you will get a minimized version
 
 ## JSONSCHEMA exporter notes
 
 ### --extended-all-attributes
+
 Lets the exporter generate _all_ extended metadata attributes found in the model. By default the exporter is generating only those given by the `-e`/`--extended-attributes` parameter. This will also add unconverted VSS standard attributes into the schema using the following attributes
 
 | VSS attribute | in schema     |
-|---------------|---------------|
+| ------------- | ------------- |
 | type          | x-VSStype     |
 | datatype      | x-datatype    |
 | deprecation   | x-deprecation |
@@ -357,36 +389,41 @@ Lets the exporter generate _all_ extended metadata attributes found in the model
 Not that strict JSON schema validators might not accept jsonschemas with such extra, non-standard entries.
 
 ### --no-additional-properties
+
 Do not allow properties not defined in VSS tree, when elements are validated against the schema, what this basically does is setting
 
 ```json
 "additionalProperties": false
 ```
+
 for all defined objects. See: https://json-schema.org/draft/2020-12/json-schema-core#additionalProperties
 
-###  --require-all-properties
+### --require-all-properties
+
 Require all elements defined in VSS tree for a valid object, i.e. this populates the `required` list with all children. See: https://json-schema.org/draft/2020-12/json-schema-validation#name-required
 
 ### --pretty
+
 If the paramter is set it will pretty-print the JSON output, otherwise you will get a minimized version
 
 ## YAML exporter notes
 
 ### --extended-all-attributes
+
 Lets the exporter generate _all_ extended metadata attributes found in the model. By default the exporter is generating only those given by the `-e`/`--extended-attributes` parameter.
 
 ### --all-idl-features
+
 Will also generate non-payload const attributes such as unit/datatype. Default is not to generate them/comment them out because at least Cyclone DDS and FastDDS do not support const. For more information check the [DDS-IDL exporter docs](ddsidl.md).
 
 ## GRAPHQL exporter notes
 
 ### --gql-fields name,description
+
 Add additional fields to the nodes in the graphql schema. use: <field_name>,<description>.
 Can be used more than once.
-
 
 ## Writing your own generator
 
 Just have a look at current implementations of exporters.
 Start by copy pasting the `def cli()`. Think about parameters the exporter supports.
-

--- a/src/vss_tools/cli_options.py
+++ b/src/vss_tools/cli_options.py
@@ -12,6 +12,7 @@ import rich_click as click
 from rich_click import option
 
 from vss_tools.model import get_all_model_fields
+from vss_tools.strict import StrictOption
 
 
 def validate_attribute(value):
@@ -63,11 +64,19 @@ strict_opt = option(
     show_default=True,
 )
 
+strict_exceptions_opt = option(
+    "--strict-exceptions",
+    help="""A YAML file that specifies a list of absolute VSS signal paths to be excluded from the strict check
+    Entries are VSS signal paths the value either empty or a list of allowed aborts.
+    """,
+    type=click.Path(dir_okay=False, readable=True, path_type=Path, exists=True),
+)
+
 aborts_opt = option(
     "--aborts",
     "-a",
     multiple=True,
-    type=click.Choice(["unknown-attribute", "name-style"]),
+    type=click.Choice([StrictOption.NAME_STYLE.value, StrictOption.UNKNOWN_ATTRIBUTE.value]),
     help="Abort on selected option. The '--strict' option enables all of them.",
     show_choices=True,
 )

--- a/src/vss_tools/exporters/apigear.py
+++ b/src/vss_tools/exporters/apigear.py
@@ -449,6 +449,7 @@ def export_apigear(
 @clo.quantities_opt
 @clo.units_opt
 @clo.types_opt
+@clo.strict_exceptions_opt
 @click.option(
     "--output-dir",
     required=True,
@@ -486,6 +487,7 @@ def cli(
     units: tuple[Path],
     types: tuple[Path],
     output_dir: Path,
+    strict_exceptions: Path | None,
     apigear_template_unreal_path: Path,
     apigear_template_cpp_path: Path,
     apigear_template_qt5_path: Path,
@@ -504,6 +506,7 @@ def cli(
         units=units,
         types=types,
         overlays=overlays,
+        strict_exceptions_file=strict_exceptions,
     )
     log.info("Generating ApiGear output...")
     if output_dir.exists():

--- a/src/vss_tools/exporters/binary.py
+++ b/src/vss_tools/exporters/binary.py
@@ -60,7 +60,7 @@ def intToHexChar(hexInt):
 # Create a struct containing the length of the string as uint8
 #  and the string itself
 def create_l8v_string(s: str) -> bytes:
-    pack = struct.pack(f"{len(s)+1}p", s.encode())
+    pack = struct.pack(f"{len(s) + 1}p", s.encode())
     # log.debug(f"create_l8v_string: {s} as {pack.hex()}")
     return pack
 
@@ -113,6 +113,7 @@ def export_node(node: VSSNode, f: BinaryIO):
 @clo.units_opt
 @clo.types_opt
 @clo.types_output_opt
+@clo.strict_exceptions_opt
 def cli(
     vspec: Path,
     output: Path,
@@ -125,6 +126,7 @@ def cli(
     units: tuple[Path],
     types: tuple[Path],
     types_output: Path | None,
+    strict_exceptions: Path | None,
 ):
     """
     Export to Binary.
@@ -140,6 +142,7 @@ def cli(
         units=units,
         types=types,
         overlays=overlays,
+        strict_exceptions_file=strict_exceptions,
     )
 
     log.info("Generating binary output...")

--- a/src/vss_tools/exporters/csv.py
+++ b/src/vss_tools/exporters/csv.py
@@ -97,6 +97,7 @@ def write_csv(rows: list[list[Any]], output: Path):
 @clo.units_opt
 @clo.types_opt
 @clo.types_output_opt
+@clo.strict_exceptions_opt
 @click.option(
     "--stats-sankey",
     type=click.Path(path_type=Path),
@@ -128,6 +129,7 @@ def cli(
     stats_sankey: Path | None,
     stats_piechart: Path | None,
     stats_old_piechart: Path | None,
+    strict_exceptions: Path | None,
 ):
     """
     Export as CSV.
@@ -159,6 +161,7 @@ def cli(
         types=types,
         overlays=overlays,
         expand=expand,
+        strict_exceptions_file=strict_exceptions,
     )
     log.info("Generating CSV output...")
 

--- a/src/vss_tools/exporters/ddsidl.py
+++ b/src/vss_tools/exporters/ddsidl.py
@@ -227,8 +227,7 @@ def export_node(node: VSSNode, generate_all_idl_features: bool) -> None:
                 allowed_values = str(allowed)
             else:
                 log.warning(
-                    f"VSS2IDL can only handle allowed values for string type, "
-                    f"signal {node.name} has type {datatype}"
+                    f"VSS2IDL can only handle allowed values for string type, signal {node.name} has type {datatype}"
                 )
 
         idl_file_buffer.append("struct " + getAllowedName(node.name))
@@ -390,6 +389,7 @@ def export_idl(file, root, generate_all_idl_features=False):
 @clo.quantities_opt
 @clo.units_opt
 @clo.types_opt
+@clo.strict_exceptions_opt
 @click.option(
     "--all-idl-features",
     is_flag=True,
@@ -407,6 +407,7 @@ def cli(
     units: tuple[Path],
     types: tuple[Path],
     all_idl_features: bool,
+    strict_exceptions: Path | None,
 ):
     """
     Export as DDSIDL.
@@ -421,6 +422,7 @@ def cli(
         units=units,
         types=types,
         overlays=overlays,
+        strict_exceptions_file=strict_exceptions,
     )
     log.info("Generating DDS-IDL output...")
 

--- a/src/vss_tools/exporters/franca.py
+++ b/src/vss_tools/exporters/franca.py
@@ -91,6 +91,7 @@ def print_franca_content(file: TextIOWrapper, root: VSSNode) -> None:
 @clo.overlays_opt
 @clo.quantities_opt
 @clo.units_opt
+@clo.strict_exceptions_opt
 @click.option("--franca-vss-version", help="Adds franca version info.")
 def cli(
     vspec: Path,
@@ -104,6 +105,7 @@ def cli(
     units: tuple[Path],
     types: tuple[Path],
     franca_vss_version: str,
+    strict_exceptions: Path | None,
 ):
     """
     Export as Franca.
@@ -119,6 +121,7 @@ def cli(
         types=types,
         units=units,
         overlays=overlays,
+        strict_exceptions_file=strict_exceptions,
     )
     with open(output, "w") as f:
         print_franca_header(f, franca_vss_version)

--- a/src/vss_tools/exporters/go.py
+++ b/src/vss_tools/exporters/go.py
@@ -270,6 +270,7 @@ def strip_structs_prefix(prefix: str, structs: dict[str, GoStruct]) -> int:
 @clo.quantities_opt
 @clo.units_opt
 @clo.types_opt
+@clo.strict_exceptions_opt
 @click.option("--package", default="vss", help="Go package name", show_default=True)
 @click.option("--short-names/--no-short-names", default=True, show_default=True, help="Shorten struct names")
 def cli(
@@ -285,6 +286,7 @@ def cli(
     types: tuple[Path],
     package: str,
     short_names: bool,
+    strict_exceptions: Path | None,
 ):
     """
     Export as Go structs.
@@ -299,6 +301,7 @@ def cli(
         units=units,
         types=types,
         overlays=overlays,
+        strict_exceptions_file=strict_exceptions,
     )
     instance_map = get_instance_mapping(tree)
     structs = get_go_structs(tree, instance_map)

--- a/src/vss_tools/exporters/graphql.py
+++ b/src/vss_tools/exporters/graphql.py
@@ -535,6 +535,7 @@ def sort_dict_by_key(dictionary: dict) -> dict:
 @clo.overlays_opt
 @clo.quantities_opt
 @clo.units_opt
+@clo.strict_exceptions_opt
 @click.option(
     "--legacy-mapping-output",
     type=click.Path(dir_okay=False, writable=True, path_type=Path),
@@ -551,6 +552,7 @@ def cli(
     quantities: tuple[Path],
     units: tuple[Path],
     legacy_mapping_output: Path | None,
+    strict_exceptions: Path | None,
 ):
     """
     Export a VSS specification to a GraphQL schema.
@@ -566,6 +568,7 @@ def cli(
             units=units,
             overlays=overlays,
             expand=False,
+            strict_exceptions_file=strict_exceptions,
         )
 
         log.info("Generating GraphQL output...")

--- a/src/vss_tools/exporters/id.py
+++ b/src/vss_tools/exporters/id.py
@@ -145,6 +145,7 @@ def export_node(data: dict[str, Any], node: VSSNode, id_counter, strict_mode: bo
 @clo.quantities_opt
 @clo.units_opt
 @clo.types_opt
+@clo.strict_exceptions_opt
 @click.option(
     "--validate-static-uid",
     type=click.Path(dir_okay=False, readable=True, exists=True, path_type=Path),
@@ -171,6 +172,7 @@ def cli(
     validate_static_uid: Path,
     validate_only: bool,
     case_sensitive: bool,
+    strict_exceptions: Path | None,
 ):
     """
     Export as IDs.
@@ -186,6 +188,7 @@ def cli(
         types=types,
         overlays=overlays,
         expand=expand,
+        strict_exceptions_file=strict_exceptions,
     )
     log.info("Generating vspec output including static UIDs...")
 
@@ -194,9 +197,7 @@ def cli(
     id_counter, _ = export_node(signals_yaml_dict, tree, id_counter, case_sensitive)
 
     if validate_static_uid:
-        log.info(
-            f"Now validating nodes, static UIDs, types, units and description with " f"file '{validate_static_uid}'"
-        )
+        log.info(f"Now validating nodes, static UIDs, types, units and description with file '{validate_static_uid}'")
 
         validation_tree, _ = get_trees(
             vspec=validate_static_uid,

--- a/src/vss_tools/exporters/json.py
+++ b/src/vss_tools/exporters/json.py
@@ -50,6 +50,7 @@ def get_data(node: VSSNode, with_extra_attributes: bool = True, extended_attribu
 @clo.types_output_opt
 @clo.pretty_print_opt
 @clo.extend_all_attributes_opt
+@clo.strict_exceptions_opt
 @click.option(
     "--stats-radial",
     type=click.Path(path_type=Path),
@@ -73,6 +74,7 @@ def cli(
     pretty: bool,
     extend_all_attributes: bool,
     stats_radial: Path | None,
+    strict_exceptions: Path | None,
 ):
     """
     Export as JSON.
@@ -92,6 +94,7 @@ def cli(
         types=types,
         overlays=overlays,
         expand=expand,
+        strict_exceptions_file=strict_exceptions,
     )
     log.info("Generating JSON output...")
     indent = None

--- a/src/vss_tools/exporters/jsonschema.py
+++ b/src/vss_tools/exporters/jsonschema.py
@@ -58,6 +58,7 @@ type_map = {
 @clo.types_opt
 @clo.extend_all_attributes_opt
 @clo.pretty_print_opt
+@clo.strict_exceptions_opt
 @click.option(
     "--no-additional-properties",
     is_flag=True,
@@ -84,6 +85,7 @@ def cli(
     pretty: bool,
     no_additional_properties: bool,
     require_all_properties: bool,
+    strict_exceptions: Path | None,
 ):
     """
     Export as a jsonschema.
@@ -99,6 +101,7 @@ def cli(
         types=types,
         overlays=overlays,
         expand=expand,
+        strict_exceptions_file=strict_exceptions,
     )
     log.info("Generating JSON schema...")
     indent = None

--- a/src/vss_tools/exporters/plantuml.py
+++ b/src/vss_tools/exporters/plantuml.py
@@ -193,6 +193,7 @@ def get_rendered_tree(node: VSSNode, fill, attributes: tuple[str]) -> str:
 @clo.quantities_opt
 @clo.units_opt
 @clo.types_opt
+@clo.strict_exceptions_opt
 @click.option("--attr", help="Show VSSData attribute", multiple=True)
 def cli(
     vspec: Path,
@@ -207,6 +208,7 @@ def cli(
     types: tuple[Path],
     output: Path | None,
     attr: tuple[str],
+    strict_exceptions: Path | None,
 ):
     """
     Export as PlantUML.
@@ -222,6 +224,7 @@ def cli(
         types=types,
         overlays=overlays,
         expand=expand,
+        strict_exceptions_file=strict_exceptions,
     )
 
     plant_code = get_enums(tree, "", attr)

--- a/src/vss_tools/exporters/protobuf.py
+++ b/src/vss_tools/exporters/protobuf.py
@@ -175,6 +175,7 @@ def print_messages(nodes: tuple[VSSNode], fd: TextIOWrapper, static_uid: bool, a
 @clo.quantities_opt
 @clo.units_opt
 @clo.types_opt
+@clo.strict_exceptions_opt
 @click.option(
     "--types-out-dir",
     help="Output directory for generated protos.",
@@ -200,6 +201,7 @@ def cli(
     types_out_dir: Path | None,
     static_uid: bool,
     add_optional: bool,
+    strict_exceptions: Path | None,
 ):
     """
     Export as protobuf.
@@ -215,6 +217,7 @@ def cli(
         units=units,
         types=types,
         overlays=overlays,
+        strict_exceptions_file=strict_exceptions,
     )
     if datatype_tree:
         if not types_out_dir:

--- a/src/vss_tools/exporters/samm/__init__.py
+++ b/src/vss_tools/exporters/samm/__init__.py
@@ -160,6 +160,7 @@ Path to or name for the target folder, where generated aspect models (.ttl files
 @clo.units_opt
 @clo.types_opt
 @clo.types_output_opt
+@clo.strict_exceptions_opt
 def cli(
     vspec: Path,
     target_folder: Path,
@@ -172,6 +173,7 @@ def cli(
     units: tuple[Path],
     types: tuple[Path],
     types_output: Path,
+    strict_exceptions: Path | None,
     signals_file,
     output_namespace,
     split,
@@ -191,7 +193,17 @@ def cli(
     #       Just keep in mind that this might lead to some additional logic,
     #       to make sure that each case is handled correctly.
     vss_tree, datatype_tree = get_trees(
-        vspec, include_dirs, aborts, strict, extended_attributes, quantities, units, types, overlays, False
+        vspec,
+        include_dirs,
+        aborts,
+        strict,
+        extended_attributes,
+        quantities,
+        units,
+        types,
+        overlays,
+        False,
+        strict_exceptions,
     )
 
     # Get the VSS version from the vss_tree::VersionVSS
@@ -271,8 +283,7 @@ def cli(
             )
         else:
             log.warning(
-                "VSS to ESMF - SAMM processing - COMPLETED\n\n"
-                "VSS tree was not converted because it is DEPRECATED.\n\n"
+                "VSS to ESMF - SAMM processing - COMPLETED\n\nVSS tree was not converted because it is DEPRECATED.\n\n"
             )
 
     else:

--- a/src/vss_tools/exporters/tree.py
+++ b/src/vss_tools/exporters/tree.py
@@ -44,12 +44,14 @@ def get_rendered_tree(tree: VSSNode, attributes: tuple[str]) -> str:
 @clo.quantities_opt
 @clo.units_opt
 @clo.types_opt
+@clo.strict_exceptions_opt
 @click.option("--attr", help="Show VSSData attribute", multiple=True)
 def cli(
     vspec: Path,
     include_dirs: tuple[Path],
     extended_attributes: tuple[str],
     strict: bool,
+    strict_exceptions: Path | None,
     aborts: tuple[str],
     expand: bool,
     overlays: tuple[Path],
@@ -73,6 +75,7 @@ def cli(
         types=types,
         overlays=overlays,
         expand=expand,
+        strict_exceptions_file=strict_exceptions,
     )
 
     rendered_tree = get_rendered_tree(tree, attr)

--- a/src/vss_tools/exporters/yaml.py
+++ b/src/vss_tools/exporters/yaml.py
@@ -61,6 +61,7 @@ class NoAliasDumper(yaml.SafeDumper):
 @clo.types_opt
 @clo.types_output_opt
 @clo.extend_all_attributes_opt
+@clo.strict_exceptions_opt
 def cli(
     vspec: Path,
     output: Path,
@@ -75,6 +76,7 @@ def cli(
     types: tuple[Path],
     types_output: Path | None,
     extend_all_attributes: bool,
+    strict_exceptions: Path | None,
 ):
     """
     Export as YAML.
@@ -90,6 +92,7 @@ def cli(
         types=types,
         overlays=overlays,
         expand=expand,
+        strict_exceptions_file=strict_exceptions,
     )
     log.info("Generating YAML output...")
     tree_data = tree.as_flat_dict(extend_all_attributes, extended_attributes)

--- a/src/vss_tools/strict.py
+++ b/src/vss_tools/strict.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2025 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+from enum import Enum
+from pathlib import Path
+
+import yaml
+from pydantic import BaseModel
+
+
+class StrictExceptions:
+    def __init__(self) -> None:
+        self.names: set[str] = set()
+        self.attributes: set[str] = set()
+
+
+class StrictOption(str, Enum):
+    NAME_STYLE = "name-style"
+    UNKNOWN_ATTRIBUTE = "unknown-attribute"
+
+
+class StrictException(BaseModel):
+    fqn: str
+    options: set[StrictOption] | None = None
+
+
+def load_strict_exceptions(file: Path | None) -> StrictExceptions:
+    exceptions = StrictExceptions()
+
+    if not file:
+        return exceptions
+
+    with open(file) as f:
+        data = yaml.safe_load(f)
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Invalid exceptions file format (not a dict): {file}")
+
+    key: str
+    value: set[StrictOption] | None
+    for key, value in data.items():
+        exception = StrictException(fqn=key, options=value)
+
+        if exception.options:
+            for e in exception.options:
+                if e == StrictOption.NAME_STYLE:
+                    exceptions.names.add(exception.fqn)
+                elif e == StrictOption.UNKNOWN_ATTRIBUTE:
+                    exceptions.attributes.add(exception.fqn)
+        else:
+            exceptions.names.add(exception.fqn)
+            exceptions.attributes.add(exception.fqn)
+
+    return exceptions

--- a/src/vss_tools/tree.py
+++ b/src/vss_tools/tree.py
@@ -291,7 +291,7 @@ class VSSNode(Node):  # type: ignore[misc]
                     if not node.name.startswith("Is") and not node.name.startswith("Has"):
                         violations.append([node.get_fqn(), "Not starting with 'Is' or 'Has'"])
         if violations:
-            log.info(f"Naming violations: {len(violations)}")
+            log.info(f"Naming violations (before applying exceptions): {len(violations)}")
         return violations
 
     def get_extra_attributes(self, allowed: tuple[str, ...]) -> list[list[str]]:
@@ -305,7 +305,7 @@ class VSSNode(Node):  # type: ignore[misc]
                 if field not in allowed:
                     violations.append([node.get_fqn(), field])
         if violations:
-            log.warning(f"Attributes, violations={len(violations)}")
+            log.info(f"Attributes (before applying exceptions): {len(violations)}")
         return violations
 
     def as_flat_dict(self, with_extra_attributes: bool, extended_attributes: tuple[str, ...] = ()) -> dict[str, Any]:

--- a/tests/test_strict.py
+++ b/tests/test_strict.py
@@ -1,0 +1,143 @@
+# Copyright (c) 2025 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import tempfile
+from pathlib import Path
+
+import pydantic
+import pytest
+import yaml
+from vss_tools.strict import StrictException, StrictExceptions, StrictOption, load_strict_exceptions
+
+
+class TestStrictException:
+    def test_init_with_fqn_only(self):
+        exception = StrictException(fqn="Vehicle.Speed")
+        assert exception.fqn == "Vehicle.Speed"
+        assert exception.options is None
+
+    def test_init_with_options(self):
+        options = {StrictOption.NAME_STYLE}
+        exception = StrictException(fqn="Vehicle.Speed", options=options)
+        assert exception.fqn == "Vehicle.Speed"
+        assert exception.options == options
+
+    def test_init_with_multiple_options(self):
+        options = {StrictOption.NAME_STYLE, StrictOption.UNKNOWN_ATTRIBUTE}
+        exception = StrictException(fqn="Vehicle.Speed", options=options)
+        assert exception.fqn == "Vehicle.Speed"
+        assert exception.options == options
+
+
+class TestLoadStrictExceptions:
+    def test_load_with_none_file(self):
+        exceptions = load_strict_exceptions(None)
+        assert isinstance(exceptions, StrictExceptions)
+        assert len(exceptions.names) == 0
+        assert len(exceptions.attributes) == 0
+
+    def test_load_empty_file(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
+            yaml.dump({}, f)
+            temp_path = Path(f.name)
+            exceptions = load_strict_exceptions(temp_path)
+            assert isinstance(exceptions, StrictExceptions)
+            assert len(exceptions.names) == 0
+            assert len(exceptions.attributes) == 0
+
+    def test_load_with_name_style_exception(self):
+        data = {"Vehicle.Speed": ["name-style"]}
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
+            yaml.dump(data, f)
+            temp_path = Path(f.name)
+            exceptions = load_strict_exceptions(temp_path)
+            assert "Vehicle.Speed" in exceptions.names
+            assert "Vehicle.Speed" not in exceptions.attributes
+
+    def test_load_with_unknown_attribute_exception(self):
+        data = {"Vehicle.Speed": ["unknown-attribute"]}
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
+            yaml.dump(data, f)
+            temp_path = Path(f.name)
+            exceptions = load_strict_exceptions(temp_path)
+            assert "Vehicle.Speed" not in exceptions.names
+            assert "Vehicle.Speed" in exceptions.attributes
+
+    def test_load_with_multiple_exceptions(self):
+        data = {"Vehicle.Speed": ["name-style", "unknown-attribute"]}
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
+            yaml.dump(data, f)
+            temp_path = Path(f.name)
+            exceptions = load_strict_exceptions(temp_path)
+            assert "Vehicle.Speed" in exceptions.names
+            assert "Vehicle.Speed" in exceptions.attributes
+
+    def test_load_with_null_options(self):
+        data = {"Vehicle.Speed": None}
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
+            yaml.dump(data, f)
+            temp_path = Path(f.name)
+            exceptions = load_strict_exceptions(temp_path)
+            assert "Vehicle.Speed" in exceptions.names
+            assert "Vehicle.Speed" in exceptions.attributes
+
+    def test_load_multiple_entries(self):
+        data = {
+            "Vehicle.Speed": ["name-style"],
+            "Vehicle.Engine.RPM": ["unknown-attribute"],
+            "Vehicle.Body.Doors": None,
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
+            yaml.dump(data, f)
+            temp_path = Path(f.name)
+            exceptions = load_strict_exceptions(temp_path)
+            assert "Vehicle.Speed" in exceptions.names
+            assert "Vehicle.Speed" not in exceptions.attributes
+            assert "Vehicle.Engine.RPM" not in exceptions.names
+            assert "Vehicle.Engine.RPM" in exceptions.attributes
+            assert "Vehicle.Body.Doors" in exceptions.names
+            assert "Vehicle.Body.Doors" in exceptions.attributes
+
+    def test_load_invalid_entry(self):
+        data = {
+            "Vehicle.Speed": ["what am I"],
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
+            yaml.dump(data, f)
+            temp_path = Path(f.name)
+            with pytest.raises(pydantic.ValidationError):
+                _ = load_strict_exceptions(temp_path)
+
+    def test_load_with_invalid_file_format(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
+            _ = f.write("invalid: yaml: content: [")
+            temp_path = Path(f.name)
+            with pytest.raises(ValueError):
+                _ = load_strict_exceptions(temp_path)
+
+    def test_load_with_non_dict_content(self):
+        data = ["not", "a", "dict"]
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
+            yaml.dump(data, f)
+            temp_path = Path(f.name)
+            with pytest.raises(ValueError, match="Invalid exceptions file format"):
+                _ = load_strict_exceptions(temp_path)
+
+    def test_load_with_nonexistent_file(self):
+        nonexistent_path = Path("/nonexistent/file.yaml")
+        with pytest.raises(FileNotFoundError):
+            _ = load_strict_exceptions(nonexistent_path)
+
+    def test_load_with_empty_string_options(self):
+        data: dict[str, list[str] | None] = {"Vehicle.Speed": []}
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
+            yaml.dump(data, f)
+            temp_path = Path(f.name)
+            exceptions = load_strict_exceptions(temp_path)
+            assert "Vehicle.Speed" in exceptions.names
+            assert "Vehicle.Speed" in exceptions.attributes

--- a/tests/vspec/test_strict/exceptions.yaml
+++ b/tests/vspec/test_strict/exceptions.yaml
@@ -1,0 +1,3 @@
+A.NotStartingWithIs:
+  - name-style
+A.uInt8:

--- a/tests/vspec/test_strict/test_strict_e2e.py
+++ b/tests/vspec/test_strict/test_strict_e2e.py
@@ -49,3 +49,13 @@ def test_strict_error(vspec_file: str, tmp_path):
     cmd = f"vspec export json --pretty --strict -u {TEST_UNITS} -q {TEST_QUANT} --vspec {spec} --output {output}"
     process = subprocess.run(cmd.split())
     assert process.returncode != 0
+
+
+@pytest.mark.parametrize("vspec_file", ["faulty_case.vspec", "faulty_name_boolean.vspec"])
+def test_strict_exceptions(vspec_file: str, tmp_path):
+    spec = HERE / vspec_file
+    output = tmp_path / "out.json"
+    cmd = f"vspec export json --pretty --strict --strict-exceptions {HERE / 'exceptions.yaml'}"
+    cmd += f" -u {TEST_UNITS} -q {TEST_QUANT} --vspec {spec} --output {output}"
+    process = subprocess.run(cmd.split())
+    assert process.returncode == 0


### PR DESCRIPTION
# About

Idea is to be able to enable `--strict` and/or `--aborts` e.g. in CI but allowing current existing violations.

Added `--strict-exceptions` that should point to a YAML file defining exceptions in the following way:

```yaml
Vehicle.Foo: # Allow all violations

Vehicle.Bar: # Allow name violoations
  - name-style

Vehicle.Zed: # Allow unknown attribute violations
  - unknown-attribute

Vehicle.Yada: # Allow specific violations
  - name-style
  - unknown-attribute
```

Refactored available strict options into an enum and using it.