### PR TITLE
fix(ddsidl): replace spaces with underscores in string enum literals

### DIFF
--- a/src/vss_tools/exporters/ddsidl.py
+++ b/src/vss_tools/exporters/ddsidl.py
@@ -154,6 +154,7 @@ def getAllowedName(name):
 
 
 def get_allowed_enum_literal(name: str):
+    name = name.replace(" ", "_")
     if name[0].isdigit():
         return "d" + name
     return name

--- a/tests/vspec/test_allowed_spaces/expected.ddsidl
+++ b/tests/vspec/test_allowed_spaces/expected.ddsidl
@@ -1,0 +1,13 @@
+module A
+{
+module GearSelect_M
+{
+enum GearSelectValues{Park_Brake,Drive_Forward};
+};
+struct GearSelect
+{
+GearSelect_M::GearSelectValues value;
+//const string type ="actuator";
+//const string description="Gear selection mode.";
+};
+};

--- a/tests/vspec/test_allowed_spaces/test.vspec
+++ b/tests/vspec/test_allowed_spaces/test.vspec
@@ -1,0 +1,10 @@
+#
+A:
+  type: branch
+  description: Branch A.
+
+A.GearSelect:
+  datatype: string
+  type: actuator
+  allowed: ['Park Brake', 'Drive Forward']
+  description: Gear selection mode.


### PR DESCRIPTION
Allowed values containing spaces (e.g. `'Park Brake'`) were emitted
verbatim as IDL enum literals, producing output like:

```idl
enum GearSelectValues{Park Brake,Drive Forward};
```

IDL identifiers cannot contain spaces, so any downstream IDL compiler
will reject this.  A one-line fix in `get_allowed_enum_literal` replaces
each space with an underscore before emitting the identifier:

```idl
enum GearSelectValues{Park_Brake,Drive_Forward};
```

A new test directory `test_allowed_spaces` exercises this path through
the generic test runner.

Note: this is orthogonal to the open keyword-check fix in #515.

Fixes #336