### PR TITLE
`[yaml exporter]` Not sorting keys

### DIFF
--- a/src/vss_tools/exporters/yaml.py
+++ b/src/vss_tools/exporters/yaml.py
@@ -33,7 +33,7 @@ def export_yaml(file_name, content_dict):
             f,
             default_flow_style=False,
             Dumper=NoAliasDumper,
-            sort_keys=True,
+            sort_keys=False,
             width=1024,
             indent=2,
             encoding="utf-8",

--- a/tests/vspec/test_allowed/expected.yaml
+++ b/tests/vspec/test_allowed/expected.yaml
@@ -1,38 +1,38 @@
 A:
-  description: Branch A.
   type: branch
-
-A.Float:
-  allowed:
-  - 1.1
-  - 2.54
-  - 3
-  datatype: float
-  description: A float
-  type: actuator
-
-A.Int:
-  allowed:
-  - 1
-  - 2
-  - 3
-  datatype: uint16
-  description: An int
-  type: sensor
+  description: Branch A.
 
 A.String:
+  type: sensor
+  description: A string
+  datatype: string
   allowed:
   - January
   - February
-  datatype: string
-  description: A string
-  type: sensor
 
 A.StringArray:
+  type: sensor
+  description: A string array
+  datatype: string[]
   allowed:
   - January
   - February
   - March
-  datatype: string[]
-  description: A string array
+
+A.Int:
   type: sensor
+  description: An int
+  datatype: uint16
+  allowed:
+  - 1
+  - 2
+  - 3
+
+A.Float:
+  type: actuator
+  description: A float
+  datatype: float
+  allowed:
+  - 1.1
+  - 2.54
+  - 3

--- a/tests/vspec/test_comment/expected.yaml
+++ b/tests/vspec/test_comment/expected.yaml
@@ -1,81 +1,81 @@
 A:
-  description: Branch A.
   type: branch
+  description: Branch A.
+
+A.SingleLineNotQuoted:
+  type: sensor
+  description: A sensor.
+  comment: January is a great month!
+  datatype: float
+  unit: km
+
+A.SingleLineInternalQuotes:
+  type: sensor
+  description: A sensor.
+  comment: February is a "great" month!
+  datatype: float
+  unit: km
+
+A.SingleLineQuoted:
+  type: sensor
+  description: A sensor.
+  comment: March is a great month!
+  datatype: float
+  unit: km
+
+A.SingleLineQuotedInternalQuotes:
+  type: sensor
+  description: A sensor.
+  comment: April is a "great" month!
+  datatype: float
+  unit: km
+
+A.SingleLineComma:
+  type: sensor
+  description: A sensor.
+  comment: May, is a great month!
+  datatype: float
+  unit: km
+
+A.SingleLineCommaQuoted:
+  type: sensor
+  description: A sensor.
+  comment: June, is a great month!
+  datatype: float
+  unit: km
 
 A.MultiLineCommaNotQuoted:
+  type: sensor
+  description: A sensor.
   comment: July, is a great month!
   datatype: float
-  description: A sensor.
-  type: sensor
   unit: km
 
 A.MultiLineCommaQuoted:
+  type: sensor
+  description: A sensor.
   comment: August, is a great month!
   datatype: float
-  description: A sensor.
-  type: sensor
-  unit: km
-
-A.MultiLineLiteralStyleQuote:
-  comment: 'November,
-
-    is a "great" month!
-
-    '
-  datatype: float
-  description: A sensor.
-  type: sensor
   unit: km
 
 A.MultiLineStyleInitialBreak:
+  type: sensor
+  description: A sensor.
   comment: 'October,
 
     is a great month!
 
     '
   datatype: float
-  description: A sensor.
-  type: sensor
   unit: km
 
-A.SingleLineComma:
-  comment: May, is a great month!
-  datatype: float
-  description: A sensor.
+A.MultiLineLiteralStyleQuote:
   type: sensor
-  unit: km
+  description: A sensor.
+  comment: 'November,
 
-A.SingleLineCommaQuoted:
-  comment: June, is a great month!
-  datatype: float
-  description: A sensor.
-  type: sensor
-  unit: km
+    is a "great" month!
 
