### PR TITLE
fix(franca): use double-quoted strings in allowed value output

### DIFF
--- a/src/vss_tools/exporters/franca.py
+++ b/src/vss_tools/exporters/franca.py
@@ -75,7 +75,8 @@ def print_franca_content(file: TextIOWrapper, root: VSSNode) -> None:
                 output += f",\n\tmax: {max}"
             allowed = getattr(data, "allowed", None)
             if allowed:
-                output += f",\n\tallowed: {allowed}"
+                formatted = ", ".join(f'"{v}"' if isinstance(v, str) else str(v) for v in allowed)
+                output += f",\n\tallowed: [{formatted}]"
             output += "\n}"
     file.write(output)
 

--- a/tests/vspec/test_allowed/expected.franca
+++ b/tests/vspec/test_allowed/expected.franca
@@ -23,13 +23,13 @@ const SignalSpec[] signal_spec = [
 	type: "sensor",
 	description: "A string",
 	datatype: "string",
-	allowed: ['January', 'February']
+	allowed: ["January", "February"]
 },
 {	name: "A.StringArray",
 	type: "sensor",
 	description: "A string array",
 	datatype: "string[]",
-	allowed: ['January', 'February', 'March']
+	allowed: ["January", "February", "March"]
 },
 {	name: "A.Int",
 	type: "sensor",


### PR DESCRIPTION
The `allowed` field was emitted using Python's `repr()` of the list,
producing single-quoted strings like `['January', 'February']`.  This
is not valid Franca IDL syntax, and for string values containing spaces
(e.g. `'Park Brake'`) the spaces would appear unescaped inside the
downstream parser's interpretation of the literal.

Emit string elements as `"value"` (double-quoted) and leave numeric
elements as bare literals, which is consistent with the rest of the
Franca output.

```
# Before
allowed: ['January', 'February']

# After
allowed: ["January", "February"]
```

Expected franca output updated for `test_allowed` accordingly.

Note: PR #514 proposes removing this exporter; this fix applies in the
meantime.

Fixes #336 (franca side)