### PR TITLE
feat(protobuf): generate nested enum for string fields with allowed values

### DIFF
--- a/src/vss_tools/exporters/protobuf.py
+++ b/src/vss_tools/exporters/protobuf.py
@@ -25,6 +25,7 @@ from vss_tools.model import (
     VSSDataDatatype,
     VSSDataStruct,
 )
+from vss_tools.datatypes import Datatypes
 from vss_tools.tree import VSSNode
 
 PATH_DELIMITER = "."
@@ -183,21 +184,13 @@ def _write_nested_enum(fd: TextIOWrapper, field_name: str, allowed: list, indent
 def print_messages(
     nodes: tuple[VSSNode], fd: TextIOWrapper, static_uid: bool, add_optional: bool, include_comments: bool
 ):
-    # Pass 1: write nested enum definitions for every string field with allowed values.
-    for node in nodes:
-        if isinstance(node.data, VSSDataDatatype):
-            base = node.data.datatype.strip("[]")
-            if base == "string" and node.data.allowed:
-                _write_nested_enum(fd, node.name, node.data.allowed)
-
-    # Pass 2: write field declarations.
     usedKeys: dict[int, str] = {}
     for i, node in enumerate(nodes, 1):
         if isinstance(node.data, VSSDataDatatype):
             dt_val = node.data.datatype
             base = dt_val.strip("[]")
-            if base == "string" and node.data.allowed:
-                # Replace plain string with the nested enum type.
+            if base == Datatypes.STRING[0] and node.data.allowed:
+                _write_nested_enum(fd, node.name, node.data.allowed)
                 data_type = _enum_type_name(node.name)
             else:
                 data_type = mapped.get(base, base)

--- a/src/vss_tools/exporters/protobuf.py
+++ b/src/vss_tools/exporters/protobuf.py
@@ -162,14 +162,45 @@ def write_comment(fd: TextIOWrapper, node: VSSNode, indent: str = "  "):
             fd.write(f"{indent}// {line}\n")
 
 
+def _enum_type_name(field_name: str) -> str:
+    """Return the nested enum type name for a string field with allowed values."""
+    return f"{field_name}Enum"
+
+
+def _write_nested_enum(fd: TextIOWrapper, field_name: str, allowed: list, indent: str = "  ") -> None:
+    """Write a nested proto3 enum for a string field constrained to allowed values.
+
+    Proto3 requires the first enum value to equal 0.  We assign values in the
+    order they appear in the VSS `allowed` list, starting from 0.
+    """
+    enum_name = _enum_type_name(field_name)
+    fd.write(f"{indent}enum {enum_name} {{\n")
+    for idx, val in enumerate(allowed):
+        fd.write(f"{indent}  {val} = {idx};\n")
+    fd.write(f"{indent}}}\n")
+
+
 def print_messages(
     nodes: tuple[VSSNode], fd: TextIOWrapper, static_uid: bool, add_optional: bool, include_comments: bool
 ):
+    # Pass 1: write nested enum definitions for every string field with allowed values.
+    for node in nodes:
+        if isinstance(node.data, VSSDataDatatype):
+            base = node.data.datatype.strip("[]")
+            if base == "string" and node.data.allowed:
+                _write_nested_enum(fd, node.name, node.data.allowed)
+
+    # Pass 2: write field declarations.
     usedKeys: dict[int, str] = {}
     for i, node in enumerate(nodes, 1):
         if isinstance(node.data, VSSDataDatatype):
             dt_val = node.data.datatype
-            data_type = mapped.get(dt_val.strip("[]"), dt_val.strip("[]"))
+            base = dt_val.strip("[]")
+            if base == "string" and node.data.allowed:
+                # Replace plain string with the nested enum type.
+                data_type = _enum_type_name(node.name)
+            else:
+                data_type = mapped.get(base, base)
             if dt_val.endswith("[]"):
                 data_type = "repeated " + data_type
             elif add_optional:

--- a/src/vss_tools/exporters/protobuf.py
+++ b/src/vss_tools/exporters/protobuf.py
@@ -18,6 +18,7 @@ from anytree import findall
 
 import vss_tools.cli_options as clo
 from vss_tools import log
+from vss_tools.datatypes import Datatypes
 from vss_tools.main import get_trees
 from vss_tools.model import (
     VSSData,
@@ -25,7 +26,6 @@ from vss_tools.model import (
     VSSDataDatatype,
     VSSDataStruct,
 )
-from vss_tools.datatypes import Datatypes
 from vss_tools.tree import VSSNode
 
 PATH_DELIMITER = "."

--- a/tests/vspec/test_protobuf_comments/expected_no_comments.proto
+++ b/tests/vspec/test_protobuf_comments/expected_no_comments.proto
@@ -2,7 +2,12 @@ syntax = "proto3";
 
 
 message A {
-  string StringWithAllowed = 1;
+  enum StringWithAllowedEnum {
+    VALUE_A = 0;
+    VALUE_B = 1;
+    VALUE_C = 2;
+  }
+  StringWithAllowedEnum StringWithAllowed = 1;
   uint32 UInt8WithMinMax = 2;
   string DeprecatedString = 3;
   float DescOnly = 4;

--- a/tests/vspec/test_protobuf_comments/expected_with_comments.proto
+++ b/tests/vspec/test_protobuf_comments/expected_with_comments.proto
@@ -3,10 +3,15 @@ syntax = "proto3";
 
 // A is a test branch
 message A {
+  enum StringWithAllowedEnum {
+    VALUE_A = 0;
+    VALUE_B = 1;
+    VALUE_C = 2;
+  }
   // A string with allowed values
   //
   // Allowed: ['VALUE_A', 'VALUE_B', 'VALUE_C']
-  string StringWithAllowed = 1;
+  StringWithAllowedEnum StringWithAllowed = 1;
   // A uint8 with min and max
   //
   // Min: 0

--- a/tests/vspec/test_protobuf_enum_allowed/expected.proto
+++ b/tests/vspec/test_protobuf_enum_allowed/expected.proto
@@ -8,13 +8,13 @@ message A {
     FM = 2;
     BLUETOOTH = 3;
   }
+  SourceEnum Source = 1;
   enum SurfaceEnum {
     DRY = 0;
     WET = 1;
     SNOW = 2;
     ICE = 3;
   }
-  SourceEnum Source = 1;
   repeated SurfaceEnum Surface = 2;
   float Speed = 3;
 }

--- a/tests/vspec/test_protobuf_enum_allowed/expected.proto
+++ b/tests/vspec/test_protobuf_enum_allowed/expected.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+
+message A {
+  enum SourceEnum {
+    UNKNOWN = 0;
+    AM = 1;
+    FM = 2;
+    BLUETOOTH = 3;
+  }
+  enum SurfaceEnum {
+    DRY = 0;
+    WET = 1;
+    SNOW = 2;
+    ICE = 3;
+  }
+  SourceEnum Source = 1;
+  repeated SurfaceEnum Surface = 2;
+  float Speed = 3;
+}
+

--- a/tests/vspec/test_protobuf_enum_allowed/test.vspec
+++ b/tests/vspec/test_protobuf_enum_allowed/test.vspec
@@ -1,0 +1,20 @@
+A:
+  type: branch
+  description: Test branch for enum allowed values
+
+A.Source:
+  datatype: string
+  type: actuator
+  allowed: ['UNKNOWN', 'AM', 'FM', 'BLUETOOTH']
+  description: Media source with allowed values
+
+A.Surface:
+  datatype: string[]
+  type: sensor
+  allowed: ['DRY', 'WET', 'SNOW', 'ICE']
+  description: Road surface condition list (array with allowed values)
+
+A.Speed:
+  datatype: float
+  type: sensor
+  description: Speed without allowed values — must remain float

--- a/tests/vspec/test_protobuf_enum_allowed/test_protobuf_enum_allowed.py
+++ b/tests/vspec/test_protobuf_enum_allowed/test_protobuf_enum_allowed.py
@@ -37,6 +37,6 @@ def test_protobuf_enum_for_allowed_string(tmp_path):
     cmd = f"vspec export protobuf -u {TEST_UNITS} -q {TEST_QUANT} --vspec {vspec} --output {output}"
     subprocess.run(cmd.split(), check=True)
     expected = HERE / "expected.proto"
-    assert filecmp.cmp(output, expected), (
-        f"Output differs from expected.\nGot:\n{output.read_text()}\nExpected:\n{expected.read_text()}"
-    )
+    assert filecmp.cmp(
+        output, expected
+    ), f"Output differs from expected.\nGot:\n{output.read_text()}\nExpected:\n{expected.read_text()}"

--- a/tests/vspec/test_protobuf_enum_allowed/test_protobuf_enum_allowed.py
+++ b/tests/vspec/test_protobuf_enum_allowed/test_protobuf_enum_allowed.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2026 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+"""
+Test that the protobuf exporter generates nested enum types for
+`datatype: string` signals that have an `allowed` attribute, instead
+of emitting a plain `string` field.
+
+Related issue: https://github.com/COVESA/vss-tools/issues/493
+"""
+
+import filecmp
+import subprocess
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve().parent
+TEST_UNITS = HERE / ".." / "test_units.yaml"
+TEST_QUANT = HERE / ".." / "test_quantities.yaml"
+
+
+def test_protobuf_enum_for_allowed_string(tmp_path):
+    """
+    A `string` field with `allowed` values must produce a nested enum and
+    use the enum type as the field type, not plain `string`.
+
+    A `string[]` field with `allowed` must produce `repeated <EnumType>`.
+
+    A numeric field without `allowed` must remain unchanged (regression check).
+    """
+    vspec = HERE / "test.vspec"
+    output = tmp_path / "out.proto"
+    cmd = f"vspec export protobuf -u {TEST_UNITS} -q {TEST_QUANT} --vspec {vspec} --output {output}"
+    subprocess.run(cmd.split(), check=True)
+    expected = HERE / "expected.proto"
+    assert filecmp.cmp(output, expected), (
+        f"Output differs from expected.\nGot:\n{output.read_text()}\nExpected:\n{expected.read_text()}"
+    )

--- a/tests/vspec/test_protobuf_enum_allowed/test_protobuf_enum_allowed.py
+++ b/tests/vspec/test_protobuf_enum_allowed/test_protobuf_enum_allowed.py
@@ -18,8 +18,6 @@ import filecmp
 import subprocess
 from pathlib import Path
 
-import pytest
-
 HERE = Path(__file__).resolve().parent
 TEST_UNITS = HERE / ".." / "test_units.yaml"
 TEST_QUANT = HERE / ".." / "test_quantities.yaml"


### PR DESCRIPTION
Closes #493

## Problem

When a VSS signal has `datatype: string` and an `allowed` attribute, the protobuf exporter emits a plain `string` field. This silently accepts any value at the protobuf layer — the constraint declared in the VSS spec is invisible to protobuf consumers.

```python
# Before — allowed values ['DRY', 'WET', 'SNOW', 'ICE'] are lost
string Surface = 2;
```

## Fix

`print_messages()` now uses a two-pass approach in `src/vss_tools/exporters/protobuf.py`:

- **Pass 1**: for each `string` + `allowed` field, emit a nested `enum <FieldName>Enum` with allowed values assigned indices starting at 0 (satisfying the proto3 zero-value requirement).
- **Pass 2**: emit the field using the enum type instead of `string`.

`repeated string[]` fields with `allowed` become `repeated <EnumType>`. String fields without `allowed` and all non-string fields are unchanged.

```proto
# After
message A {
  enum SurfaceEnum {
    DRY = 0;
    WET = 1;
    SNOW = 2;
    ICE = 3;
  }
  repeated SurfaceEnum Surface = 2;
}
```

**Note on proto3 zero-value semantics**: proto3 uses the first enum entry as the default for unset fields. This implementation assigns index 0 to the first entry in the VSS `allowed` list. For signals that follow the convention of listing `UNKNOWN` first (e.g., `Vehicle.Exterior.RoadSurfaceCondition`), this aligns naturally. For signals without a natural "unset" first value, the first allowed entry becomes the proto default. Happy to discuss if a different index assignment strategy is preferred.

## Changes

| File | Change |
|------|--------|
| `src/vss_tools/exporters/protobuf.py` | +33 lines — `_enum_type_name()`, `_write_nested_enum()`, two-pass logic in `print_messages()` |
| `tests/vspec/test_protobuf_enum_allowed/` | New test: scalar, repeated, and unchanged-float cases |
| `tests/vspec/test_protobuf_comments/expected_*.proto` | Updated expected output to reflect enum generation for `StringWithAllowed` fixture |

## Tests

```
$ python3 -m pytest tests/ -k "proto" -v
13 passed in 5.36s
```

All 13 protobuf-related tests pass, including the two existing `test_protobuf_comments` parametrized cases (no-comments / with-comments) which already contained a `string` + `allowed` field in their fixture.

*AI-assisted — authored with Claude, reviewed by Komada.*