### PR TITLE
feat(strict): add DEFAULT_MATCHES_FIRST_ALLOWED check for default==allowed[0]

### DIFF
--- a/src/vss_tools/cli_options.py
+++ b/src/vss_tools/cli_options.py
@@ -76,11 +76,13 @@ aborts_opt = option(
     "--aborts",
     "-a",
     multiple=True,
-    type=click.Choice([
-        StrictOption.NAME_STYLE.value,
-        StrictOption.UNKNOWN_ATTRIBUTE.value,
-        StrictOption.DEFAULT_MATCHES_FIRST_ALLOWED.value,
-    ]),
+    type=click.Choice(
+        [
+            StrictOption.NAME_STYLE.value,
+            StrictOption.UNKNOWN_ATTRIBUTE.value,
+            StrictOption.DEFAULT_MATCHES_FIRST_ALLOWED.value,
+        ]
+    ),
     help="Abort on selected option. The '--strict' option enables all of them.",
     show_choices=True,
 )

--- a/src/vss_tools/cli_options.py
+++ b/src/vss_tools/cli_options.py
@@ -76,7 +76,11 @@ aborts_opt = option(
     "--aborts",
     "-a",
     multiple=True,
-    type=click.Choice([StrictOption.NAME_STYLE.value, StrictOption.UNKNOWN_ATTRIBUTE.value]),
+    type=click.Choice([
+        StrictOption.NAME_STYLE.value,
+        StrictOption.UNKNOWN_ATTRIBUTE.value,
+        StrictOption.DEFAULT_MATCHES_FIRST_ALLOWED.value,
+    ]),
     help="Abort on selected option. The '--strict' option enables all of them.",
     show_choices=True,
 )

--- a/src/vss_tools/main.py
+++ b/src/vss_tools/main.py
@@ -116,9 +116,7 @@ def check_default_first_allowed_violations(
                     f"default != allowed[0]: '{violation[0]}' ({violation[1]}). "
                     "Canonical pattern: allowed: ['UNKNOWN', ...] + default: 'UNKNOWN'."
                 )
-            raise DefaultFirstAllowedException(
-                f"default != allowed[0] violations detected: {violations}"
-            )
+            raise DefaultFirstAllowedException(f"default != allowed[0] violations detected: {violations}")
 
 
 def get_types_root(types: tuple[Path, ...], include_dirs: list[Path]) -> VSSNode | None:

--- a/src/vss_tools/main.py
+++ b/src/vss_tools/main.py
@@ -36,6 +36,10 @@ class ExtraAttributesException(Exception):
     pass
 
 
+class DefaultFirstAllowedException(Exception):
+    pass
+
+
 class MultipleTypeTreesException(Exception):
     pass
 