-A.SingleLineInternalQuotes:
-  comment: February is a "great" month!
+    '
   datatype: float
-  description: A sensor.
-  type: sensor
-  unit: km
-
-A.SingleLineNotQuoted:
-  comment: January is a great month!
-  datatype: float
-  description: A sensor.
-  type: sensor
-  unit: km
-
-A.SingleLineQuoted:
-  comment: March is a great month!
-  datatype: float
-  description: A sensor.
-  type: sensor
-  unit: km
-
-A.SingleLineQuotedInternalQuotes:
-  comment: April is a "great" month!
-  datatype: float
-  description: A sensor.
-  type: sensor
   unit: km

--- a/tests/vspec/test_datatypes/expected.yaml
+++ b/tests/vspec/test_datatypes/expected.yaml
@@ -1,68 +1,68 @@
 A:
-  description: Branch A.
   type: branch
+  description: Branch A.
 
-A.Double:
-  datatype: double
-  description: A double.
+A.UInt8:
   type: sensor
-  unit: km
-
-A.Float:
-  datatype: float
-  description: A float.
-  type: sensor
-  unit: km
-
-A.Int16:
-  datatype: int16
-  description: An int16.
-  type: sensor
-  unit: km
-
-A.Int32:
-  datatype: int32
-  description: An int32
-  type: sensor
-  unit: km
-
-A.Int64:
-  datatype: int64
-  description: An int64
-  type: sensor
+  description: A uint8.
+  datatype: uint8
   unit: km
 
 A.Int8:
-  datatype: int8
-  description: An int8.
   type: sensor
+  description: An int8.
+  datatype: int8
   unit: km
 
-A.IsBoolean:
-  datatype: boolean
-  description: A boolean
-  type: sensor
-
 A.UInt16:
-  datatype: uint16
-  description: A uint16.
   type: sensor
+  description: A uint16.
+  datatype: uint16
+  unit: km
+
+A.Int16:
+  type: sensor
+  description: An int16.
+  datatype: int16
   unit: km
 
 A.UInt32:
-  datatype: uint16
-  description: A uint32.
   type: sensor
+  description: A uint32.
+  datatype: uint16
+  unit: km
+
+A.Int32:
+  type: sensor
+  description: An int32
+  datatype: int32
   unit: km
 
 A.UInt64:
-  datatype: uint64
-  description: A uint64.
   type: sensor
+  description: A uint64.
+  datatype: uint64
   unit: km
 
-A.UInt8:
-  datatype: uint8
-  description: A uint8.
+A.Int64:
   type: sensor
+  description: An int64
+  datatype: int64
+  unit: km
+
+A.IsBoolean:
+  type: sensor
+  description: A boolean
+  datatype: boolean
+
+A.Float:
+  type: sensor
+  description: A float.
+  datatype: float
+  unit: km
+
+A.Double:
+  type: sensor
+  description: A double.
+  datatype: double
   unit: km

--- a/tests/vspec/test_instances/expected.yaml
+++ b/tests/vspec/test_instances/expected.yaml
@@ -1,66 +1,66 @@
 A:
-  description: Branch A.
   type: branch
+  description: Branch A.
 
 A.B:
-  comment: This comment will be duplicated
-  description: This description will be duplicated.
   type: branch
+  description: This description will be duplicated.
+  comment: This comment will be duplicated
 
 A.B.Row1:
-  comment: This comment will be duplicated
-  description: This description will be duplicated.
   type: branch
+  description: This description will be duplicated.
+  comment: This comment will be duplicated
 
 A.B.Row1.Left:
-  comment: This comment will be duplicated
-  description: This description will be duplicated.
   type: branch
+  description: This description will be duplicated.
+  comment: This comment will be duplicated
 
 A.B.Row1.Left.C:
+  type: sensor
+  description: This description will also exist multiple times.
   comment: As well as this comment.
   datatype: int8
-  description: This description will also exist multiple times.
-  type: sensor
   unit: km
 
 A.B.Row1.Right:
-  comment: This comment will be duplicated
-  description: This description will be duplicated.
   type: branch
