### PR TITLE
fix(units): accept unit keys case-insensitively

### DIFF
--- a/src/vss_tools/model.py
+++ b/src/vss_tools/model.py
@@ -420,6 +420,9 @@ class VSSDataDatatype(VSSData):
     def check_valid_unit(cls, v: str | None) -> str | None:
         if v is None:
             return v
+        v_lower = v.lower()
+        if v_lower in dynamic_units:
+            return v_lower
         if v not in dynamic_units:
             raise ValueError(f"'{v}' is not a valid unit")
         return v

--- a/src/vss_tools/model.py
+++ b/src/vss_tools/model.py
@@ -423,7 +423,7 @@ class VSSDataDatatype(VSSData):
         v_lower = v.lower()
         if v_lower not in dynamic_units:
             raise ValueError(f"'{v}' is not a valid unit")
-        return v_lower
+        return dynamic_units[v_lower].key or v_lower
 
     @model_validator(mode="after")
     def check_datatype_matching_allowed_unit_datatypes(self) -> Self:
@@ -434,7 +434,7 @@ class VSSDataDatatype(VSSData):
         if self.unit:
             if not Datatypes.get_type(self.datatype):
                 raise ValueError(f"Cannot use 'unit' with complex datatype: '{self.datatype}'")
-            allowed_datatypes = dynamic_units[self.unit].allowed_datatypes
+            allowed_datatypes = dynamic_units[self.unit.lower()].allowed_datatypes
             if allowed_datatypes is None:
                 allowed_datatypes = []
             if not any(Datatypes.is_subtype_of(self.datatype.rstrip("[]"), a) for a in allowed_datatypes):

--- a/src/vss_tools/model.py
+++ b/src/vss_tools/model.py
@@ -421,11 +421,9 @@ class VSSDataDatatype(VSSData):
         if v is None:
             return v
         v_lower = v.lower()
-        if v_lower in dynamic_units:
-            return v_lower
-        if v not in dynamic_units:
+        if v_lower not in dynamic_units:
             raise ValueError(f"'{v}' is not a valid unit")
-        return v
+        return v_lower
 
     @model_validator(mode="after")
     def check_datatype_matching_allowed_unit_datatypes(self) -> Self:

--- a/src/vss_tools/units_quantities.py
+++ b/src/vss_tools/units_quantities.py
@@ -33,6 +33,7 @@ def load_units_or_quantities(
             continue
         log.info(f"Loaded '{class_type.__name__}', file={file.absolute()}, elements={len(content)}")
         for k, v in content.items():
+            k_original = k
             k = k.lower()
             if v is None:
                 raise MalformedDictException(f"'{class_type.__name__}', '{k}' is 'None'")
@@ -40,9 +41,9 @@ def load_units_or_quantities(
             if k in data:
                 overwrite = True
             try:
-                # For VSSUnit, inject the key from the YAML dictionary key
+                # For VSSUnit, inject the canonical key (original casing) from the YAML key
                 if class_type == VSSUnit and isinstance(v, dict):
-                    v["key"] = k
+                    v["key"] = k_original
                 val = class_type(**v)
                 if overwrite:
                     log.warning(

--- a/src/vss_tools/units_quantities.py
+++ b/src/vss_tools/units_quantities.py
@@ -33,6 +33,7 @@ def load_units_or_quantities(
             continue
         log.info(f"Loaded '{class_type.__name__}', file={file.absolute()}, elements={len(content)}")
         for k, v in content.items():
+            k = k.lower()
             if v is None:
                 raise MalformedDictException(f"'{class_type.__name__}', '{k}' is 'None'")
             overwrite = False

--- a/tests/vspec/test_consistency/test_consistency.py
+++ b/tests/vspec/test_consistency/test_consistency.py
@@ -24,7 +24,7 @@ DATA = HERE / "data"
         (3, 1, 4, "'foo' is not of type 'uint8[]'"),
         (4, 1, 4, "'min/max' and 'allowed' cannot be used together"),
         (5, 1, 4, "default value '4' is not in 'allowed' list"),
-        (6, 1, 4, "'string' is not allowed for unit 'kwh'"),
+        (6, 1, 4, "'string' is not allowed for unit 'kWh'"),
         (7, 1, 4, "Forbidden extra attribute (core attribute): 'Vehicle':'datatype'"),
         (8, 1, 4, "'default' array size does not match 'arraysize'"),
     ],

--- a/tests/vspec/test_consistency/test_consistency.py
+++ b/tests/vspec/test_consistency/test_consistency.py
@@ -24,7 +24,7 @@ DATA = HERE / "data"
         (3, 1, 4, "'foo' is not of type 'uint8[]'"),
         (4, 1, 4, "'min/max' and 'allowed' cannot be used together"),
         (5, 1, 4, "default value '4' is not in 'allowed' list"),
-        (6, 1, 4, "'string' is not allowed for unit 'kWh'"),
+        (6, 1, 4, "'string' is not allowed for unit 'kwh'"),
         (7, 1, 4, "Forbidden extra attribute (core attribute): 'Vehicle':'datatype'"),
         (8, 1, 4, "'default' array size does not match 'arraysize'"),
     ],

--- a/tests/vspec/test_units/expected_canonical_case.json
+++ b/tests/vspec/test_units/expected_canonical_case.json
@@ -1,0 +1,14 @@
+{
+  "A": {
+    "children": {
+      "SignalEnergy": {
+        "datatype": "float",
+        "description": "Energy in kilowatt hours.",
+        "type": "sensor",
+        "unit": "kWh"
+      }
+    },
+    "description": "Branch A.",
+    "type": "branch"
+  }
+}

--- a/tests/vspec/test_units/signals_canonical_case_units.vspec
+++ b/tests/vspec/test_units/signals_canonical_case_units.vspec
@@ -1,0 +1,10 @@
+#
+A:
+  type: branch
+  description: Branch A.
+
+A.SignalEnergy:
+  datatype: float
+  type: sensor
+  unit: kwh
+  description: Energy in kilowatt hours.

--- a/tests/vspec/test_units/signals_mixed_case_units.vspec
+++ b/tests/vspec/test_units/signals_mixed_case_units.vspec
@@ -1,0 +1,16 @@
+#
+A:
+  type: branch
+  description: Branch A.
+
+A.SignalPuncheon:
+  datatype: float
+  type: sensor
+  unit: Puncheon
+  description: Volume in puncheons.
+
+A.SignalHogshead:
+  datatype: float
+  type: sensor
+  unit: HOGSHEAD
+  description: Volume in hogshead.

--- a/tests/vspec/test_units/test_units.py
+++ b/tests/vspec/test_units/test_units.py
@@ -130,6 +130,17 @@ def test_unit_key_case_insensitive(tmp_path):
     )
 
 
+def test_unit_key_canonical_case_preserved(tmp_path):
+    """Unit keys with mixed case in units.yaml must be output with that casing, not lowercased."""
+    run_unit(
+        tmp_path,
+        "signals_canonical_case_units.vspec",
+        ["units_kwh.yaml"],
+        "expected_canonical_case.json",
+        ["quantities.yaml"],
+    )
+
+
 # Special units not defined
 
 

--- a/tests/vspec/test_units/test_units.py
+++ b/tests/vspec/test_units/test_units.py
@@ -121,6 +121,15 @@ def test_multiple_unit_files(tmp_path):
     )
 
 
+def test_unit_key_case_insensitive(tmp_path):
+    run_unit(
+        tmp_path,
+        "signals_mixed_case_units.vspec",
+        ["units_all.yaml"],
+        "expected_special.json",
+    )
+
+
 # Special units not defined
 
 

--- a/tests/vspec/test_units/units_kwh.yaml
+++ b/tests/vspec/test_units/units_kwh.yaml
@@ -1,0 +1,5 @@
+kWh:
+  unit: kilowatt hour
+  definition: Energy measured in kilowatt hours
+  quantity: volume
+  allowed-datatypes: [numeric]


### PR DESCRIPTION
Unit keys in YAML unit files and \`unit:\` fields in vspec signal
definitions are now normalised to lowercase on load.

This means \`Celsius\`, \`CELSIUS\`, and \`celsius\` all resolve to
the same unit without error, matching the expectation raised in #489.

## Changes

- \`units_quantities.py\`: lowercase each YAML key before storing it
  in the loaded-units dict
- \`model.py\` \`check_valid_unit\`: try the lowercase form first so
  that any capitalisation in a vspec file is accepted; the stored
  value is normalised to lowercase
- New test vspec \`signals_mixed_case_units.vspec\` and a corresponding
  \`test_unit_key_case_insensitive\` test case

Fixes #489