### PR TITLE
exporters: encoding="utf-8" across text writes; samm/file_helper to context manager

### DIFF
--- a/src/vss_tools/exporters/apigear.py
+++ b/src/vss_tools/exporters/apigear.py
@@ -400,7 +400,7 @@ def generate_solution(
 
 
 def export_yaml(file_name, content_dict):
-    with open(file_name, "w") as f:
+    with open(file_name, "w", encoding="utf-8") as f:
         yaml.dump(
             content_dict,
             f,

--- a/src/vss_tools/exporters/csv.py
+++ b/src/vss_tools/exporters/csv.py
@@ -74,7 +74,7 @@ def add_rows(
 
 
 def write_csv(rows: list[list[Any]], output: Path):
-    with open(output, "w", newline="") as f:
+    with open(output, "w", encoding="utf-8", newline="") as f:
         writer = csv.writer(f)
         writer.writerows(rows)
 

--- a/src/vss_tools/exporters/ddsidl.py
+++ b/src/vss_tools/exporters/ddsidl.py
@@ -428,10 +428,10 @@ def cli(
 
     if datatype_tree is not None:
         exporter = StructExporter()
-        with open(output, "w") as idl_out:
+        with open(output, "w", encoding="utf-8") as idl_out:
             idl_out.write(exporter.export(datatype_tree))
 
-    with open(output, "a" if datatype_tree is not None else "w") as idl_out:
+    with open(output, "a" if datatype_tree is not None else "w", encoding="utf-8") as idl_out:
         export_idl(
             idl_out,
             tree,

--- a/src/vss_tools/exporters/franca.py
+++ b/src/vss_tools/exporters/franca.py
@@ -123,7 +123,7 @@ def cli(
         overlays=overlays,
         strict_exceptions_file=strict_exceptions,
     )
-    with open(output, "w") as f:
+    with open(output, "w", encoding="utf-8") as f:
         print_franca_header(f, franca_vss_version)
         print_franca_content(f, tree)
         f.write("\n]")

--- a/src/vss_tools/exporters/go.py
+++ b/src/vss_tools/exporters/go.py
@@ -327,7 +327,7 @@ def cli(
             else:
                 rounds += 1
 
-    with open(output, "w") as f:
+    with open(output, "w", encoding="utf-8") as f:
         f.write(f"package {package}\n\n")
         for struct in structs.values():
             f.write(str(struct))

--- a/src/vss_tools/exporters/id.py
+++ b/src/vss_tools/exporters/id.py
@@ -213,5 +213,5 @@ def cli(
         vss2id_val.validate_static_uids(signals_yaml_dict, validation_tree, strict)
 
     if not validate_only:
-        with open(output, "w") as f:
+        with open(output, "w", encoding="utf-8") as f:
             yaml.dump(signals_yaml_dict, f)

--- a/src/vss_tools/exporters/json.py
+++ b/src/vss_tools/exporters/json.py
@@ -110,12 +110,12 @@ def cli(
             log.info("Adding custom data types to signal dictionary")
             signals_data["ComplexDataTypes"] = types_data
         else:
-            with open(types_output, "w") as f:
+            with open(types_output, "w", encoding="utf-8") as f:
                 json.dump(types_data, f, indent=indent, sort_keys=True)
 
     # Only write main JSON output if output path is provided
     if output:
-        with open(output, "w") as f:
+        with open(output, "w", encoding="utf-8") as f:
             json.dump(signals_data, f, indent=indent, sort_keys=True)
 
     # Generate radial statistics if requested

--- a/src/vss_tools/exporters/plantuml.py
+++ b/src/vss_tools/exporters/plantuml.py
@@ -237,7 +237,7 @@ def cli(
 
     if output:
         log.info(f"Writing tree to: {output.absolute()}")
-        with open(output, "w") as f:
+        with open(output, "w", encoding="utf-8") as f:
             f.write(plant_code)
     else:
         log.info(plant_code)

--- a/src/vss_tools/exporters/protobuf.py
+++ b/src/vss_tools/exporters/protobuf.py
@@ -41,7 +41,7 @@ mapped = {
 
 
 def init_package_file(path: Path, package_name: str):
-    with open(path, "w") as f:
+    with open(path, "w", encoding="utf-8") as f:
         log.info(f"Initializing {path}, package {package_name}")
         f.write('syntax = "proto3";\n\n')
         f.write(f"package {package_name};\n\n")
@@ -298,6 +298,6 @@ def cli(
             log.warning(f"No output directory given. Writing to: {types_out_dir.absolute()}")
         traverse_data_type_tree(datatype_tree, static_uid, add_optional, include_comments, types_out_dir)
 
-    with open(output, "w") as f:
+    with open(output, "w", encoding="utf-8") as f:
         log.info(f"Writing to: {output}")
         traverse_signal_tree(tree, f, static_uid, add_optional, include_comments)

--- a/src/vss_tools/exporters/s2dm/__init__.py
+++ b/src/vss_tools/exporters/s2dm/__init__.py
@@ -125,7 +125,7 @@ def cli(
             full_schema_str = print_schema_with_vspec_directives(
                 schema, unit_enums_metadata, allowed_enums_metadata, vspec_comments
             )
-            with open(graphql_file, "w") as outfile:
+            with open(graphql_file, "w", encoding="utf-8") as outfile:
                 outfile.write(full_schema_str)
 
             log.info(f"GraphQL schema written to {graphql_file}")

--- a/src/vss_tools/exporters/s2dm/reference_generator.py
+++ b/src/vss_tools/exporters/s2dm/reference_generator.py
@@ -109,7 +109,7 @@ def generate_vspec_reference(
                         except FileNotFoundError:
                             raise S2DMExporterException(f"Units file not found: {f}") from None
 
-                    with open(units_output, "w") as outf:
+                    with open(units_output, "w", encoding="utf-8") as outf:
                         yaml.dump(merged, outf, default_flow_style=False, sort_keys=True)
 
                 log.info(f"  - Units file: {units_output.name}")
@@ -143,7 +143,7 @@ def generate_vspec_reference(
                         except FileNotFoundError:
                             raise S2DMExporterException(f"Quantities file not found: {f}") from None
 
-                    with open(quantities_output, "w") as outf:
+                    with open(quantities_output, "w", encoding="utf-8") as outf:
                         yaml.dump(merged, outf, default_flow_style=False, sort_keys=True)
 
                 log.info(f"  - Quantities file: {quantities_output.name}")
@@ -224,7 +224,7 @@ It could serve as a supporting reference for traceability or debugging.
         readme_path = reference_dir / "README.md"
 
         try:
-            with open(readme_path, "w") as f:
+            with open(readme_path, "w", encoding="utf-8") as f:
                 f.write(readme_content)
             log.info(f"  - README: {readme_path.name}")
         except (PermissionError, OSError) as e:

--- a/src/vss_tools/exporters/samm/helpers/file_helper.py
+++ b/src/vss_tools/exporters/samm/helpers/file_helper.py
@@ -45,14 +45,15 @@ def write_graph_to_file(path_to_file: Path, file_name: str, graph: Graph):
     output_folder: Path = Path(path_to_file)
     output_folder.mkdir(parents=True, exist_ok=True)
 
-    # Create and write data to ttl file
+    # Create and write data to ttl file. Use a context manager so the file
+    # is closed even if .write() raises, and pin the encoding to UTF-8 so
+    # RDF graphs containing non-ASCII characters serialise consistently
+    # across platforms (matches the encoding fix applied to the other
+    # exporters in the previous commit).
     output_file: Path = output_folder / f"{file_name}.ttl"
-    file_writer = output_file.open("w")
-    file_writer.write(filedata)
-
-    # Add new line and close the file
-    file_writer.write("\n")
-    file_writer.close()
+    with output_file.open("w", encoding="utf-8") as file_writer:
+        file_writer.write(filedata)
+        file_writer.write("\n")
 
     # Return file location
     return output_file

--- a/src/vss_tools/exporters/stats_utils.py
+++ b/src/vss_tools/exporters/stats_utils.py
@@ -128,6 +128,6 @@ def process_radial_stats(signals_data: dict[str, Any], output: Path) -> None:
         "children": children,
     }
 
-    with open(output, "w") as f:
+    with open(output, "w", encoding="utf-8") as f:
         json.dump(radial_tree_data, f, indent=2)
     log.info(f"Radial tree stats JSON saved: {output}")

--- a/src/vss_tools/exporters/tree.py
+++ b/src/vss_tools/exporters/tree.py
@@ -84,7 +84,7 @@ def cli(
 
     if output:
         log.info(f"Writing tree to: {output.absolute()}")
-        with open(output, "w") as f:
+        with open(output, "w", encoding="utf-8") as f:
             f.write(rendered_tree)
     else:
         log.info(rendered_tree)

--- a/src/vss_tools/exporters/yaml.py
+++ b/src/vss_tools/exporters/yaml.py
@@ -22,7 +22,12 @@ from vss_tools.main import get_trees
 
 
 def export_yaml(file_name, content_dict):
-    with open(file_name, "w") as f:
+    # Open the file in text mode with explicit utf-8 encoding so allow_unicode=True
+    # can write non-ASCII characters (e.g. ° in unit names) without crashing on
+    # platforms whose default encoding is not UTF-8 (e.g. Windows cp1252).
+    # Note: the `encoding=...` kwarg passed to yaml.dump below is ignored when the
+    # stream is a text-mode file, but is kept for clarity.
+    with open(file_name, "w", encoding="utf-8") as f:
         yaml.dump(
             content_dict,
             f,


### PR DESCRIPTION
## Problem

Two related file-handling hardening fixes across the exporters:

### 1. Missing `encoding="utf-8"` on text-write `open()` calls

Fourteen exporters (`json`, `tree`, `yaml`, `csv`, `protobuf`,
`plantuml`, `go`, `id`, `franca`, `ddsidl`, `stats_utils`, `apigear`,
`s2dm/__init__`, `s2dm/reference_generator`) opened output files
with `open(path, "w")` in text mode without specifying an encoding.

On platforms whose default text-file encoding is not UTF-8 (notably
Windows cp1252), writing a VSS spec containing non-ASCII characters —
e.g. `°` in unit names, `Ω` in resistance units, accented characters
in descriptions — crashes with `UnicodeEncodeError`. Same shape on
non-UTF-8 Linux locales.

`jsonschema.py` already does this correctly; everything else didn't.

### 2. `samm/helpers/file_helper.write_graph_to_file` not using a context manager

The function opened the output `.ttl` file with `output_file.open("w")`,
wrote to it, then manually called `.close()` at the end. If any of the
intermediate `.write()` calls raised, the file descriptor would leak.
It also lacked the encoding fix from #1.

## Fix

Two commits, one per problem:

1. **`exporters: add encoding="utf-8" to all text-write open() calls`**
   — adds `encoding="utf-8"` to every `open(path, "w")` (and
   `open(path, "w", newline="")` for CSV) across the 14 exporters.

2. **`exporters/samm: use context manager and utf-8 encoding in file_helper`**
   — wraps the two `.write()` calls in a `with` block and pins the
   encoding.

## Notes

- `yaml.py` had a confusing `encoding="utf-8"` kwarg passed to
  `yaml.dump()`, which is silently ignored when the dump target is a
  text-mode file (PyYAML only honours that kwarg on byte-mode
  streams). Left in place with a comment explaining why; the real
  fix is on `open()`.
- CSV's existing `newline=""` argument is preserved (correct for
  cross-platform CSV writing).
- No new tests added: the fix is mechanical and the failure mode it
  prevents is platform/locale-specific. Happy to add a test if
  maintainers can suggest a clean way to simulate non-UTF-8 default
  encoding in CI.

## Related

Companion to the validation hardening in #515, #516, and #517.