+  description: This description will be duplicated.
+  comment: This comment will be duplicated
 
 A.B.Row1.Right.C:
+  type: sensor
+  description: This description will also exist multiple times.
   comment: As well as this comment.
   datatype: int8
-  description: This description will also exist multiple times.
-  type: sensor
   unit: km
 
 A.B.Row2:
-  comment: This comment will be duplicated
-  description: This description will be duplicated.
   type: branch
+  description: This description will be duplicated.
+  comment: This comment will be duplicated
 
 A.B.Row2.Left:
-  comment: This comment will be duplicated
-  description: This description will be duplicated.
   type: branch
+  description: This description will be duplicated.
+  comment: This comment will be duplicated
 
 A.B.Row2.Left.C:
+  type: sensor
+  description: This description will also exist multiple times.
   comment: As well as this comment.
   datatype: int8
-  description: This description will also exist multiple times.
-  type: sensor
   unit: km
 
 A.B.Row2.Right:
-  comment: This comment will be duplicated
-  description: This description will be duplicated.
   type: branch
+  description: This description will be duplicated.
+  comment: This comment will be duplicated
 
 A.B.Row2.Right.C:
+  type: sensor
+  description: This description will also exist multiple times.
   comment: As well as this comment.
   datatype: int8
-  description: This description will also exist multiple times.
-  type: sensor
   unit: km

--- a/tests/vspec/test_min_max/expected.yaml
+++ b/tests/vspec/test_min_max/expected.yaml
@@ -1,87 +1,87 @@
 A:
-  description: Branch A.
   type: branch
-
-A.FloatMaxZero:
-  datatype: float
-  description: Max Zero.
-  max: 0.0
-  type: sensor
-
-A.FloatMaxZeroInt:
-  datatype: float
-  description: Max Zero.
-  max: 0
-  type: sensor
-
-A.FloatMinMax:
-  datatype: float
-  description: Min & Max.
-  max: 236723.4
-  min: -165.56323
-  type: sensor
-
-A.FloatMinZero:
-  datatype: float
-  description: Min Zero.
-  min: 0.0
-  type: sensor
-
-A.FloatMinZeroInt:
-  datatype: float
-  description: Min Zero.
-  min: 0
-  type: sensor
-
-A.FloatNoMinMax:
-  datatype: float
-  description: No Min Max.
-  type: sensor
-
-A.FloatOnlyMax:
-  datatype: float
-  description: Only Max.
-  max: 32.3
-  type: sensor
-
-A.FloatOnlyMin:
-  datatype: float
-  description: Only Min.
-  min: -2.5
-  type: sensor
-
-A.IntMaxZero:
-  datatype: int8
-  description: Max Zero.
-  max: 0
-  type: sensor
-
-A.IntMinMax:
-  datatype: int8
-  description: Min & Max.
-  max: 6
-  min: 3
-  type: sensor
-
-A.IntMinZero:
-  datatype: int8
-  description: Min Zero.
-  min: 0
-  type: sensor
+  description: Branch A.
 
 A.IntNoMinMax:
-  datatype: int8
-  description: No Min Max.
   type: sensor
+  description: No Min Max.
+  datatype: int8
 
 A.IntOnlyMax:
-  datatype: int8
-  description: Only Max.
-  max: 32
   type: sensor
+  description: Only Max.
+  datatype: int8
+  max: 32
 
 A.IntOnlyMin:
-  datatype: int8
-  description: Only Min.
-  min: 3
   type: sensor
