### PR TITLE
Timeseries Based Signal Representation in ros2interface exporter (#12)

### DIFF
--- a/src/vss_tools/model.py
+++ b/src/vss_tools/model.py
@@ -132,8 +132,7 @@ class VSSData(VSSRaw):
         """Give better explanation for empty description."""
         if self.description == "":
             raise ValueError(
-                "All nodes in the final tree must have a description. "
-                "Implicit branches are not allowed in final tree!"
+                "All nodes in the final tree must have a description. Implicit branches are not allowed in final tree!"
             )
         return self
 
@@ -160,12 +159,18 @@ class VSSDataBranch(VSSData):
         return v
 
 
+class Qudt(BaseModel):
+    unit: str
+    kind: str = Field(alias="quantity-kind")
+
+
 class VSSUnit(BaseModel):
     definition: str
     unit: str | None
-    quantity: str
+    quantity: str | None = None
     allowed_datatypes: list[str] | None = Field(alias="allowed-datatypes", default=None)
     key: str | None = None  # The actual unit key (e.g., 'km'), populated during loading
+    qudt: Qudt | None = None
 
     @field_validator("quantity")
     @classmethod
@@ -182,6 +187,12 @@ class VSSUnit(BaseModel):
             if value not in datatypes:
                 raise ValueError(f"Invalid datatype: '{value}'")
         return values
+
+    @model_validator(mode="after")
+    def check_quantity(self) -> Self:
+        if self.quantity is None and self.qudt is None:
+            raise ValueError("either 'quantity' or 'qudt.quantity' has to be set")
+        return self
 
 
 class VSSQuantity(BaseModel):
@@ -469,8 +480,7 @@ class VSSDataDatatype(VSSData):
                 for def_val in check_values:
                     if not re.match(reg_exp, def_val):
                         raise ValueError(
-                            f"Specified '{value_type}' value: '{def_val}' "
-                            f"must match defined pattern: '{self.pattern}'"
+                            f"Specified '{value_type}' value: '{def_val}' must match defined pattern: '{self.pattern}'"
                         )
 
             if self.default:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -9,7 +9,8 @@ from typing import Any
 
 import pydantic
 import pytest
-from vss_tools.model import VSSDataDatatype
+from vss_tools.datatypes import dynamic_quantities
+from vss_tools.model import VSSDataDatatype, VSSUnit
 
 
 @pytest.mark.parametrize(
@@ -75,6 +76,32 @@ def test_vss_data_datatype(data: dict[str, Any], ok: bool) -> None:
     data_ok = True
     try:
         VSSDataDatatype(**data)
+    except pydantic.ValidationError as e:
+        data_ok = False
+        print(e)
+
+    assert ok == data_ok
+
+
+@pytest.mark.parametrize(
+    "data, ok",
+    [
+        ({}, False),
+        ({"quantity": "q"}, True),
+        ({"qudt": {}}, False),
+        ({"qudt": {"unit": "u", "quantity-kind": "k"}}, True),
+    ],
+)
+def test_vss_unit(data: dict[str, Any], ok: bool) -> None:
+    dynamic_quantities.clear()
+    dynamic_quantities.append("q")
+
+    data.update({"definition": "def", "unit": "u"})
+
+    data_ok = True
+    print(data)
+    try:
+        VSSUnit(**data)
     except pydantic.ValidationError as e:
         data_ok = False
         print(e)


### PR DESCRIPTION
* feat(timeseries): added timeseries support in ros2interface

exporter

- ros2interface exporter now supports a new CLI param --timeseries
- timeseries can emit .msg .srv files for signals
- test cases are also updated to support new CLI parameter
- ros2interface documentation is also updated to support new CLI param
- --srv Get now documents an empty request + single latest-value response (was time-window request + array response)
- --timeseries documented as get|set|both (was a boolean flag)
- Split Output into latest-single-value and timeseries service sections; annotate each .srv with its gating condition
- Update examples and usage synopsis; add combined --srv + --timeseries

---------

Signed-off-by: Ali Momin <ali_momin@jp.honda>