### PR TITLE
Fix imports in generated Java files.

### DIFF
--- a/src/vss_tools/utils/vhal/vhal_mapper.py
+++ b/src/vss_tools/utils/vhal/vhal_mapper.py
@@ -267,8 +267,6 @@ class VhalMapper:
             f"import static android.car.feature.Flags.FLAG_{self.ACONFIG_FLAG_NAME.upper()};",
             "import android.annotation.FlaggedApi;",
             "import android.annotation.RequiresPermission;",
-            "import android.car.hardware.CarPropertyConfig;",
-            "import android.car.VehicleAreaType;",
             "",
             "public final class VehiclePropertyIdsOem {",
             "",
@@ -301,10 +299,10 @@ class VhalMapper:
                 content_lines.extend(
                     [
                         "\t * <p>Property Config:",
-                        "\t * <ul>",
-                        f"\t *  <li>{{@link CarPropertyConfig#{access}}}",
-                        f"\t *  <li>{{@link VehicleAreaType#{area_type}}}",
-                        f"\t *  <li>{{@link CarPropertyConfig#{change_mode}}}",
+                        "\t * <ul>",  # the below @link entries must be fully qualified for VehiclePropertyIdsParser
+                        f"\t *  <li>{{@link android.car.hardware.CarPropertyConfig#{access}}}",
+                        f"\t *  <li>{{@link android.car.VehicleAreaType#{area_type}}}",
+                        f"\t *  <li>{{@link android.car.hardware.CarPropertyConfig#{change_mode}}}",
                         f"\t *  <li>{{@code {property_type}}} property type",
                         "\t * </ul>",
                         "\t *",

--- a/tests/vspec/test_static_uids_vhal/validation_jsons/VehiclePropertyIdsOem.java
+++ b/tests/vspec/test_static_uids_vhal/validation_jsons/VehiclePropertyIdsOem.java
@@ -3,8 +3,6 @@ package android.car.oem;
 import static android.car.feature.Flags.FLAG_OEM_VEHICLE_PROPERTY;
 import android.annotation.FlaggedApi;
 import android.annotation.RequiresPermission;
-import android.car.hardware.CarPropertyConfig;
-import android.car.VehicleAreaType;
 
 public final class VehiclePropertyIdsOem {
 
@@ -12,9 +10,9 @@ public final class VehiclePropertyIdsOem {
 	 * Average speed for the current trip.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -32,9 +30,9 @@ public final class VehiclePropertyIdsOem {
 	 * The available volume for cargo or luggage. For automobiles, this is usually the trunk volume.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -52,9 +50,9 @@ public final class VehiclePropertyIdsOem {
 	 * Vehicle curb weight, including all liquids and full tank of fuel, but no cargo or passengers.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -72,9 +70,9 @@ public final class VehiclePropertyIdsOem {
 	 * Current altitude relative to WGS 84 reference ellipsoid, as measured at the position of GNSS receiver antenna.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -92,9 +90,9 @@ public final class VehiclePropertyIdsOem {
 	 * Fix status of GNSS receiver.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -114,9 +112,9 @@ public final class VehiclePropertyIdsOem {
 	 * axle.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -136,9 +134,9 @@ public final class VehiclePropertyIdsOem {
 	 * Left/Right is as seen from driver perspective, i.e. by a person looking forward.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -157,9 +155,9 @@ public final class VehiclePropertyIdsOem {
 	 * axle. Positive values = above center of rear axle. Negative values = below center of rear axle.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -177,9 +175,9 @@ public final class VehiclePropertyIdsOem {
 	 * Current heading relative to geographic north. 0 = North, 90 = East, 180 = South, 270 = West.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -197,9 +195,9 @@ public final class VehiclePropertyIdsOem {
 	 * Accuracy of the latitude and longitude coordinates.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -217,9 +215,9 @@ public final class VehiclePropertyIdsOem {
 	 * Current latitude of vehicle in WGS 84 geodetic coordinates, as measured at the position of GNSS receiver antenna.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -237,9 +235,9 @@ public final class VehiclePropertyIdsOem {
 	 * Current longitude of vehicle in WGS 84 geodetic coordinates, as measured at the position of GNSS receiver antenna.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -257,9 +255,9 @@ public final class VehiclePropertyIdsOem {
 	 * Timestamp from GNSS system for current location, formatted according to ISO 8601 with UTC time zone.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -277,9 +275,9 @@ public final class VehiclePropertyIdsOem {
 	 * Accuracy of altitude.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -297,9 +295,9 @@ public final class VehiclePropertyIdsOem {
 	 * Current overall Vehicle weight. Including passengers, cargo and other load inside the car.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -317,9 +315,9 @@ public final class VehiclePropertyIdsOem {
 	 * The CO2 emissions.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -337,9 +335,9 @@ public final class VehiclePropertyIdsOem {
 	 * Curb weight of vehicle, including all liquids and full tank of fuel and full load of cargo and passengers.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -357,9 +355,9 @@ public final class VehiclePropertyIdsOem {
 	 * Overall vehicle height.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -379,9 +377,9 @@ public final class VehiclePropertyIdsOem {
 	 * Vehicle not broken down.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Boolean} property type
 	 * </ul>
 	 *
@@ -399,9 +397,9 @@ public final class VehiclePropertyIdsOem {
 	 * Indicates whether the vehicle is stationary or moving.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Boolean} property type
 	 * </ul>
 	 *
@@ -419,9 +417,9 @@ public final class VehiclePropertyIdsOem {
 	 * Overall vehicle length.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -439,9 +437,9 @@ public final class VehiclePropertyIdsOem {
 	 * State of the supply voltage of the control units (usually 12V).
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -459,9 +457,9 @@ public final class VehiclePropertyIdsOem {
 	 * Maximum vertical weight on the tow ball of a trailer.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -479,9 +477,9 @@ public final class VehiclePropertyIdsOem {
 	 * Maximum weight of trailer.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -499,9 +497,9 @@ public final class VehiclePropertyIdsOem {
 	 * The accumulated energy from regenerative braking over lifetime.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -519,9 +517,9 @@ public final class VehiclePropertyIdsOem {
 	 * Engine coolant level.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -539,9 +537,9 @@ public final class VehiclePropertyIdsOem {
 	 * Engine coolant temperature.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -559,9 +557,9 @@ public final class VehiclePropertyIdsOem {
 	 * Engine oil capacity in liters.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -579,9 +577,9 @@ public final class VehiclePropertyIdsOem {
 	 * Engine oil level.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -599,9 +597,9 @@ public final class VehiclePropertyIdsOem {
 	 * EOT, Engine oil temperature.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -619,9 +617,9 @@ public final class VehiclePropertyIdsOem {
 	 * Engine Running. True if engine is rotating (Speed > 0).
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Boolean} property type
 	 * </ul>
 	 *
@@ -639,9 +637,9 @@ public final class VehiclePropertyIdsOem {
 	 * Engine speed measured as rotations per minute.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -659,9 +657,9 @@ public final class VehiclePropertyIdsOem {
 	 * Current available fuel in the fuel tank expressed in liters.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -679,9 +677,9 @@ public final class VehiclePropertyIdsOem {
 	 * Average consumption in liters per 100 km.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -699,9 +697,9 @@ public final class VehiclePropertyIdsOem {
 	 * Fuel consumption since last refueling.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -719,9 +717,9 @@ public final class VehiclePropertyIdsOem {
 	 * Fuel amount in liters consumed since start of current trip.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -739,9 +737,9 @@ public final class VehiclePropertyIdsOem {
 	 * Defines the hybrid type of the vehicle.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -759,9 +757,9 @@ public final class VehiclePropertyIdsOem {
 	 * Current consumption in liters per 100 km.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -779,9 +777,9 @@ public final class VehiclePropertyIdsOem {
 	 * Indicates whether eco start stop is currently enabled.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Boolean} property type
 	 * </ul>
 	 *
@@ -799,9 +797,9 @@ public final class VehiclePropertyIdsOem {
 	 * Indicates that the fuel level is low (e.g. <50km range).
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Boolean} property type
 	 * </ul>
 	 *
@@ -819,9 +817,9 @@ public final class VehiclePropertyIdsOem {
 	 * Status of the fuel port flap(s). True if at least one is open.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ_WRITE}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ_WRITE}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Boolean} property type
 	 * </ul>
 	 *
@@ -840,9 +838,9 @@ public final class VehiclePropertyIdsOem {
 	 * Remaining range in meters using only liquid fuel.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -860,9 +858,9 @@ public final class VehiclePropertyIdsOem {
 	 * Position of refuel port(s). First part indicates side of vehicle, second part relative position on that side.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -880,9 +878,9 @@ public final class VehiclePropertyIdsOem {
 	 * Level in fuel tank as percent of capacity. 0 = empty. 100 = full.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -901,9 +899,9 @@ public final class VehiclePropertyIdsOem {
 	 * with additional suffix for octane (RON) where relevant.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -921,9 +919,9 @@ public final class VehiclePropertyIdsOem {
 	 * High level information of fuel types supported
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -941,9 +939,9 @@ public final class VehiclePropertyIdsOem {
 	 * Capacity of the fuel tank in liters.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -961,9 +959,9 @@ public final class VehiclePropertyIdsOem {
 	 * Time remaining in seconds before the fuel tank is empty.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -981,9 +979,9 @@ public final class VehiclePropertyIdsOem {
 	 * Remaining range in meters using all energy sources available in the vehicle.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -1001,9 +999,9 @@ public final class VehiclePropertyIdsOem {
 	 * Time remaining in seconds before all energy sources available in the vehicle are empty.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -1021,9 +1019,9 @@ public final class VehiclePropertyIdsOem {
 	 * Defines the powertrain type of the vehicle.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -1041,9 +1039,9 @@ public final class VehiclePropertyIdsOem {
 	 * The permitted total weight of cargo and installations (e.g. a roof rack) on top of the vehicle.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -1061,9 +1059,9 @@ public final class VehiclePropertyIdsOem {
 	 * Vehicle speed.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -1081,9 +1079,9 @@ public final class VehiclePropertyIdsOem {
 	 * Start time of current or latest trip, formatted according to ISO 8601 with UTC time zone.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -1101,9 +1099,9 @@ public final class VehiclePropertyIdsOem {
 	 * Signal indicating if trailer is connected or not.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Boolean} property type
 	 * </ul>
 	 *
@@ -1121,9 +1119,9 @@ public final class VehiclePropertyIdsOem {
 	 * Odometer reading, total distance traveled during the lifetime of the vehicle.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -1141,9 +1139,9 @@ public final class VehiclePropertyIdsOem {
 	 * Distance traveled since start of current trip.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -1161,9 +1159,9 @@ public final class VehiclePropertyIdsOem {
 	 * Duration of latest trip.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -1181,9 +1179,9 @@ public final class VehiclePropertyIdsOem {
 	 * Trip meter reading.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ_WRITE}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ_WRITE}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE}
 	 *  <li>{@code Float} property type
 	 * </ul>
 	 *
@@ -1202,9 +1200,9 @@ public final class VehiclePropertyIdsOem {
 	 * Minimum turning diameter, Wall-to-Wall, as defined by SAE J1100-2009 D102.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -1222,9 +1220,9 @@ public final class VehiclePropertyIdsOem {
 	 * Indicates the design and body style of the vehicle (e.g. station wagon, hatchback, etc.).
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -1242,9 +1240,9 @@ public final class VehiclePropertyIdsOem {
 	 * Vehicle brand or manufacturer.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -1262,9 +1260,9 @@ public final class VehiclePropertyIdsOem {
 	 * The date in ISO 8601 format of the first registration of the vehicle with the respective public authorities.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -1282,9 +1280,9 @@ public final class VehiclePropertyIdsOem {
 	 * The license plate of the vehicle.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -1302,9 +1300,9 @@ public final class VehiclePropertyIdsOem {
 	 * Indicates that the vehicle meets the respective emission standard.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -1322,9 +1320,9 @@ public final class VehiclePropertyIdsOem {
 	 * Vehicle model.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -1342,9 +1340,9 @@ public final class VehiclePropertyIdsOem {
 	 * The date in ISO 8601 format of production of the item, e.g. vehicle.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -1362,9 +1360,9 @@ public final class VehiclePropertyIdsOem {
 	 * The main color of the exterior within the basic color palette (eg. red, blue, black, white, ...).
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -1383,9 +1381,9 @@ public final class VehiclePropertyIdsOem {
 	 * model).
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -1404,9 +1402,9 @@ public final class VehiclePropertyIdsOem {
 	 * of limitations set by law.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -1424,9 +1422,9 @@ public final class VehiclePropertyIdsOem {
 	 * 17-character Vehicle Identification Number (VIN) as defined by ISO 3779.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -1444,9 +1442,9 @@ public final class VehiclePropertyIdsOem {
 	 * 3-character World Manufacturer Identification (WMI) as defined by ISO 3780.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code String} property type
 	 * </ul>
 	 *
@@ -1464,9 +1462,9 @@ public final class VehiclePropertyIdsOem {
 	 * Model year of the vehicle.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -1484,9 +1482,9 @@ public final class VehiclePropertyIdsOem {
 	 * Overall vehicle width excluding mirrors, as defined by SAE J1100-2009 W103.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -1504,9 +1502,9 @@ public final class VehiclePropertyIdsOem {
 	 * Overall vehicle width with mirrors folded, as defined by SAE J1100-2009 W145.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *
@@ -1524,9 +1522,9 @@ public final class VehiclePropertyIdsOem {
 	 * Overall vehicle width including mirrors, as defined by SAE J1100-2009 W144.
 	 * <p>Property Config:
 	 * <ul>
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
-	 *  <li>{@link VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
-	 *  <li>{@link CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ}
+	 *  <li>{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_GLOBAL}
+	 *  <li>{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC}
 	 *  <li>{@code Int32} property type
 	 * </ul>
 	 *


### PR DESCRIPTION
The generated java files must use fully qualified constants of android.car package in its @links in their comments as required by packages/services/Car/tools/vehiclepropertyidsparser/src/com/android/car/tool/VehiclePropertyIdsParser.java:81-86