+  description: Only Min.
+  datatype: int8
+  min: 3
+
+A.IntMinMax:
+  type: sensor
+  description: Min & Max.
+  datatype: int8
+  min: 3
+  max: 6
+
+A.IntMaxZero:
+  type: sensor
+  description: Max Zero.
+  datatype: int8
+  max: 0
+
+A.IntMinZero:
+  type: sensor
+  description: Min Zero.
+  datatype: int8
+  min: 0
+
+A.FloatNoMinMax:
+  type: sensor
+  description: No Min Max.
+  datatype: float
+
+A.FloatOnlyMax:
+  type: sensor
+  description: Only Max.
+  datatype: float
+  max: 32.3
+
+A.FloatOnlyMin:
+  type: sensor
+  description: Only Min.
+  datatype: float
+  min: -2.5
+
+A.FloatMinMax:
+  type: sensor
+  description: Min & Max.
+  datatype: float
+  min: -165.56323
+  max: 236723.4
+
+A.FloatMaxZero:
+  type: sensor
+  description: Max Zero.
+  datatype: float
+  max: 0.0
+
+A.FloatMinZero:
+  type: sensor
+  description: Min Zero.
+  datatype: float
+  min: 0.0
+
+A.FloatMaxZeroInt:
+  type: sensor
+  description: Max Zero.
+  datatype: float
+  max: 0
+
+A.FloatMinZeroInt:
+  type: sensor
+  description: Min Zero.
+  datatype: float
+  min: 0

--- a/tests/vspec/test_overlay_struct/expected.yaml
+++ b/tests/vspec/test_overlay_struct/expected.yaml
@@ -1,40 +1,40 @@
 A:
-  description: Branch A.
   type: branch
+  description: Branch A.
 
 A.SignalA:
-  datatype: Types.Struct1
-  description: This is the first signal.
   type: sensor
+  description: This is the first signal.
+  datatype: Types.Struct1
 
 A.SignalB:
-  datatype: Types.Struct2
-  description: This is the second signal.
   type: sensor
+  description: This is the second signal.
+  datatype: Types.Struct2
 
 ComplexDataTypes:
   Types:
-    description: Top-level branch for vehicle data types.
     type: branch
+    description: Top-level branch for vehicle data types.
   Types.Struct1:
-    description: A struct with datatype property defined.
     type: struct
+    description: A struct with datatype property defined.
   Types.Struct1.x:
-    datatype: double
-    description: x property
     type: property
+    description: x property
+    datatype: double
   Types.Struct1.y:
-    datatype: uint16
-    description: y property
     type: property
+    description: y property
+    datatype: uint16
   Types.Struct2:
-    description: A struct with datatype property defined.
     type: struct
+    description: A struct with datatype property defined.
   Types.Struct2.c:
-    datatype: double
+    type: property
     description: x property
-    type: property
+    datatype: double
   Types.Struct2.d:
-    datatype: uint16
-    description: y property
     type: property
+    description: y property
+    datatype: uint16

--- a/tests/vspec/test_overlay_struct_array/expected.yaml
+++ b/tests/vspec/test_overlay_struct_array/expected.yaml
@@ -1,29 +1,29 @@
 A:
-  description: Branch A.
   type: branch
+  description: Branch A.
 
 A.SignalA:
-  datatype: Types.Struct1[]
-  description: This is the first signal.
   type: sensor
+  description: This is the first signal.
+  datatype: Types.Struct1[]
 
 A.SignalB:
-  datatype: Types.Struct1[]
-  description: This is the second signal.
   type: sensor
+  description: This is the second signal.
+  datatype: Types.Struct1[]
 
 ComplexDataTypes:
   Types:
-    description: Top-level branch for vehicle data types.
     type: branch
+    description: Top-level branch for vehicle data types.
   Types.Struct1:
-    description: A struct with datatype property defined.
     type: struct
+    description: A struct with datatype property defined.
   Types.Struct1.x:
-    datatype: double
+    type: property
     description: x property
-    type: property
+    datatype: double
   Types.Struct1.y:
-    datatype: uint16
-    description: y property
     type: property
+    description: y property
+    datatype: uint16

--- a/tests/vspec/test_structs/expected-signals-types.yaml
+++ b/tests/vspec/test_structs/expected-signals-types.yaml
@@ -1,68 +1,68 @@
 A:
-  description: Branch A.
   type: branch
-
-A.NestedStructSensor:
-  datatype: VehicleDataTypes.TestBranch1.NestedStruct
-  description: A rich sensor with user-defined data type.
-  type: sensor
-
-A.ParentStructSensor:
-  datatype: VehicleDataTypes.TestBranch1.ParentStruct
-  description: A rich sensor with user-defined data type.
-  type: sensor
+  description: Branch A.
 
 A.UInt8:
-  datatype: uint8
-  description: A uint8.
   type: sensor
