### PR TITLE
feat: support wildcard (glob) keys in overlay files

### DIFF
--- a/src/vss_tools/vspec.py
+++ b/src/vss_tools/vspec.py
@@ -7,6 +7,8 @@
 # SPDX-License-Identifier: MPL-2.0
 from __future__ import annotations
 
+import copy
+import fnmatch
 from pathlib import Path
 from typing import Any
 
@@ -102,8 +104,22 @@ class VSpec:
     def __str__(self) -> str:
         return f"{self.__class__.__name__}, src={self.source}, prefix={self.prefix}, includes={len(self.includes)}"
 
+    def _expand_globs(self, overlay_data: dict[str, Any]) -> dict[str, Any]:
+        """Return overlay_data with wildcard keys expanded against self.data."""
+        result: dict[str, Any] = {}
+        for key, value in overlay_data.items():
+            if "*" not in key:
+                result[key] = value
+                continue
+            matches = [k for k in self.data if fnmatch.fnmatch(k, key)]
+            if not matches:
+                log.warning(f"Overlay glob '{key}' matched no keys in the base spec")
+            for match in matches:
+                result[match] = copy.deepcopy(value)
+        return result
+
     def update(self, other: VSpec) -> None:
-        deep_update(self.data, other.data)
+        deep_update(self.data, self._expand_globs(other.data))
 
 
 def get_vspecs(includes: list[Path], spec: Path, prefix: str | None = None) -> list[VSpec]:

--- a/tests/vspec/test_overlay_glob/expected.json
+++ b/tests/vspec/test_overlay_glob/expected.json
@@ -1,0 +1,37 @@
+{
+  "A": {
+    "children": {
+      "Other": {
+        "datatype": "uint8",
+        "description": "Unrelated signal.",
+        "type": "sensor"
+      },
+      "Row1": {
+        "children": {
+          "Signal": {
+            "comment": "Applied to all row signals via glob.",
+            "datatype": "float",
+            "description": "First row signal.",
+            "type": "sensor"
+          }
+        },
+        "description": "Row 1.",
+        "type": "branch"
+      },
+      "Row2": {
+        "children": {
+          "Signal": {
+            "comment": "Applied to all row signals via glob.",
+            "datatype": "float",
+            "description": "Second row signal.",
+            "type": "sensor"
+          }
+        },
+        "description": "Row 2.",
+        "type": "branch"
+      }
+    },
+    "description": "Branch A.",
+    "type": "branch"
+  }
+}

--- a/tests/vspec/test_overlay_glob/overlay_glob.vspec
+++ b/tests/vspec/test_overlay_glob/overlay_glob.vspec
@@ -1,0 +1,2 @@
+"A.*.Signal":
+  comment: Applied to all row signals via glob.

--- a/tests/vspec/test_overlay_glob/overlay_no_match.vspec
+++ b/tests/vspec/test_overlay_glob/overlay_no_match.vspec
@@ -1,0 +1,2 @@
+"A.*.DoesNotExist":
+  comment: This glob should match nothing and produce a warning.

--- a/tests/vspec/test_overlay_glob/test.vspec
+++ b/tests/vspec/test_overlay_glob/test.vspec
@@ -1,0 +1,26 @@
+A:
+  type: branch
+  description: Branch A.
+
+A.Row1:
+  type: branch
+  description: Row 1.
+
+A.Row1.Signal:
+  datatype: float
+  type: sensor
+  description: First row signal.
+
+A.Row2:
+  type: branch
+  description: Row 2.
+
+A.Row2.Signal:
+  datatype: float
+  type: sensor
+  description: Second row signal.
+
+A.Other:
+  datatype: uint8
+  type: sensor
+  description: Unrelated signal.

--- a/tests/vspec/test_overlay_glob/test_overlay_glob.py
+++ b/tests/vspec/test_overlay_glob/test_overlay_glob.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2024 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import filecmp
+import subprocess
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+TEST_UNITS = HERE / ".." / "test_units.yaml"
+TEST_QUANT = HERE / ".." / "test_quantities.yaml"
+
+
+def _run(overlay: Path, tmp_path: Path, log_path: Path) -> subprocess.CompletedProcess:
+    spec = HERE / "test.vspec"
+    output = tmp_path / "out.json"
+    cmd = (
+        f"vspec --log-file {log_path} export json --pretty"
+        f" -s {spec} -u {TEST_UNITS} -q {TEST_QUANT}"
+        f" -l {overlay} --output {output}"
+    )
+    return subprocess.run(cmd.split(), capture_output=True, text=True)
+
+
+def test_glob_overlay_expands_to_all_matching_signals(tmp_path: Path):
+    log = tmp_path / "log.txt"
+    result = _run(HERE / "overlay_glob.vspec", tmp_path, log)
+    assert result.returncode == 0, result.stderr
+    assert filecmp.cmp(tmp_path / "out.json", HERE / "expected.json")
+
+
+def test_glob_overlay_no_match_warns(tmp_path: Path):
+    log = tmp_path / "log.txt"
+    result = _run(HERE / "overlay_no_match.vspec", tmp_path, log)
+    assert result.returncode == 0, result.stderr
+    assert "matched no keys" in log.read_text()


### PR DESCRIPTION
## Summary

Overlay YAML keys that contain `*` are now expanded against the accumulated spec before merging, letting overlay authors apply attributes to multiple signals in one declaration:

```yaml
# Add a comment to every Row*.Signal leaf in one shot
"Vehicle.Cabin.Door.*.*.IsLocked":
  comment: Managed by fleet policy.

"A.*.Signal":
  comment: Applies to every matching row signal.
```

**Implementation** — `VSpec._expand_globs()` in `vspec.py`:

- Uses Python's `fnmatch`, where `*` matches any substring including dots (multi-segment wildcards work naturally)
- Glob keys are expanded to one concrete key per match before `deep_update` runs — ordering is deterministic (inherits from `self.data` iteration order)
- If a glob matches nothing a `WARNING` is logged and the load succeeds, allowing forward-compatible overlays

Resolves #193.

## Test plan

- [ ] `uv run pytest tests/vspec/test_overlay_glob/` — both tests pass
- [ ] `A.*.Signal` glob applies `comment:` to `A.Row1.Signal` and `A.Row2.Signal` but not `A.Other`
- [ ] A glob matching nothing logs `"matched no keys"` and exits 0
- [ ] Existing overlay tests (`tests/vspec/test_overlay/`) unchanged