### PR TITLE
fix: id exporter now generates static UIDs for struct and property nodes

### DIFF
--- a/src/vss_tools/exporters/id.py
+++ b/src/vss_tools/exporters/id.py
@@ -177,7 +177,7 @@ def cli(
     """
     Export as IDs.
     """
-    tree, _ = get_trees(
+    tree, datatype_tree = get_trees(
         vspec=vspec,
         include_dirs=include_dirs,
         aborts=aborts,
@@ -195,6 +195,8 @@ def cli(
     id_counter: int = 0
     signals_yaml_dict: Dict[str, str] = {}  # Use str for ID values
     id_counter, _ = export_node(signals_yaml_dict, tree, id_counter, case_sensitive)
+    if datatype_tree:
+        id_counter, _ = export_node(signals_yaml_dict, datatype_tree, id_counter, case_sensitive)
 
     if validate_static_uid:
         log.info(f"Now validating nodes, static UIDs, types, units and description with file '{validate_static_uid}'")

--- a/tests/vspec/test_id_struct/test.vspec
+++ b/tests/vspec/test_id_struct/test.vspec
@@ -1,0 +1,8 @@
+A:
+  type: branch
+  description: Branch A.
+
+A.Signal:
+  datatype: float
+  type: sensor
+  description: A simple signal.

--- a/tests/vspec/test_id_struct/test_id_struct.py
+++ b/tests/vspec/test_id_struct/test_id_struct.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2024 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import subprocess
+from pathlib import Path
+
+import yaml
+
+HERE = Path(__file__).resolve().parent
+TEST_UNITS = HERE / ".." / "test_units.yaml"
+TEST_QUANT = HERE / ".." / "test_quantities.yaml"
+
+
+def test_id_exporter_includes_struct_nodes(tmp_path: Path):
+    output = tmp_path / "out.yaml"
+    cmd = (
+        f"vspec export id -s {HERE / 'test.vspec'}"
+        f" -u {TEST_UNITS} -q {TEST_QUANT}"
+        f" --types {HERE / 'types.vspec'}"
+        f" -o {output}"
+    )
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
+    assert process.returncode == 0, process.stderr
+
+    ids = yaml.safe_load(output.read_text())
+    assert ids is not None
+
+    # Struct and property nodes must appear in the output
+    assert "Types.Reading" in ids, "struct node missing from id output"
+    assert "Types.Reading.Value" in ids, "property node missing from id output"
+    assert "Types.Reading.Quality" in ids, "property node missing from id output"
+
+    # Each entry must have a staticUID
+    for key in ("Types.Reading", "Types.Reading.Value", "Types.Reading.Quality"):
+        assert "staticUID" in ids[key], f"{key} is missing staticUID"
+        assert ids[key]["staticUID"].startswith("0x"), f"{key} staticUID not hex"
+
+    # Regular signal nodes still present
+    assert "A.Signal" in ids

--- a/tests/vspec/test_id_struct/test_id_struct.py
+++ b/tests/vspec/test_id_struct/test_id_struct.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Contributors to COVESA
+# Copyright (c) 2026 Contributors to COVESA
 #
 # This program and the accompanying materials are made available under the
 # terms of the Mozilla Public License 2.0 which is available at

--- a/tests/vspec/test_id_struct/types.vspec
+++ b/tests/vspec/test_id_struct/types.vspec
@@ -1,0 +1,17 @@
+Types:
+  type: branch
+  description: Custom type definitions.
+
+Types.Reading:
+  type: struct
+  description: A sensor reading with value and quality.
+
+Types.Reading.Value:
+  type: property
+  datatype: float
+  description: The measured value.
+
+Types.Reading.Quality:
+  type: property
+  datatype: uint8
+  description: Quality indicator from 0 to 100.


### PR DESCRIPTION
## Summary

`get_trees()` returns a `(tree, datatype_tree)` tuple. The `id` exporter was discarding the second value, so struct (`VSSDataStruct`) and property (`VSSDataProperty`) nodes defined via `--types` never received static UIDs.

One-line fix: capture `datatype_tree` and run `export_node` on it after processing the main tree.

Resolves #439.

## Test plan

- [ ] `uv run pytest tests/vspec/test_id_struct/` passes
- [ ] `vspec export id --types <types.vspec> -s <signals.vspec> -o out.yaml` — `out.yaml` contains `Types.*` entries with `staticUID` keys
- [ ] Existing `tests/vspec/test_static_uids/` tests unaffected (no `--types` used there)