+  description: A uint8.
+  datatype: uint8
   unit: km
+
+A.ParentStructSensor:
+  type: sensor
+  description: A rich sensor with user-defined data type.
+  datatype: VehicleDataTypes.TestBranch1.ParentStruct
+
+A.NestedStructSensor:
+  type: sensor
+  description: A rich sensor with user-defined data type.
+  datatype: VehicleDataTypes.TestBranch1.NestedStruct
 
 ComplexDataTypes:
   VehicleDataTypes:
+    type: branch
     description: Top-level branch for vehicle data types.
-    type: branch
   VehicleDataTypes.TestBranch1:
-    description: Test branch with structs and properties definitions
     type: branch
+    description: Test branch with structs and properties definitions
   VehicleDataTypes.TestBranch1.NestedStruct:
-    description: A struct that is going to be used within another struct - Nested
     type: struct
+    description: A struct that is going to be used within another struct - Nested
   VehicleDataTypes.TestBranch1.NestedStruct.x:
-    datatype: double
+    type: property
     description: x property
-    min: -10
-    type: property
-  VehicleDataTypes.TestBranch1.NestedStruct.y:
     datatype: double
-    description: y property
-    max: 10
+    min: -10
+  VehicleDataTypes.TestBranch1.NestedStruct.y:
     type: property
+    description: y property
+    datatype: double
+    max: 10
   VehicleDataTypes.TestBranch1.NestedStruct.z:
+    type: property
+    description: z property
     datatype: double
     default: 1
-    description: z property
-    type: property
   VehicleDataTypes.TestBranch1.ParentStruct:
-    description: A struct that is going to contain properties that are structs themselves
     type: struct
-  VehicleDataTypes.TestBranch1.ParentStruct.x_properties:
-    datatype: VehicleDataTypes.TestBranch1.NestedStruct[]
-    description: A property of struct-type array and an arraysize
-    type: property
+    description: A struct that is going to contain properties that are structs themselves
   VehicleDataTypes.TestBranch1.ParentStruct.x_property:
-    datatype: VehicleDataTypes.TestBranch1.NestedStruct
+    type: property
     description: A property of struct-type. The struct name is specified relative to the branch
-    type: property
-  VehicleDataTypes.TestBranch1.ParentStruct.y_properties:
-    datatype: VehicleDataTypes.TestBranch1.NestedStruct[]
-    description: A property of struct-type array and no arraysize
-    type: property
-  VehicleDataTypes.TestBranch1.ParentStruct.y_property:
     datatype: VehicleDataTypes.TestBranch1.NestedStruct
+  VehicleDataTypes.TestBranch1.ParentStruct.y_property:
+    type: property
     description: A property of struct-type. The struct name is specified as a fully qualified name
+    datatype: VehicleDataTypes.TestBranch1.NestedStruct
+  VehicleDataTypes.TestBranch1.ParentStruct.x_properties:
     type: property
+    description: A property of struct-type array and an arraysize
+    datatype: VehicleDataTypes.TestBranch1.NestedStruct[]
+  VehicleDataTypes.TestBranch1.ParentStruct.y_properties:
+    type: property
+    description: A property of struct-type array and no arraysize
+    datatype: VehicleDataTypes.TestBranch1.NestedStruct[]
   VehicleDataTypes.TestBranch1.ParentStruct.z_property:
-    datatype: double
-    description: A primitive property
     type: property
+    description: A primitive property
+    datatype: double

--- a/tests/vspec/test_structs/expected-signals.yaml
+++ b/tests/vspec/test_structs/expected-signals.yaml
@@ -1,19 +1,19 @@
 A:
-  description: Branch A.
   type: branch
-
-A.NestedStructSensor:
-  datatype: VehicleDataTypes.TestBranch1.NestedStruct
-  description: A rich sensor with user-defined data type.
-  type: sensor
-
-A.ParentStructSensor:
-  datatype: VehicleDataTypes.TestBranch1.ParentStruct
-  description: A rich sensor with user-defined data type.
-  type: sensor
+  description: Branch A.
 
 A.UInt8:
-  datatype: uint8
-  description: A uint8.
   type: sensor