@@ -99,6 +103,22 @@ def check_extra_attribute_violations(
     if strict or StrictOption.UNKNOWN_ATTRIBUTE in aborts:
         if extra_attributes:
             raise ExtraAttributesException(f"Forbidden extra attributes detected: {extra_attributes}")
+
+
+def check_default_first_allowed_violations(
+    root: VSSNode, strict: bool, aborts: tuple[str, ...], exceptions: set[str]
+) -> None:
+    if strict or StrictOption.DEFAULT_MATCHES_FIRST_ALLOWED in aborts:
+        violations = root.get_default_first_allowed_violations()
+        if violations and any([v[0] not in exceptions for v in violations]):
+            for violation in violations:
+                log.warning(
+                    f"default != allowed[0]: '{violation[0]}' ({violation[1]}). "
+                    "Canonical pattern: allowed: ['UNKNOWN', ...] + default: 'UNKNOWN'."
+                )
+            raise DefaultFirstAllowedException(
+                f"default != allowed[0] violations detected: {violations}"
+            )
 
 
 def get_types_root(types: tuple[Path, ...], include_dirs: list[Path]) -> VSSNode | None:
@@ -251,7 +271,8 @@ def get_trees(
     try:
         check_name_violations(root, strict, aborts, strict_exceptions.names)
         check_extra_attribute_violations(root, strict, aborts, extended_attributes, strict_exceptions.attributes)
-    except (NameViolationException, ExtraAttributesException) as e:
+        check_default_first_allowed_violations(root, strict, aborts, strict_exceptions.defaults)
+    except (NameViolationException, ExtraAttributesException, DefaultFirstAllowedException) as e:
         log.critical(e)
         exit(1)
 

--- a/src/vss_tools/strict.py
+++ b/src/vss_tools/strict.py
@@ -16,11 +16,13 @@ class StrictExceptions:
     def __init__(self) -> None:
         self.names: set[str] = set()
         self.attributes: set[str] = set()
+        self.defaults: set[str] = set()
 
 
 class StrictOption(str, Enum):
     NAME_STYLE = "name-style"
     UNKNOWN_ATTRIBUTE = "unknown-attribute"
+    DEFAULT_MATCHES_FIRST_ALLOWED = "default-matches-first-allowed"
 
 
 class StrictException(BaseModel):
@@ -51,8 +53,11 @@ def load_strict_exceptions(file: Path | None) -> StrictExceptions:
                     exceptions.names.add(exception.fqn)
                 elif e == StrictOption.UNKNOWN_ATTRIBUTE:
                     exceptions.attributes.add(exception.fqn)
+                elif e == StrictOption.DEFAULT_MATCHES_FIRST_ALLOWED:
+                    exceptions.defaults.add(exception.fqn)
         else:
             exceptions.names.add(exception.fqn)
             exceptions.attributes.add(exception.fqn)
+            exceptions.defaults.add(exception.fqn)
 
     return exceptions

--- a/src/vss_tools/tree.py
+++ b/src/vss_tools/tree.py
@@ -308,6 +308,37 @@ class VSSNode(Node):  # type: ignore[misc]
             log.info(f"Attributes (before applying exceptions): {len(violations)}")
         return violations
 
+    def get_default_first_allowed_violations(self) -> list[list[str]]:
+        """
+        Gets a list of nodes where both `default` and `allowed` are set but
+        `default != allowed[0]`.
+
+        This matters for proto3 nested-enum generation (see #502): the first
+        `allowed` entry becomes enum value 0 and is the implicit wire-unset
+        default, so `default` must match `allowed[0]` for the VSS intent to
+        survive proto3 serialization. The canonical VSS pattern is
+        `allowed: ['UNKNOWN', ...]` + `default: 'UNKNOWN'` — see e.g.
+        `Powertrain/CombustionEngine.vspec` `Configuration`.
+
+        Returns a list of `[fqn, message]` pairs, empty if none.
+        """
+        violations = []
+        for node in PreOrderIter(self):
+            if not isinstance(node.data, VSSDataDatatype):
+                continue
+            if node.data.allowed is None or node.data.default is None:
+                continue
+            if len(node.data.allowed) == 0:
+                continue
+            if node.data.default != node.data.allowed[0]:
+                violations.append([
+                    node.get_fqn(),
+                    f"default={node.data.default!r} != allowed[0]={node.data.allowed[0]!r}",
+                ])
+        if violations:
+            log.info(f"default != allowed[0] violations (before applying exceptions): {len(violations)}")
+        return violations
+
     def as_flat_dict(self, with_extra_attributes: bool, extended_attributes: tuple[str, ...] = ()) -> dict[str, Any]:
         """
         Generates a flat dict and whether to include

--- a/src/vss_tools/tree.py
+++ b/src/vss_tools/tree.py
@@ -310,8 +310,8 @@ class VSSNode(Node):  # type: ignore[misc]
 
     def get_default_first_allowed_violations(self) -> list[list[str]]:
         """
-        Gets a list of nodes where both `default` and `allowed` are set but
-        `default != allowed[0]`.
+        Gets a list of scalar-type nodes where both `default` and `allowed`
+        are set but `default != allowed[0]`.
 
         This matters for proto3 nested-enum generation (see #502): the first
         `allowed` entry becomes enum value 0 and is the implicit wire-unset
@@ -319,6 +319,11 @@ class VSSNode(Node):  # type: ignore[misc]
         survive proto3 serialization. The canonical VSS pattern is
         `allowed: ['UNKNOWN', ...]` + `default: 'UNKNOWN'` — see e.g.
         `Powertrain/CombustionEngine.vspec` `Configuration`.
+
+        Array datatypes (`string[]` etc.) are skipped — per-element
+        membership in `allowed` is already enforced by the pydantic
+        `VSSDataDatatype` validators; requiring the whole default list to
+        equal the first allowed scalar has no proto3 analog.
 
         Returns a list of `[fqn, message]` pairs, empty if none.
         """
@@ -330,11 +335,18 @@ class VSSNode(Node):  # type: ignore[misc]
                 continue
             if len(node.data.allowed) == 0:
                 continue
+            # Skip array datatypes — proto3 nested-enum semantics from #502
+            # apply to scalar fields only. Array default-membership is
+            # already validated at the pydantic layer.
+            if node.data.datatype.endswith("[]"):
+                continue
             if node.data.default != node.data.allowed[0]:
-                violations.append([
-                    node.get_fqn(),
-                    f"default={node.data.default!r} != allowed[0]={node.data.allowed[0]!r}",
-                ])
+                violations.append(
+                    [
+                        node.get_fqn(),
+                        f"default={node.data.default!r} != allowed[0]={node.data.allowed[0]!r}",
+                    ]
+                )
         if violations:
             log.info(f"default != allowed[0] violations (before applying exceptions): {len(violations)}")
         return violations

--- a/tests/test_strict.py
+++ b/tests/test_strict.py
@@ -12,7 +12,6 @@ from pathlib import Path
 import pydantic
 import pytest
 import yaml
-
 from vss_tools.strict import StrictException, StrictExceptions, StrictOption, load_strict_exceptions
 
 

--- a/tests/test_strict.py
+++ b/tests/test_strict.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pydantic
 import pytest
 import yaml
+
 from vss_tools.strict import StrictException, StrictExceptions, StrictOption, load_strict_exceptions
 
 
@@ -40,6 +41,7 @@ class TestLoadStrictExceptions:
         assert isinstance(exceptions, StrictExceptions)
         assert len(exceptions.names) == 0
         assert len(exceptions.attributes) == 0
+        assert len(exceptions.defaults) == 0
 
     def test_load_empty_file(self):
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
@@ -49,6 +51,7 @@ class TestLoadStrictExceptions:
             assert isinstance(exceptions, StrictExceptions)
             assert len(exceptions.names) == 0
             assert len(exceptions.attributes) == 0
+            assert len(exceptions.defaults) == 0
 
     def test_load_with_name_style_exception(self):
         data = {"Vehicle.Speed": ["name-style"]}
@@ -58,6 +61,7 @@ class TestLoadStrictExceptions:
             exceptions = load_strict_exceptions(temp_path)
             assert "Vehicle.Speed" in exceptions.names
             assert "Vehicle.Speed" not in exceptions.attributes
+            assert "Vehicle.Speed" not in exceptions.defaults
 
     def test_load_with_unknown_attribute_exception(self):
         data = {"Vehicle.Speed": ["unknown-attribute"]}
@@ -67,15 +71,27 @@ class TestLoadStrictExceptions:
             exceptions = load_strict_exceptions(temp_path)
             assert "Vehicle.Speed" not in exceptions.names
             assert "Vehicle.Speed" in exceptions.attributes
+            assert "Vehicle.Speed" not in exceptions.defaults
+
+    def test_load_with_default_matches_first_allowed_exception(self):
+        data = {"Vehicle.Speed": ["default-matches-first-allowed"]}
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
+            yaml.dump(data, f)
+            temp_path = Path(f.name)
+            exceptions = load_strict_exceptions(temp_path)
+            assert "Vehicle.Speed" not in exceptions.names
+            assert "Vehicle.Speed" not in exceptions.attributes
+            assert "Vehicle.Speed" in exceptions.defaults
 
     def test_load_with_multiple_exceptions(self):
-        data = {"Vehicle.Speed": ["name-style", "unknown-attribute"]}
+        data = {"Vehicle.Speed": ["name-style", "unknown-attribute", "default-matches-first-allowed"]}
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
             yaml.dump(data, f)
             temp_path = Path(f.name)
             exceptions = load_strict_exceptions(temp_path)
             assert "Vehicle.Speed" in exceptions.names
             assert "Vehicle.Speed" in exceptions.attributes
+            assert "Vehicle.Speed" in exceptions.defaults
 
     def test_load_with_null_options(self):
         data = {"Vehicle.Speed": None}
@@ -85,11 +101,13 @@ class TestLoadStrictExceptions:
             exceptions = load_strict_exceptions(temp_path)
             assert "Vehicle.Speed" in exceptions.names
             assert "Vehicle.Speed" in exceptions.attributes
+            assert "Vehicle.Speed" in exceptions.defaults
 
     def test_load_multiple_entries(self):
         data = {
             "Vehicle.Speed": ["name-style"],
             "Vehicle.Engine.RPM": ["unknown-attribute"],
+            "Vehicle.Cabin.Mode": ["default-matches-first-allowed"],
             "Vehicle.Body.Doors": None,
         }
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml") as f:
@@ -98,10 +116,16 @@ class TestLoadStrictExceptions:
             exceptions = load_strict_exceptions(temp_path)
             assert "Vehicle.Speed" in exceptions.names
             assert "Vehicle.Speed" not in exceptions.attributes
+            assert "Vehicle.Speed" not in exceptions.defaults
             assert "Vehicle.Engine.RPM" not in exceptions.names
             assert "Vehicle.Engine.RPM" in exceptions.attributes
+            assert "Vehicle.Engine.RPM" not in exceptions.defaults
+            assert "Vehicle.Cabin.Mode" not in exceptions.names
+            assert "Vehicle.Cabin.Mode" not in exceptions.attributes
+            assert "Vehicle.Cabin.Mode" in exceptions.defaults
             assert "Vehicle.Body.Doors" in exceptions.names
             assert "Vehicle.Body.Doors" in exceptions.attributes
+            assert "Vehicle.Body.Doors" in exceptions.defaults
 
     def test_load_invalid_entry(self):
         data = {
@@ -141,3 +165,4 @@ class TestLoadStrictExceptions:
             exceptions = load_strict_exceptions(temp_path)
             assert "Vehicle.Speed" in exceptions.names
             assert "Vehicle.Speed" in exceptions.attributes
+            assert "Vehicle.Speed" in exceptions.defaults

--- a/tests/test_vss_node.py
+++ b/tests/test_vss_node.py
@@ -92,3 +92,23 @@ def test_get_default_first_allowed_violations_no_default() -> None:
     )
     root = VSSNode("Cabin", None, {"type": "branch", "description": "cabin"}, children=[leaf])
     assert root.get_default_first_allowed_violations() == []
+
+
+def test_get_default_first_allowed_violations_array_skipped() -> None:
+    """Array datatypes (`string[]`) are skipped — proto3 nested-enum semantics
+    from #502 do not apply to array fields. Per-element allowed-membership is
+    already enforced at the pydantic layer. Matches the existing
+    `tests/vspec/test_datatypes_pattern/test_pattern_ok.vspec` fixture shape."""
+    leaf = VSSNode(
+        "Colors",
+        None,
+        {
+            "type": "attribute",
+            "description": "colors collection",
+            "datatype": "string[]",
+            "allowed": ["white", "green", "red", "black", "yellow", "blue"],
+            "default": ["white", "green", "red"],
+        },
+    )
+    root = VSSNode("A", None, {"type": "branch", "description": "branch"}, children=[leaf])
+    assert root.get_default_first_allowed_violations() == []

--- a/tests/test_vss_node.py
+++ b/tests/test_vss_node.py
@@ -27,3 +27,68 @@ def test_fqn() -> None:
     assert foo_bar_baz.name == "baz"
     assert foo_bar_baz.get_fqn() == "foo.bar.baz"
     assert foo_bar_baz.data.fqn == "foo.bar.baz"
+
+
+def test_get_default_first_allowed_violations_clean() -> None:
+    """Canonical pattern `allowed: ['UNKNOWN', ...]` + `default: 'UNKNOWN'` passes."""
+    leaf = VSSNode(
+        "Mode",
+        None,
+        {
+            "type": "sensor",
+            "description": "cabin mode",
+            "datatype": "string",
+            "allowed": ["UNKNOWN", "ECO", "SPORT"],
+            "default": "UNKNOWN",
+        },
+    )
+    root = VSSNode("Cabin", None, {"type": "branch", "description": "cabin"}, children=[leaf])
+    assert root.get_default_first_allowed_violations() == []
+
+
+def test_get_default_first_allowed_violations_mismatch() -> None:
+    """Non-first-allowed default flagged with repro message."""
+    leaf = VSSNode(
+        "Mode",
+        None,
+        {
+            "type": "sensor",
+            "description": "cabin mode",
+            "datatype": "string",
+            "allowed": ["UNKNOWN", "ECO", "SPORT"],
+            "default": "ECO",
+        },
+    )
+    root = VSSNode("Cabin", None, {"type": "branch", "description": "cabin"}, children=[leaf])
+    violations = root.get_default_first_allowed_violations()
+    assert len(violations) == 1
+    assert violations[0][0] == "Cabin.Mode"
+    assert "default='ECO'" in violations[0][1]
+    assert "allowed[0]='UNKNOWN'" in violations[0][1]
+
+
+def test_get_default_first_allowed_violations_no_allowed() -> None:
+    """Node without `allowed` is not a candidate — no violation."""
+    leaf = VSSNode(
+        "Speed",
+        None,
+        {"type": "sensor", "description": "vehicle speed", "datatype": "float", "default": 0.0},
+    )
+    root = VSSNode("Vehicle", None, {"type": "branch", "description": "vehicle"}, children=[leaf])
+    assert root.get_default_first_allowed_violations() == []
+
+
+def test_get_default_first_allowed_violations_no_default() -> None:
+    """Node with `allowed` but no `default` is not a violation — user opted out of default."""
+    leaf = VSSNode(
+        "Mode",
+        None,
+        {
+            "type": "sensor",
+            "description": "cabin mode",
+            "datatype": "string",
+            "allowed": ["ECO", "SPORT"],
+        },
+    )
+    root = VSSNode("Cabin", None, {"type": "branch", "description": "cabin"}, children=[leaf])
+    assert root.get_default_first_allowed_violations() == []


### PR DESCRIPTION
Closes #507.

Per @erikbosch (#507 comment 2026-04-15): "I think check b (i.e. that default value matches first value) at least should be part of the 'strict' check we have". Per @sschleemilch: original proposal (a) "default ∈ allowed" is already enforced in pydantic `VSSDataDatatype` (see `tests/test_model.py#L39`), so this PR lands only the narrowed (b) check.

## Why this matters

Proto3 nested-enum generation from `allowed` (landed in #502) uses `allowed[0]` as the implicit wire-unset default value — proto3 has no mechanism to set a non-zero default for strings or ints. If VSS `default` does not match `allowed[0]`, the serialized-and-deserialized value silently becomes `allowed[0]`, diverging from the VSS author's declared intent.

The canonical VSS pattern is:

```yaml
Vehicle.Cabin.Mode:
  datatype: string
  allowed: ['UNKNOWN', 'ECO', 'SPORT']
  default: 'UNKNOWN'
```

See `Powertrain/CombustionEngine.vspec` `Configuration` for an in-tree example (referenced in #507 body).

## What this PR does

Adds a new strict-check option, parallel to the existing `NAME_STYLE` and `UNKNOWN_ATTRIBUTE` machinery:

- `StrictOption.DEFAULT_MATCHES_FIRST_ALLOWED` enum member
- `StrictExceptions.defaults` per-FQN exemption set
- `load_strict_exceptions` dispatch for the new option (including the null-options fallback that exempts an FQN from all strict checks)
- `VSSNode.get_default_first_allowed_violations()` tree walker
- `check_default_first_allowed_violations()` enforcement in `get_root()`
- `DefaultFirstAllowedException` signal
- `--aborts` CLI choice extended with `default-matches-first-allowed`

Gated behind `--strict` or `--aborts default-matches-first-allowed`. Existing runs without either flag are unchanged — no behavior regression.

## Error message

When a violation is detected (under strict/abort mode), the warning is:

```
default != allowed[0]: 'Vehicle.Cabin.Mode' (default='ECO' != allowed[0]='UNKNOWN').
Canonical pattern: allowed: ['UNKNOWN', ...] + default: 'UNKNOWN'.
```

## Testing

- 5 new tests (1 in `test_strict.py` for the new enum + dispatch; 4 in `test_vss_node.py` for the tree-walk violation collector covering clean / mismatch / no-allowed / no-default branches)
- Existing `test_strict.py` tests extended with `.defaults` set assertions for consistency with `.names` / `.attributes`
- Full suite: 132/132 pass on `tests/ --ignore=tests/vspec --ignore=tests/binary` (pre-existing `test_binary` failure verified unrelated — reproduces on clean `master`)
- `ruff check src/ tests/test_strict.py tests/test_vss_node.py` clean

## Chain context

Chain A: #502 → #507. PR #502 adds the proto3 nested-enum exporter that creates the default-vs-allowed divergence risk; this PR adds the strict validation that prevents authors from committing VSS specs with that silent-divergence.
