### PR TITLE
model: use `is None` instead of falsy check in check_default_min_max

### DIFF
--- a/src/vss_tools/model.py
+++ b/src/vss_tools/model.py
@@ -260,11 +260,6 @@ class VSSDataDatatype(VSSData):
         return self
 
     def check_default_min_max(self) -> Self:
-        # Use an explicit None check rather than a falsy check: `not self.default`
-        # treats default=0 as missing, so a numeric signal with default=0 and
-        # min>0 (or default=0 and max<0) silently passed validation. Same shape
-        # for default=False / default=[] / default="", though those mostly bite
-        # for the numeric case.
         if self.default is None:
             return self
         values = [self.default]

--- a/src/vss_tools/model.py
+++ b/src/vss_tools/model.py
@@ -260,7 +260,12 @@ class VSSDataDatatype(VSSData):
         return self
 
     def check_default_min_max(self) -> Self:
-        if not self.default:
+        # Use an explicit None check rather than a falsy check: `not self.default`
+        # treats default=0 as missing, so a numeric signal with default=0 and
+        # min>0 (or default=0 and max<0) silently passed validation. Same shape
+        # for default=False / default=[] / default="", though those mostly bite
+        # for the numeric case.
+        if self.default is None:
             return self
         values = [self.default]
         if isinstance(self.default, list):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -31,6 +31,12 @@ from vss_tools.model import VSSDataDatatype
         ({"datatype": "uint8", "max": 100, "default": 90}, True),
         ({"datatype": "uint8", "min": 10, "default": 5}, False),
         ({"datatype": "uint8", "min": 10, "default": 10}, True),
+        # Regression: `default=0` (a falsy but valid numeric default) used to
+        # bypass min/max validation entirely because `check_default_min_max`
+        # tested `if not self.default:` instead of `if self.default is None:`.
+        ({"datatype": "uint8", "min": 1, "default": 0}, False),
+        ({"datatype": "int8", "max": -1, "default": 0}, False),
+        ({"datatype": "uint8", "min": 0, "default": 0}, True),
         ({"datatype": "uint8", "default": 300}, False),
         ({"datatype": "uint8", "default": 200}, True),
         ({"datatype": "boolean", "default": True}, True),

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -31,9 +31,6 @@ from vss_tools.model import VSSDataDatatype
         ({"datatype": "uint8", "max": 100, "default": 90}, True),
         ({"datatype": "uint8", "min": 10, "default": 5}, False),
         ({"datatype": "uint8", "min": 10, "default": 10}, True),
-        # Regression: `default=0` (a falsy but valid numeric default) used to
-        # bypass min/max validation entirely because `check_default_min_max`
-        # tested `if not self.default:` instead of `if self.default is None:`.
         ({"datatype": "uint8", "min": 1, "default": 0}, False),
         ({"datatype": "int8", "max": -1, "default": 0}, False),
         ({"datatype": "uint8", "min": 0, "default": 0}, True),


### PR DESCRIPTION
## Problem

`check_default_min_max` in `src/vss_tools/model.py` returned early
when `not self.default` was truthy. Python treats `0`, `False`, `""`,
and `[]` as falsy, so a numeric signal like:

```yaml
Vehicle.SomeSignal:
  type: sensor
  datatype: uint8
  description: "..."
  min: 10
  default: 0   # < min, should be rejected — but silently passed
```

…silently passed validation. Same for `default: 0` with a negative
`max`. The intended range check was a no-op for any falsy default.

## Fix

```diff
-        if not self.default:
+        if self.default is None:
```

The downstream loop already handles list-vs-scalar correctly; with
this fix, `default=0` runs through the comparison and raises
`ValidationError` when out of range.

## Test

Three new parametrize cases in `tests/test_model.py`:

```python
({"datatype": "uint8", "min": 1, "default": 0}, False),   # bug case
({"datatype": "int8",  "max": -1, "default": 0}, False),  # bug case
({"datatype": "uint8", "min": 0, "default": 0}, True),    # sanity
```

The first two would have passed (incorrectly) before this PR. The
third confirms `default=0` is still allowed when within bounds.

## Notes

- Companion to #516 (assert→raise refactor in the same file). Both
  PRs harden the same `model.py` validators against silent failure.
- I noticed this bug while writing #516 but kept it out to keep the
  scopes separable. They can land in either order without conflict.