+  description: A uint8.
+  datatype: uint8
   unit: km
+
+A.ParentStructSensor:
+  type: sensor
+  description: A rich sensor with user-defined data type.
+  datatype: VehicleDataTypes.TestBranch1.ParentStruct
+
+A.NestedStructSensor:
+  type: sensor
+  description: A rich sensor with user-defined data type.
+  datatype: VehicleDataTypes.TestBranch1.NestedStruct

--- a/tests/vspec/test_structs/expected.yaml
+++ b/tests/vspec/test_structs/expected.yaml
@@ -1,58 +1,58 @@
 VehicleDataTypes:
-  description: Top-level branch for vehicle data types.
   type: branch
+  description: Top-level branch for vehicle data types.
 
 VehicleDataTypes.TestBranch1:
-  description: Test branch with structs and properties definitions
   type: branch
+  description: Test branch with structs and properties definitions
 
 VehicleDataTypes.TestBranch1.NestedStruct:
-  description: A struct that is going to be used within another struct - Nested
   type: struct
+  description: A struct that is going to be used within another struct - Nested
 
 VehicleDataTypes.TestBranch1.NestedStruct.x:
-  datatype: double
-  description: x property
-  min: -10
   type: property
+  description: x property
+  datatype: double
+  min: -10
 
 VehicleDataTypes.TestBranch1.NestedStruct.y:
-  datatype: double
-  description: y property
-  max: 10
   type: property
+  description: y property
+  datatype: double
+  max: 10
 
 VehicleDataTypes.TestBranch1.NestedStruct.z:
+  type: property
+  description: z property
   datatype: double
   default: 1
-  description: z property
-  type: property
 
 VehicleDataTypes.TestBranch1.ParentStruct:
-  description: A struct that is going to contain properties that are structs themselves
   type: struct
-
-VehicleDataTypes.TestBranch1.ParentStruct.x_properties:
-  datatype: VehicleDataTypes.TestBranch1.NestedStruct[]
-  description: A property of struct-type array and an arraysize
-  type: property
+  description: A struct that is going to contain properties that are structs themselves
 
 VehicleDataTypes.TestBranch1.ParentStruct.x_property:
-  datatype: VehicleDataTypes.TestBranch1.NestedStruct
+  type: property
   description: A property of struct-type. The struct name is specified relative to the branch
-  type: property
-
-VehicleDataTypes.TestBranch1.ParentStruct.y_properties:
-  datatype: VehicleDataTypes.TestBranch1.NestedStruct[]
-  description: A property of struct-type array and no arraysize
-  type: property
+  datatype: VehicleDataTypes.TestBranch1.NestedStruct
 
 VehicleDataTypes.TestBranch1.ParentStruct.y_property:
-  datatype: VehicleDataTypes.TestBranch1.NestedStruct
-  description: A property of struct-type. The struct name is specified as a fully qualified name
   type: property
+  description: A property of struct-type. The struct name is specified as a fully qualified name
+  datatype: VehicleDataTypes.TestBranch1.NestedStruct
+
+VehicleDataTypes.TestBranch1.ParentStruct.x_properties:
+  type: property
+  description: A property of struct-type array and an arraysize
+  datatype: VehicleDataTypes.TestBranch1.NestedStruct[]
+
+VehicleDataTypes.TestBranch1.ParentStruct.y_properties:
+  type: property
+  description: A property of struct-type array and no arraysize
+  datatype: VehicleDataTypes.TestBranch1.NestedStruct[]
 
 VehicleDataTypes.TestBranch1.ParentStruct.z_property:
-  datatype: double
-  description: A primitive property
   type: property
+  description: A primitive property
+  datatype: double


### PR DESCRIPTION
# About

Not sorting keys of the exported yaml, which will keep the initial ordering of the vspec files which seems more natural.
Also does not shuffle around `enum` values alphabetically. Technically it's possible to just apply that for the `enum` dict with some additional effort. However, I think we might just preserve the original structure (as it might be intended by the writers).

Note that of course that is only relevant for human readers of the output, no difference when parsing as dicts are never guaranteeing an order when iterating.

fixes #542 