### PR TITLE
feat: add optional 'url' field to VSSUnit for linking to standard specifications

### DIFF
--- a/src/vss_tools/model.py
+++ b/src/vss_tools/model.py
@@ -132,8 +132,7 @@ class VSSData(VSSRaw):
         """Give better explanation for empty description."""
         if self.description == "":
             raise ValueError(
-                "All nodes in the final tree must have a description. "
-                "Implicit branches are not allowed in final tree!"
+                "All nodes in the final tree must have a description. Implicit branches are not allowed in final tree!"
             )
         return self
 
@@ -165,6 +164,7 @@ class VSSUnit(BaseModel):
     unit: str | None
     quantity: str
     allowed_datatypes: list[str] | None = Field(alias="allowed-datatypes", default=None)
+    url: str | None = None
     key: str | None = None  # The actual unit key (e.g., 'km'), populated during loading
 
     @field_validator("quantity")
@@ -468,8 +468,7 @@ class VSSDataDatatype(VSSData):
                 for def_val in check_values:
                     if not re.match(reg_exp, def_val):
                         raise ValueError(
-                            f"Specified '{value_type}' value: '{def_val}' "
-                            f"must match defined pattern: '{self.pattern}'"
+                            f"Specified '{value_type}' value: '{def_val}' must match defined pattern: '{self.pattern}'"
                         )
 
             if self.default:

--- a/tests/vspec/test_units/signals_with_url_units.vspec
+++ b/tests/vspec/test_units/signals_with_url_units.vspec
@@ -1,0 +1,15 @@
+A:
+  type: branch
+  description: Branch A.
+
+A.Temperature:
+  datatype: float
+  type: sensor
+  unit: celsius
+  description: Temperature in Celsius.
+
+A.Distance:
+  datatype: float
+  type: sensor
+  unit: km
+  description: Distance in kilometers.

--- a/tests/vspec/test_units/test_units.py
+++ b/tests/vspec/test_units/test_units.py
@@ -231,3 +231,14 @@ def test_quantity_err_no_def(tmp_path):
         "'volume' is 'None'",
         ["quantities_no_def.yaml"],
     )
+
+
+def test_unit_url_field_accepted(tmp_path):
+    """Units with an optional 'url' field load and validate without error."""
+    spec = HERE / "signals_with_url_units.vspec"
+    units = HERE / "units_with_url.yaml"
+    quantities = HERE / ".." / "test_quantities.yaml"
+    out = tmp_path / "out.json"
+    cmd = f"vspec export json --pretty --vspec {spec} -u {units} -q {quantities} --output {out}"
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
+    assert process.returncode == 0, process.stderr

--- a/tests/vspec/test_units/units_with_url.yaml
+++ b/tests/vspec/test_units/units_with_url.yaml
@@ -1,0 +1,12 @@
+km:
+  definition: Length measured in kilometers
+  unit: kilometer
+  quantity: length
+  allowed-datatypes: ['numeric']
+  url: https://ucum.org/ucum#km
+celsius:
+  definition: Temperature measured in degree celsius
+  unit: degree celsius
+  quantity: temperature
+  allowed-datatypes: ['numeric']
+  url: https://ucum.org/ucum#Cel


### PR DESCRIPTION
## Summary

Adds `url: str | None = None` to the `VSSUnit` Pydantic model so unit definition files can reference an authoritative external specification (UCUM, BIPM SI Brochure, QUDT, etc.).

The field is entirely optional — all existing unit files load unchanged.

Example unit file entry:

```yaml
km:
  definition: Length measured in kilometers
  unit: kilometer
  quantity: length
  allowed-datatypes: ['numeric']
  url: https://ucum.org/ucum#km
```

Resolves #153.

## Test plan

- [ ] `uv run pytest tests/vspec/test_units/test_units.py::test_unit_url_field_accepted` passes
- [ ] All existing unit tests continue to pass (no regression)
- [ ] Unit files without `url:` still load correctly