### PR TITLE
Add support in VHAL tool for generating property area IDs.

### DIFF
--- a/src/vss_tools/exporters/vhal.py
+++ b/src/vss_tools/exporters/vhal.py
@@ -30,6 +30,12 @@ from vss_tools.utils.vhal.vhal_mapper import VhalMapper
     """,
 )
 @click.option(
+    "--vhal-area-config",
+    type=click.Path(dir_okay=False, readable=True, path_type=Path, exists=True),
+    required=False,
+    help="Path to the JSON file containing the VSS area configuration rules.",
+)
+@click.option(
     "--continuous-change-mode",
     type=click.Path(dir_okay=False, readable=True, path_type=Path, exists=True),
     required=False,
@@ -101,6 +107,7 @@ from vss_tools.utils.vhal.vhal_mapper import VhalMapper
 def cli(
     vspec: Path,
     vhal_map: Path | None,
+    vhal_area_config: Path | None,
     continuous_change_mode: Path | None,
     extend_new: bool,
     property_group: int,
@@ -134,6 +141,13 @@ def cli(
         override_units=override_vhal_units,
         override_datatype=override_vhal_datatype,
     )
+
+    vhal_area_config_file = (
+        vhal_area_config
+        if vhal_area_config is not None
+        else (aosp_workspace_path / "device/generic/car/emulator/vhalmap/vhal_area_config.json")
+    )
+    mapper.load_area_config(vhal_area_config_file)
 
     if continuous_change_mode is not None:
         mapper.load_continuous_list(continuous_change_mode)

--- a/src/vss_tools/utils/vhal/area_constants.py
+++ b/src/vss_tools/utils/vhal/area_constants.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2025 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+from typing import Any, Optional, Tuple
+
+from vss_tools.utils.vhal.property_constants import (
+    VehicleAreaDoor,
+    VehicleAreaMirror,
+    VehicleAreaSeat,
+    VehicleAreaWheel,
+    VehicleAreaWindow,
+    VhalAreaType,
+)
+
+# All possible VSS positional instance strings (lowercase)
+VSS_POSITIONAL_KEYWORDS: frozenset[str] = frozenset(
+    [
+        "row1",
+        "row2",
+        "row3",
+        "row4",
+        "left",
+        "right",
+        "center",
+        "middle",
+        "front",
+        "rear",
+        "frontleft",
+        "frontright",
+        "rearleft",
+        "rearright",
+        "driverside",
+        "passengerside",
+        "driver",
+        "passenger",
+    ]
+)
+
+# Global VSS translation map (normalizing terminology)
+VSS_SIDE_TO_COLUMN: dict[str, str] = {
+    "driverside": "left",  # ambiguous
+    "driver": "left",  # ambiguous
+    "middle": "center",
+    "passengerside": "right",  # ambiguous
+    "passenger": "right",  # ambiguous
+}
+
+# Door area: Row[1,2] × [DriverSide,PassengerSide] for Cabin.Door;
+# [Front,Rear] for Body.Trunk (HOOD / REAR).
+VSS_DOOR_AREA_MAP: dict[tuple[str, ...], VehicleAreaDoor] = {
+    ("row1", "left"): VehicleAreaDoor.ROW_1_LEFT,
+    ("row1", "right"): VehicleAreaDoor.ROW_1_RIGHT,
+    ("row2", "left"): VehicleAreaDoor.ROW_2_LEFT,
+    ("row2", "right"): VehicleAreaDoor.ROW_2_RIGHT,
+    ("row3", "left"): VehicleAreaDoor.ROW_3_LEFT,
+    ("row3", "right"): VehicleAreaDoor.ROW_3_RIGHT,
+    ("front",): VehicleAreaDoor.HOOD,
+    ("rear",): VehicleAreaDoor.REAR,
+}
+
+# Mirror area: [DriverSide,PassengerSide] → left/right mirror.
+VSS_MIRROR_AREA_MAP: dict[tuple[str, ...], VehicleAreaMirror] = {
+    ("left",): VehicleAreaMirror.DRIVER_LEFT,
+    ("center",): VehicleAreaMirror.DRIVER_CENTER,
+    ("right",): VehicleAreaMirror.DRIVER_RIGHT,
+}
+
+# Seat area: Row[1,3] × [DriverSide/Middle/PassengerSide] and [Driver/Passenger].
+# Row 4 is intentionally absent — VehicleAreaSeat has no Row 4.
+VSS_SEAT_AREA_MAP: dict[tuple[str, ...], VehicleAreaSeat] = {
+    ("row1", "left"): VehicleAreaSeat.ROW_1_LEFT,
+    ("row1", "center"): VehicleAreaSeat.ROW_1_CENTER,
+    ("row1", "right"): VehicleAreaSeat.ROW_1_RIGHT,
+    ("row2", "left"): VehicleAreaSeat.ROW_2_LEFT,
+    ("row2", "center"): VehicleAreaSeat.ROW_2_CENTER,
+    ("row2", "right"): VehicleAreaSeat.ROW_2_RIGHT,
+    ("row3", "left"): VehicleAreaSeat.ROW_3_LEFT,
+    ("row3", "center"): VehicleAreaSeat.ROW_3_CENTER,
+    ("row3", "right"): VehicleAreaSeat.ROW_3_RIGHT,
+}
+
+# Wheel area: Row[1,2] × [Left,Right]
+VSS_WHEEL_AREA_MAP: dict[tuple[str, ...], VehicleAreaWheel] = {
+    ("row1", "left"): VehicleAreaWheel.LEFT_FRONT,
+    ("row1", "right"): VehicleAreaWheel.RIGHT_FRONT,
+    ("row2", "left"): VehicleAreaWheel.LEFT_REAR,
+    ("row2", "right"): VehicleAreaWheel.RIGHT_REAR,
+    ("frontleft",): VehicleAreaWheel.LEFT_FRONT,
+    ("frontright",): VehicleAreaWheel.RIGHT_FRONT,
+    ("rearleft",): VehicleAreaWheel.LEFT_REAR,
+    ("rearright",): VehicleAreaWheel.RIGHT_REAR,
+}
+
+# Window area: [Front,Rear] for Body.Windshield.
+VSS_WINDOW_AREA_MAP: dict[tuple[str, ...], VehicleAreaWindow] = {
+    ("front",): VehicleAreaWindow.FRONT_WINDSHIELD,
+    ("rear",): VehicleAreaWindow.REAR_WINDSHIELD,
+}
+
+VEHICLE_AREA_TYPE_MAP: dict[VhalAreaType, dict[tuple[str, ...], Any]] = {
+    VhalAreaType.VEHICLE_AREA_TYPE_DOOR: VSS_DOOR_AREA_MAP,
+    VhalAreaType.VEHICLE_AREA_TYPE_MIRROR: VSS_MIRROR_AREA_MAP,
+    VhalAreaType.VEHICLE_AREA_TYPE_SEAT: VSS_SEAT_AREA_MAP,
+    VhalAreaType.VEHICLE_AREA_TYPE_WHEEL: VSS_WHEEL_AREA_MAP,
+    VhalAreaType.VEHICLE_AREA_TYPE_WINDOW: VSS_WINDOW_AREA_MAP,
+}
+
+VEHICLE_AREA_TYPE_TO_ENUM_CLASS: dict[VhalAreaType, Any] = {
+    VhalAreaType.VEHICLE_AREA_TYPE_DOOR: VehicleAreaDoor,
+    VhalAreaType.VEHICLE_AREA_TYPE_MIRROR: VehicleAreaMirror,
+    VhalAreaType.VEHICLE_AREA_TYPE_SEAT: VehicleAreaSeat,
+    VhalAreaType.VEHICLE_AREA_TYPE_WHEEL: VehicleAreaWheel,
+    VhalAreaType.VEHICLE_AREA_TYPE_WINDOW: VehicleAreaWindow,
+}
+
+VEHICLE_AREA_TYPES = {"GLOBAL", "DOOR", "MIRROR", "SEAT", "WHEEL", "WINDOW"}
+
+
+def get_extracted_instance_parts(vss_path: str) -> Tuple[str, ...]:
+    """
+    Returns the original positional instance tuple extracted from the VSS path.
+    Example: ('row1', 'driverside')
+    """
+    parts = vss_path.split(".")
+    return tuple(p for p in parts if p.lower() in VSS_POSITIONAL_KEYWORDS)
+
+
+def get_area_id(area_type: VhalAreaType, instance_tuple: Tuple[str, ...]) -> Optional[int]:
+    if not instance_tuple:
+        return None
+
+    area_map: dict = VEHICLE_AREA_TYPE_MAP.get(area_type, {})
+    if not area_map:
+        return None
+
+    # Translate side
+    key = tuple(VSS_SIDE_TO_COLUMN.get(s.lower(), s.lower()) for s in instance_tuple)
+
+    if key not in area_map:
+        return None
+
+    return area_map[key].value
+
+
+def get_explicit_area_id(area_type: VhalAreaType, area_value: str) -> Optional[int]:
+    """
+    Checks if a single explicit area value string is valid for the given Area Type,
+    and returns its integer bitmask.
+
+    Example: (VEHICLE_AREA_TYPE_DOOR, "HOOD") -> Returns 0x10000000
+
+    @param area_type: The base Area Type (e.g., VEHICLE_AREA_TYPE_DOOR)
+    @param area_value: The string value to check (e.g., "HOOD")
+    @return: The integer Area ID, or None if invalid.
+    """
+    enum_class = VEHICLE_AREA_TYPE_TO_ENUM_CLASS.get(area_type)
+
+    if not enum_class:
+        return None
+
+    safe_value = area_value.upper()
+
+    # If the member exists, return its integer value!
+    if safe_value in enum_class.__members__:
+        return enum_class.__members__[safe_value].value
+
+    return None

--- a/src/vss_tools/utils/vhal/area_constants.py
+++ b/src/vss_tools/utils/vhal/area_constants.py
@@ -17,7 +17,7 @@ from vss_tools.utils.vhal.property_constants import (
     VhalAreaType,
 )
 
-# All possible VSS positional instance strings (lowercase)
+# All possible VSS positional instance strings
 VSS_POSITIONAL_KEYWORDS: frozenset[str] = frozenset(
     [
         "row1",

--- a/src/vss_tools/utils/vhal/property_constants.py
+++ b/src/vss_tools/utils/vhal/property_constants.py
@@ -6,8 +6,6 @@
 #
 # SPDX-License-Identifier: MPL-2.0
 
-import logging
-import sys
 from enum import IntEnum
 
 from vss_tools.datatypes import Datatypes
@@ -22,8 +20,7 @@ class VhalEnum(IntEnum):
             options.append(f"{item} ({item.value})")
             if str(item) == value or item.name == value or item.value == value:
                 return item
-        logging.error(f"{cls} can have values: {', '.join(options)}; but was {value}")
-        sys.exit(1)
+        raise Exception(f"{cls} can have values: {', '.join(options)}; but was {value}")
 
     def __str__(self) -> str:
         return self.name

--- a/src/vss_tools/utils/vhal/property_constants.py
+++ b/src/vss_tools/utils/vhal/property_constants.py
@@ -8,103 +8,75 @@
 
 import logging
 import sys
-from enum import Enum, IntEnum
+from enum import IntEnum
 
 from vss_tools.datatypes import Datatypes
 
 
-class VhalAreaType(Enum):
+class VhalEnum(IntEnum):
+    @classmethod
+    def get(cls, value: int | str):
+        value = value.upper() if isinstance(value, str) else value
+        options = []
+        for item in cls:
+            options.append(f"{item} ({item.value})")
+            if str(item) == value or item.name == value or item.value == value:
+                return item
+        logging.error(f"{cls} can have values: {', '.join(options)}; but was {value}")
+        sys.exit(1)
+
+    def __str__(self) -> str:
+        return self.name
+
+
+class VhalAreaType(VhalEnum):
     """
     Values of vehicle property fields defined in
     https://cs.android.com/android/platform/superproject/main/+/main:hardware/interfaces/automotive/vehicle/aidl_property/android/hardware/automotive/vehicle/VehicleArea.aidl
     https://android.googlesource.com/platform/packages/services/Car/+/refs/heads/main/car-lib/src/android/car/VehicleAreaType.java
     """
 
-    VEHICLE_AREA_TYPE_GLOBAL = 0  # VehicleAreaType.GLOBAL java
-    VEHICLE_AREA_TYPE_GLOBAL_AIDL = int(0x01000000)  # VehicleArea.GLOBAL aidl
-
-    VEHICLE_AREA_TYPE_VENDOR = 7  # VehicleAreaType.VENDOR java
-    VEHICLE_AREA_TYPE_VENDOR_AIDL = int(0x08000000)  # VehicleArea.VENDOR aidl
+    VEHICLE_AREA_TYPE_GLOBAL = int(0x1)
+    VEHICLE_AREA_TYPE_WINDOW = int(0x3)
+    VEHICLE_AREA_TYPE_MIRROR = int(0x4)
+    VEHICLE_AREA_TYPE_SEAT = int(0x5)
+    VEHICLE_AREA_TYPE_DOOR = int(0x6)
+    VEHICLE_AREA_TYPE_WHEEL = int(0x7)
+    VEHICLE_AREA_TYPE_VENDOR = int(0x8)
 
     def __str__(self) -> str:
-        d = {
-            VhalAreaType.VEHICLE_AREA_TYPE_GLOBAL: "VehicleArea.GLOBAL",
-            VhalAreaType.VEHICLE_AREA_TYPE_VENDOR: "VehicleArea.VENDOR",
-        }
-        return d.get(self, f"VehicleAreaType.{self.name}")
-
-    @staticmethod
-    def get_java_doc(area: int) -> str:
-        if area == 0:
-            return "VEHICLE_AREA_TYPE_GLOBAL"
-        elif area == 7:
-            return "VEHICLE_AREA_TYPE_VENDOR"
-        else:
-            logging.error(f"Vehicle property access must be 0 or 7, was {area}")
-            sys.exit(1)
+        return self.name.removeprefix("VEHICLE_AREA_TYPE_")
 
 
-class VhalPropertyGroup(Enum):
+class VhalPropertyGroup(VhalEnum):
     """
     Values of vehicle property fields defined in
     https://cs.android.com/android/platform/superproject/main/+/main:hardware/interfaces/automotive/vehicle/aidl_property/android/hardware/automotive/vehicle/VehiclePropertyGroup.aidl
     """
 
-    VEHICLE_PROPERTY_GROUP_SYSTEM = int(0x10000000)  # VehiclePropertyGroup.SYSTEM aidl
-    VEHICLE_PROPERTY_GROUP_VENDOR = int(0x20000000)  # VehiclePropertyGroup.VENDOR aidl
-    VEHICLE_PROPERTY_GROUP_BACKPORTED = int(0x30000000)  # VehiclePropertyGroup.BACKPORTED aidl
-    VEHICLE_PROPERTY_GROUP_OEM = int(0x40000000)  # VehiclePropertyGroup.OEM aidl (COVESA)
-
-    @staticmethod
-    def get(group: int):
-        if group == 1:
-            return VhalPropertyGroup.VEHICLE_PROPERTY_GROUP_SYSTEM
-        elif group == 2:
-            return VhalPropertyGroup.VEHICLE_PROPERTY_GROUP_VENDOR
-        elif group == 3:
-            return VhalPropertyGroup.VEHICLE_PROPERTY_GROUP_BACKPORTED
-        elif group == 4:
-            return VhalPropertyGroup.VEHICLE_PROPERTY_GROUP_OEM
-        else:
-            logging.error(f"Group must be between 1 and 4, was {group}")
-            sys.exit(1)
+    VEHICLE_PROPERTY_GROUP_SYSTEM = int(0x1)  # VehiclePropertyGroup.SYSTEM
+    VEHICLE_PROPERTY_GROUP_VENDOR = int(0x2)  # VehiclePropertyGroup.VENDOR
+    VEHICLE_PROPERTY_GROUP_BACKPORTED = int(0x3)  # VehiclePropertyGroup.BACKPORTED
+    VEHICLE_PROPERTY_GROUP_OEM = int(0x4)  # VehiclePropertyGroup.OEM (COVESA)
 
     def __str__(self) -> str:
-        d = {
-            VhalPropertyGroup.VEHICLE_PROPERTY_GROUP_SYSTEM: "VehiclePropertyGroup.SYSTEM",
-            VhalPropertyGroup.VEHICLE_PROPERTY_GROUP_VENDOR: "VehiclePropertyGroup.VENDOR",
-            VhalPropertyGroup.VEHICLE_PROPERTY_GROUP_BACKPORTED: "VehiclePropertyGroup.BACKPORTED",
-            VhalPropertyGroup.VEHICLE_PROPERTY_GROUP_OEM: "VehiclePropertyGroup.OEM",
-        }
-        return d.get(self, "VehiclePropertyGroup.SYSTEM")
+        return self.name.removeprefix("VEHICLE_PROPERTY_GROUP_")
 
 
-class VhalPropertyType(Enum):
-    VEHICLE_PROPERTY_TYPE_STRING = int(0x00100000)  # VehiclePropertyType.STRING
-    VEHICLE_PROPERTY_TYPE_BOOLEAN = int(0x00200000)  # VehiclePropertyType.BOOLEAN
-    VEHICLE_PROPERTY_TYPE_INT32 = int(0x00400000)  # VehiclePropertyType.INT32
-    VEHICLE_PROPERTY_TYPE_INT32_VEC = int(0x00410000)  # VehiclePropertyType.INT32_VEC
-    VEHICLE_PROPERTY_TYPE_INT64 = int(0x00500000)  # VehiclePropertyType.INT64
-    VEHICLE_PROPERTY_TYPE_INT64_VEC = int(0x00510000)  # VehiclePropertyType.INT64_VEC
-    VEHICLE_PROPERTY_TYPE_FLOAT = int(0x00600000)  # VehiclePropertyType.FLOAT
-    VEHICLE_PROPERTY_TYPE_FLOAT_VEC = int(0x00610000)  # VehiclePropertyType.FLOAT_VEC
-    VEHICLE_PROPERTY_TYPE_BYTES = int(0x00700000)  # VehiclePropertyType.BYTES
-    VEHICLE_PROPERTY_TYPE_MIXED = int(0x00E00000)  # VehiclePropertyType.MIXED
+class VhalPropertyType(VhalEnum):
+    VEHICLE_PROPERTY_TYPE_STRING = int(0x10)  # VehiclePropertyType.STRING
+    VEHICLE_PROPERTY_TYPE_BOOLEAN = int(0x20)  # VehiclePropertyType.BOOLEAN
+    VEHICLE_PROPERTY_TYPE_INT32 = int(0x40)  # VehiclePropertyType.INT32
+    VEHICLE_PROPERTY_TYPE_INT32_VEC = int(0x41)  # VehiclePropertyType.INT32_VEC
+    VEHICLE_PROPERTY_TYPE_INT64 = int(0x50)  # VehiclePropertyType.INT64
+    VEHICLE_PROPERTY_TYPE_INT64_VEC = int(0x51)  # VehiclePropertyType.INT64_VEC
+    VEHICLE_PROPERTY_TYPE_FLOAT = int(0x60)  # VehiclePropertyType.FLOAT
+    VEHICLE_PROPERTY_TYPE_FLOAT_VEC = int(0x61)  # VehiclePropertyType.FLOAT_VEC
+    VEHICLE_PROPERTY_TYPE_BYTES = int(0x70)  # VehiclePropertyType.BYTES
+    VEHICLE_PROPERTY_TYPE_MIXED = int(0xE0)  # VehiclePropertyType.MIXED
 
     def __str__(self) -> str:
-        d = {
-            VhalPropertyType.VEHICLE_PROPERTY_TYPE_STRING: "VehiclePropertyType.STRING",
-            VhalPropertyType.VEHICLE_PROPERTY_TYPE_BOOLEAN: "VehiclePropertyType.BOOLEAN",
-            VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT32: "VehiclePropertyType.INT32",
-            VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT32_VEC: "VehiclePropertyType.INT32_VEC",
-            VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT64: "VehiclePropertyType.INT64",
-            VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT64_VEC: "VehiclePropertyType.INT64_VEC",
-            VhalPropertyType.VEHICLE_PROPERTY_TYPE_FLOAT: "VehiclePropertyType.FLOAT",
-            VhalPropertyType.VEHICLE_PROPERTY_TYPE_FLOAT_VEC: "VehiclePropertyType.FLOAT_VEC",
-            VhalPropertyType.VEHICLE_PROPERTY_TYPE_BYTES: "VehiclePropertyType.BYTES",
-            VhalPropertyType.VEHICLE_PROPERTY_TYPE_MIXED: "VehiclePropertyType.MIXED",
-        }
-        return d.get(self, "Unsupported")
+        return self.name.removeprefix("VEHICLE_PROPERTY_TYPE_")
 
 
 class VSSDatatypesToVhal:
@@ -117,37 +89,37 @@ class VSSDatatypesToVhal:
 
     VSS_TO_VHAL_TYPE_MAP = {
         # VHAL standard type mapping
-        Datatypes.STRING[0]: int(0x00100000),  # STRING
-        Datatypes.BOOLEAN[0]: int(0x00200000),  # BOOLEAN
-        Datatypes.INT32[0]: int(0x00400000),  # INT32
-        Datatypes.INT32_ARRAY[0]: int(0x00410000),  # INT32_VEC
-        Datatypes.INT64[0]: int(0x00500000),  # INT64
-        Datatypes.INT64_ARRAY[0]: int(0x00510000),  # INT64_VEC
-        Datatypes.FLOAT[0]: int(0x00600000),  # FLOAT
-        Datatypes.FLOAT_ARRAY[0]: int(0x00610000),  # FLOAT_VEC
+        Datatypes.STRING[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_STRING,  # STRING
+        Datatypes.BOOLEAN[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_BOOLEAN,  # BOOLEAN
+        Datatypes.INT32[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT32,  # INT32
+        Datatypes.INT32_ARRAY[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT32_VEC,  # INT32_VEC
+        Datatypes.INT64[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT64,  # INT64
+        Datatypes.INT64_ARRAY[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT64_VEC,  # INT64_VEC
+        Datatypes.FLOAT[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_FLOAT,  # FLOAT
+        Datatypes.FLOAT_ARRAY[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_FLOAT_VEC,  # FLOAT_VEC
         # Further VSS types mapped to hex values of supported types
-        Datatypes.STRING_ARRAY[0]: int(0x00100000),  # STRING
-        Datatypes.BOOLEAN_ARRAY[0]: int(0x00410000),  # INT32_VEC
-        Datatypes.INT8[0]: int(0x00400000),  # INT32
-        Datatypes.INT8_ARRAY[0]: int(0x00410000),  # INT32_VEC
-        Datatypes.UINT8[0]: int(0x00400000),  # INT32
-        Datatypes.UINT8_ARRAY[0]: int(0x00410000),  # INT32_VEC
-        Datatypes.INT16[0]: int(0x00400000),  # INT32
-        Datatypes.INT16_ARRAY[0]: int(0x00410000),  # INT32_VEC
-        Datatypes.UINT16[0]: int(0x00400000),  # INT32
-        Datatypes.UINT16_ARRAY[0]: int(0x00410000),  # INT32_VEC
-        Datatypes.UINT32[0]: int(0x00400000),  # INT32
-        Datatypes.UINT32_ARRAY[0]: int(0x00410000),  # INT32_VEC
-        Datatypes.UINT64[0]: int(0x00500000),  # INT64
-        Datatypes.UINT64_ARRAY[0]: int(0x00510000),  # INT64_VEC
-        Datatypes.DOUBLE[0]: int(0x00600000),  # fallback to FLOAT
-        Datatypes.DOUBLE_ARRAY[0]: int(0x00610000),  # fallback to FLOAT_VEC
-        Datatypes.NUMERIC[0]: int(0x00600000),  # fallback to FLOAT
-        Datatypes.NUMERIC_ARRAY[0]: int(0x00610000),  # fallback to FLOAT_VEC
+        Datatypes.STRING_ARRAY[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_STRING,  # STRING
+        Datatypes.BOOLEAN_ARRAY[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT32_VEC,  # INT32_VEC
+        Datatypes.INT8[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT32,  # INT32
+        Datatypes.INT8_ARRAY[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT32_VEC,  # INT32_VEC
+        Datatypes.UINT8[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT32,  # INT32
+        Datatypes.UINT8_ARRAY[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT32_VEC,  # INT32_VEC
+        Datatypes.INT16[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT32,  # INT32
+        Datatypes.INT16_ARRAY[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT32_VEC,  # INT32_VEC
+        Datatypes.UINT16[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT32,  # INT32
+        Datatypes.UINT16_ARRAY[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT32_VEC,  # INT32_VEC
+        Datatypes.UINT32[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT32,  # INT32
+        Datatypes.UINT32_ARRAY[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT32_VEC,  # INT32_VEC
+        Datatypes.UINT64[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT64,  # INT64
+        Datatypes.UINT64_ARRAY[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_INT64_VEC,  # INT64_VEC
+        Datatypes.DOUBLE[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_FLOAT,  # fallback to FLOAT
+        Datatypes.DOUBLE_ARRAY[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_FLOAT_VEC,  # fallback to FLOAT_VEC
+        Datatypes.NUMERIC[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_FLOAT,  # fallback to FLOAT
+        Datatypes.NUMERIC_ARRAY[0]: VhalPropertyType.VEHICLE_PROPERTY_TYPE_FLOAT_VEC,  # fallback to FLOAT_VEC
     }
 
     @classmethod
-    def get_property_type_id(cls, vss_datatype: str) -> int:
+    def get(cls, vss_datatype: str) -> VhalPropertyType:
         """
         Get a datatype ID of a datatype. For vss datatypes corresponding to a standard VHAL datatype use standard VHAL
         IDs. For those vss datatypes without corresponding standard VHAL IDs, use vendor IDs.
@@ -155,26 +127,86 @@ class VSSDatatypesToVhal:
         @param vss_datatype: VSS datatype.
         @return: Integer representation of a datatype ID.
         """
-        default_val = cls.VSS_TO_VHAL_TYPE_MAP[Datatypes.STRING[0]]
-        return cls.VSS_TO_VHAL_TYPE_MAP.get(vss_datatype, default_val)
-
-    @classmethod
-    def get_property_type_repr(cls, datatype_id: int) -> str:
-        """
-        Get a datatype string representation of a datatype. For vss datatypes corresponding to a standard VHAL datatype
-        use standard VHAL IDs. For those vss datatypes without corresponding standard VHAL IDs, use vendor IDs.
-
-        @param datatype_id: datatype Integer representation.
-        @return: String representation of a datatype
-        """
-        datatype_name = str(VhalPropertyType(datatype_id))
-        if not datatype_name:
-            raise Exception(f"Invalid property type id {datatype_id}, must be one of IDs listed in VSSDataTypeToVhal")
-
-        return datatype_name
+        return cls.VSS_TO_VHAL_TYPE_MAP.get(vss_datatype, cls.VSS_TO_VHAL_TYPE_MAP[Datatypes.STRING[0]])
 
 
-class VehiclePropertyAccess(IntEnum):
+class VehicleAreaDoor(VhalEnum):
+    """
+    Android VHAL door area values.
+    https://cs.android.com/android/platform/superproject/main/+/main:hardware/interfaces/automotive/vehicle/aidl_property/android/hardware/automotive/vehicle/VehicleAreaDoor.aidl
+    """
+
+    ROW_1_LEFT = 0x00000001
+    ROW_1_RIGHT = 0x00000004
+    ROW_2_LEFT = 0x00000010
+    ROW_2_RIGHT = 0x00000040
+    ROW_3_LEFT = 0x00000100
+    ROW_3_RIGHT = 0x00000400
+    HOOD = 0x10000000
+    REAR = 0x20000000
+
+
+class VehicleAreaMirror(VhalEnum):
+    """
+    Android VHAL mirror area values.
+    https://cs.android.com/android/platform/superproject/main/+/main:hardware/interfaces/automotive/vehicle/aidl_property/android/hardware/automotive/vehicle/VehicleAreaMirror.aidl
+    """
+
+    DRIVER_LEFT = 0x00000001
+    DRIVER_RIGHT = 0x00000002
+    DRIVER_CENTER = 0x00000004
+
+
+class VehicleAreaSeat(VhalEnum):
+    """
+    Android VHAL seat area values.
+    https://cs.android.com/android/platform/superproject/main/+/main:hardware/interfaces/automotive/vehicle/aidl_property/android/hardware/automotive/vehicle/VehicleAreaSeat.aidl
+    """
+
+    UNKNOWN = 0x0000
+    ROW_1_LEFT = 0x0001
+    ROW_1_CENTER = 0x0002
+    ROW_1_RIGHT = 0x0004
+    ROW_2_LEFT = 0x0010
+    ROW_2_CENTER = 0x0020
+    ROW_2_RIGHT = 0x0040
+    ROW_3_LEFT = 0x0100
+    ROW_3_CENTER = 0x0200
+    ROW_3_RIGHT = 0x0400
+
+
+class VehicleAreaWheel(VhalEnum):
+    """
+    Android VHAL wheel area values.
+    https://cs.android.com/android/platform/superproject/main/+/main:hardware/interfaces/automotive/vehicle/aidl_property/android/hardware/automotive/vehicle/VehicleAreaWheel.aidl
+    """
+
+    UNKNOWN = 0x00
+    LEFT_FRONT = 0x01
+    RIGHT_FRONT = 0x02
+    LEFT_REAR = 0x04
+    RIGHT_REAR = 0x08
+
+
+class VehicleAreaWindow(VhalEnum):
+    """
+    Android VHAL window area values.
+    https://cs.android.com/android/platform/superproject/main/+/main:hardware/interfaces/automotive/vehicle/aidl_property/android/hardware/automotive/vehicle/VehicleAreaWindow.aidl
+    """
+
+    FRONT_WINDSHIELD = 0x00000001
+    REAR_WINDSHIELD = 0x00000002
+    ROW_1_LEFT = 0x00000010
+    ROW_1_RIGHT = 0x00000040
+    ROW_2_LEFT = 0x00000100
+    ROW_2_RIGHT = 0x00000400
+    ROW_3_LEFT = 0x00001000
+    ROW_3_RIGHT = 0x00004000
+    ROOF_TOP_1 = 0x00010000
+    ROOF_TOP_2 = 0x00020000
+
+
+class VehiclePropertyAccess(VhalEnum):
     """
     Android VHAL vehicle property access values
     https://developer.android.com/reference/android/car/hardware/CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_READ
@@ -184,28 +216,8 @@ class VehiclePropertyAccess(IntEnum):
     WRITE = 2
     READ_WRITE = 3
 
-    def __str__(self):
-        d = {
-            VehiclePropertyAccess.READ: "VehiclePropertyAccess.READ",
-            VehiclePropertyAccess.WRITE: "VehiclePropertyAccess.WRITE",
-            VehiclePropertyAccess.READ_WRITE: "VehiclePropertyAccess.READ_WRITE",
-        }
-        return d.get(self, "VehiclePropertyAccess.READ")
 
-    @staticmethod
-    def get_java_doc(access: int) -> str:
-        if access == 1:
-            return "VEHICLE_PROPERTY_ACCESS_READ"
-        elif access == 2:
-            return "VEHICLE_PROPERTY_ACCESS_WRITE"
-        elif access == 3:
-            return "VEHICLE_PROPERTY_ACCESS_READ_WRITE"
-        else:
-            logging.error(f"Vehicle property access must be between 1 and 3, was {access}")
-            sys.exit(1)
-
-
-class VehiclePropertyChangeMode(Enum):
+class VehiclePropertyChangeMode(VhalEnum):
     """
     Android VHAL vehicle property change mode values
     https://developer.android.com/reference/android/car/hardware/CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_STATIC
@@ -214,23 +226,3 @@ class VehiclePropertyChangeMode(Enum):
     STATIC = 0
     ON_CHANGE = 1
     CONTINUOUS = 2
-
-    def __str__(self) -> str:
-        d = {
-            VehiclePropertyChangeMode.STATIC: "VehiclePropertyChangeMode.STATIC",
-            VehiclePropertyChangeMode.ON_CHANGE: "VehiclePropertyChangeMode.ON_CHANGE",
-            VehiclePropertyChangeMode.CONTINUOUS: "VehiclePropertyChangeMode.CONTINUOUS",
-        }
-        return d.get(self, "VehiclePropertyChangeMode.STATIC")
-
-    @staticmethod
-    def get_java_doc(mode: int) -> str:
-        if mode == 0:
-            return "VEHICLE_PROPERTY_CHANGE_MODE_STATIC"
-        elif mode == 1:
-            return "VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE"
-        elif mode == 2:
-            return "VEHICLE_PROPERTY_CHANGE_MODE_CONTINUOUS"
-        else:
-            logging.error(f"Change mode must be between 0 and 2, was {mode}")
-            sys.exit(1)

--- a/src/vss_tools/utils/vhal/vehicle_mapping.py
+++ b/src/vss_tools/utils/vhal/vehicle_mapping.py
@@ -5,11 +5,12 @@
 # https://www.mozilla.org/en-US/MPL/2.0/
 #
 # SPDX-License-Identifier: MPL-2.0
+from typing import Dict, List, Optional, Union
 
-from typing import List, Optional, Union
-
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 from pydantic.alias_generators import to_camel
+
+from vss_tools.utils.vhal.property_constants import VhalAreaType, VhalPropertyGroup, VhalPropertyType
 
 
 class VehicleMappingItem(BaseModel):
@@ -24,42 +25,66 @@ class VehicleMappingItem(BaseModel):
 
     :param name: Android name of the vehicle property
     :param property_id: Android area ID of the property (https://android.googlesource.com/platform/packages/services/Car/+/refs/heads/main/car-lib/src/android/car/VehicleAreaType.java)
-    :param area_id: See https://source.android.com/docs/automotive/vhal/property-configuration
     :param access: See https://source.android.com/docs/automotive/vhal/property-configuration
     :param change_mode: Android change mode for the property (https://developer.android.com/reference/android/car/hardware/CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE)
     :param unit: Android property unit
-    :param source: Corresponding fully-qualified VSS leaf name.
+    :param sources: A dictionary mapping a fully-qualified VSS leaf name to its corresponding AOSP Area ID.
+                    Example: {"Vehicle.Chassis.Axle.Row1.Wheel.Left.Speed": 1}
     :param formula: For mapping purpose, explains how to map a VSS property to Android property if direct
                     correspondence wasn't found.
     :param comment: Internal comment about current mapping.
     :param config_string: Optional Android string to contain property specific configuration.
-    :param datatype:
-    :param type:
-    :param min:
-    :param max:
+    :param type: VSS node type, e.g. actuator, sensor.
+    :param min: Minimum allowed value.
+    :param max: Maximum allowed value.
     :param allowed:
-    :param default:
-    :param deprecation:
+    :param default: Default value.
+    :param deprecation: Whether the VSS node is deprecated or not.
     """
 
     name: str
     property_id: int
-    area_id: int
     access: int
     change_mode: int
     unit: str
-    source: str
+    sources: Dict[str, int]
     formula: Optional[str] = None
     comment: Optional[str] = None
     config_string: Optional[str] = None
 
-    datatype: Optional[str] = None
     type: Optional[str] = None
     min: Optional[int] = None
     max: Optional[int] = None
     allowed: Optional[List[str]] = None
     default: Optional[Union[Union[int, str], Union[List[int], List[str]]]] = None
     deprecation: Optional[str] = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _derive_sources_from_source_and_area_id(cls, data):
+        """
+        For backward compatibility: converts obsolete "source" and "areaId" fields into the new "sources" dictionary.
+        """
+        if not isinstance(data, dict):
+            return data
+
+        if "source" in data:
+            data["sources"] = {data["source"]: data.get("areaId", 0)}
+
+        return data
+
+    @staticmethod
+    def vhal_property_id(
+        group: int | VhalPropertyGroup, area_type: int | VhalAreaType, data_type: int | VhalPropertyType, unique_id: int
+    ) -> int:
+        """
+        Construct a VHAL property ID from its components.
+        """
+        group = VhalPropertyGroup.get(group).value if isinstance(group, int) else group
+        area_type = VhalAreaType.get(area_type).value if isinstance(area_type, int) else area_type
+        data_type = VhalPropertyType.get(data_type).value if isinstance(data_type, int) else data_type
+
+        return ((group & 0xF) << 28) | ((area_type & 0xF) << 24) | ((data_type & 0xFF) << 16) | (unique_id & 0xFFFF)
 
     @property
     def vhal_group(self):

--- a/src/vss_tools/utils/vhal/vhal_area_config.py
+++ b/src/vss_tools/utils/vhal/vhal_area_config.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2025 Contributors to COVESA
+#
+# This program and the accompanying materials are made available under the
+# terms of the Mozilla Public License 2.0 which is available at
+# https://www.mozilla.org/en-US/MPL/2.0/
+#
+# SPDX-License-Identifier: MPL-2.0
+
+import re
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator, model_validator
+from pydantic.alias_generators import to_camel
+
+from vss_tools.utils.vhal.area_constants import (
+    VEHICLE_AREA_TYPES,
+    VSS_POSITIONAL_KEYWORDS,
+    get_area_id,
+    get_explicit_area_id,
+)
+from vss_tools.utils.vhal.property_constants import VhalAreaType
+
+
+class VhalAreaRuleItem(BaseModel):
+    model_config = ConfigDict(
+        frozen=True,
+        alias_generator=to_camel,
+        extra="ignore",
+        populate_by_name=True,
+    )
+    """
+    Represents a single raw JSON mapping rule item.
+
+    :param area_type: The target Android AOSP Area Type (e.g., "SEAT").
+    :param map: Explicit overrides translating specific VSS instances to AOSP-specific strings.
+                JSON comma-separated keys (e.g., "row1, left") are parsed into Python tuples.
+    :param ignore: A deny-list of instances. If a VSS path contains any of these single words
+                   (e.g., "front") or exact combinations (e.g., ["row1", "left"]), its
+                   resolution will fall back to "GLOBAL".
+    :param keep: An allow-list of instances. If populated, a VSS path MUST contain at least one
+                 of these words or combinations. If it does not, it falls back to "GLOBAL".
+    """
+    area_type: str
+    map: Dict[Tuple[str, ...], str] = Field(default_factory=dict)
+    ignore: List[Union[str, List[str]]] = Field(default_factory=list)
+    keep: List[Union[str, List[str]]] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _coerce_string(cls, data: Any) -> Any:
+        """
+        Convert raw string into dictionary.
+        """
+        if isinstance(data, str):
+            return {"area_type": data}
+        return data
+
+    @field_validator("map", mode="before")
+    @classmethod
+    def _parse_explicit_map(cls, v: Dict[str, str]) -> Dict[Tuple[str, ...], str]:
+        parsed_map = {}
+        for src, dest in v.items():
+            key_tuple = tuple(s.strip().lower() for s in src.split(","))
+            parsed_map[key_tuple] = dest.upper()
+
+        return parsed_map
+
+    @field_validator("area_type")
+    @classmethod
+    def _check_possible_area_types(cls, value: str) -> str:
+        if value not in VEHICLE_AREA_TYPES:
+            raise ValueError(f"area_type must be one of {VEHICLE_AREA_TYPES}, got {value}")
+        return value
+
+
+class VhalAreaConfigItem(BaseModel):
+    """
+    Internal container to hold a compiled area configuration - optimized runtime model for matching and resolving VSS
+    paths.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        arbitrary_types_allowed=True,
+    )
+    pattern: str
+    """
+    The raw VSS path pattern from the JSON (e.g., "Vehicle.Cabin.Door.*").
+    """
+    depth: int
+    """
+    Number of segments in the pattern (determines priority for longest-match).
+    """
+    rule: VhalAreaRuleItem
+    """
+    The validated rule for this pattern.
+    """
+    compiled_regex: re.Pattern = Field(default=None, validate_default=True)
+    """
+    The precompiled regular expression generated from the pattern.
+    """
+
+    @field_validator("compiled_regex", mode="before")
+    @classmethod
+    def _compile_pattern(cls, _: re.Pattern | None, info: ValidationInfo) -> re.Pattern:
+        pattern = info.data["pattern"]
+        regex_str = pattern.replace(".", r"\.").replace("*", r".*")
+        return re.compile(f"^{regex_str}$", flags=re.IGNORECASE)
+
+    def resolve_area_type(self, path: str) -> Optional[Tuple[VhalAreaType, int]]:
+        """
+        Resolve the effective area_type for a given VSS path.
+
+        Falls back to "GLOBAL" in any of the following cases:
+          1. Any instance extracted from `path` is listed in `item.rule.ignore`, or (when `item.rule.keep` is non-empty)
+             any extracted instance is NOT listed in `item.rule.keep`.
+          2. If `item.rule.map` is non-empty: the extracted instances can be found as a key in `item.rule.map`, but the
+             value in `item.rule.map` cannot be mapped at all.
+          3. If `item.rule.map` is empty: the extracted instances cannot be mapped at all.
+
+        :param path: the dotted VSS path string.
+        :returns: The resolved area type and area ID or `None`.
+        """
+        match = self.compiled_regex.match(path)
+        global_area = (VhalAreaType.VEHICLE_AREA_TYPE_GLOBAL, 0)
+        if match is None:
+            return None
+
+        instances = tuple(p for p in path.lower().split(".") if p.lower() in VSS_POSITIONAL_KEYWORDS)
+        instances_set = set(instances)
+        rule = self.rule
+
+        # Evaluate IGNORE / KEEP
+        if rule.ignore and self.__matches_any(rule.ignore, instances_set):
+            return global_area
+        if rule.keep and not self.__matches_any(rule.keep, instances_set):
+            return global_area
+
+        # Evaluate explicit mapping
+        area_id: int | None
+        area_type = VhalAreaType.get(rule.area_type)
+        explicit_map: Dict[Tuple[str, ...], str] = rule.map
+        if explicit_map and instances in explicit_map:
+            mapped = explicit_map.get(instances)
+            if mapped is None:
+                return global_area
+            area_id = get_explicit_area_id(area_type, mapped)
+            if area_id is None:
+                return global_area
+        elif instances:
+            area_id = get_area_id(area_type, instances)
+            if area_id is None:
+                return global_area
+        else:
+            return global_area
+
+        return area_type, area_id
+
+    @staticmethod
+    def __matches_any(sources: list[Union[str, List[str]]], targets: set[str]) -> bool:
+        """
+        Check whether any entry in `sources` matches `targets`.
+        """
+        for s in sources:
+            if isinstance(s, list):
+                if set(i for i in s).issubset(targets):
+                    return True
+            else:
+                if s in targets:
+                    return True
+        return False

--- a/src/vss_tools/utils/vhal/vhal_mapper.py
+++ b/src/vss_tools/utils/vhal/vhal_mapper.py
@@ -20,14 +20,17 @@ from pydantic import TypeAdapter
 from vss_tools.model import NodeType
 from vss_tools.tree import VSSNode
 from vss_tools.utils.misc import getattr_nn
+from vss_tools.utils.vhal.area_constants import get_extracted_instance_parts
 from vss_tools.utils.vhal.property_constants import (
     VehiclePropertyAccess,
     VehiclePropertyChangeMode,
     VhalAreaType,
     VhalPropertyGroup,
+    VhalPropertyType,
     VSSDatatypesToVhal,
 )
 from vss_tools.utils.vhal.vehicle_mapping import VehicleMappingItem
+from vss_tools.utils.vhal.vhal_area_config import VhalAreaConfigItem, VhalAreaRuleItem
 
 
 class VhalMapper:
@@ -64,10 +67,13 @@ class VhalMapper:
         self.__property_map: Dict[str, VehicleMappingItem] = {}
         self.__properties_without_source: List[VehicleMappingItem] = []
         self.__properties_with_continuous_change_mode: List[str] = []
+        self.__area_config: List[VhalAreaConfigItem] = []
         self.__min_vhal_id: int = starting_id
         self.__next_vhal_id: int = starting_id
 
-    def __get_next_vhal_property_id(self, node: VSSNode) -> int:
+    def __get_next_vhal_property_id(
+        self, area_type: int | VhalAreaType, property_type: int | VhalPropertyType, unique_id: int | None = None
+    ) -> int:
         """
         Generates static VHAL propertyIds as described here
         https://source.android.com/docs/automotive/vhal/property-configuration
@@ -81,23 +87,16 @@ class VhalMapper:
         The ID - vspec static UID generator (https://github.com/COVESA/vss-tools/blob/master/docs/id.md) cannot be used
         since it needs 4-bytes.
 
-        :param node: VSS node that we want to generate a unique VHAL property ID for.
-        :returns: 2 bytes unique ID value for the VSS node.
+        :param area_type: Area type.
+        :param property_type: Property type.
+        :param unique_id: Unique ID to reuse or `None` to generate next.
+        :returns: Full property ID including all its parts.
         """
-        node_data = node.get_vss_data()
-        datatype = getattr_nn(node_data, "datatype", None)
-
-        if not datatype:
-            raise Exception(f"Datatype not given for the VSS leaf {node.get_fqn()}")
-
-        node_uid = self.__next_vhal_id
-        self.__next_vhal_id += 1
-
-        vhal_property_type = VSSDatatypesToVhal.get_property_type_id(datatype)
-        vhal_area_type = VhalAreaType.VEHICLE_AREA_TYPE_GLOBAL_AIDL.value
-        vhal_property_group = VhalPropertyGroup.get(self.__group).value
-
-        property_id = node_uid | vhal_property_group | vhal_area_type | vhal_property_type
+        property_id = VehicleMappingItem.vhal_property_id(
+            self.__group, area_type, property_type, unique_id or self.__next_vhal_id
+        )
+        if unique_id is None:
+            self.__next_vhal_id += 1
 
         return property_id
 
@@ -113,13 +112,13 @@ class VhalMapper:
         for item in mapping:
             if item.vhal_group != self.__group:
                 logging.error(
-                    f"Invalid group {item.vhal_group} of VSS leaf {item.source}! "
+                    f"Invalid group {item.vhal_group} of VSS leaf {item.name}! "
                     f"Group must be in {[self.__group]}! You are probably regenerating a configuration "
                     f"originally generated with a different group."
                 )
             if item.vhal_id < self.__min_vhal_id or item.vhal_id > VhalMapper.MAX_VHAL_ID:
                 logging.error(
-                    f"Invalid unique ID {item.vhal_id} of VSS leaf {item.source}! "
+                    f"Invalid unique ID {item.vhal_id} of VSS leaf {item.name}! "
                     f"ID must be in range {[self.__min_vhal_id, VhalMapper.MAX_VHAL_ID]}"
                 )
             else:
@@ -129,6 +128,21 @@ class VhalMapper:
         if total != valid:
             raise Exception(f"Number of valid IDs {valid} of {total} in total.")
         return True
+
+    def load_area_config(self, file_path: Path):
+        """
+        Loads and compiles the VSS-to-VHAL area configuration rules.
+
+        Parses the provided JSON file to build the internal mapping rules. These rules
+        determine which Android Vehicle Area Type (e.g., Seat, Wheel, Door) applies
+        to specific VSS paths.
+
+        :param file_path: Path to the JSON area configuration file.
+        """
+        with open(file_path, "r") as f:
+            rules = TypeAdapter(Dict[str, VhalAreaRuleItem]).validate_json(f.read())
+        for pattern, rule in rules.items():
+            self.__area_config.append(VhalAreaConfigItem(rule=rule, pattern=pattern, depth=len(pattern.split("."))))
 
     def load_continuous_list(self, file_path: Path):
         """
@@ -171,14 +185,14 @@ class VhalMapper:
                 and self.__next_vhal_id < 1000
             ):
                 logging.error(
-                    f"When generating {VhalPropertyGroup.VEHICLE_PROPERTY_GROUP_SYSTEM} properties starting"
-                    f" ID must be greater than 1000 to prevent conflicts with Google defined properties."
+                    f"When generating VehiclePropertyGroup.{VhalPropertyGroup.VEHICLE_PROPERTY_GROUP_SYSTEM} properties"
+                    f" starting ID must be greater than 1000 to prevent conflicts with Google defined properties."
                     f" Current start is {self.__min_vhal_id}!"
                 )
                 sys.exit(1)
-            self.__property_map = {item.source: item for item in [item for item in data if item.source != ""]}
-            self.__properties_without_source = [item for item in data if item.source == ""]
-            for invalid in [item for item in data if item.source == "" and item.formula == ""]:
+            self.__property_map = {item.name: item for item in [item for item in data if len(item.sources) > 0]}
+            self.__properties_without_source = [item for item in data if len(item.sources) == 0]
+            for invalid in [item for item in data if len(item.sources) == 0 and item.formula == ""]:
                 logging.warning(f"For standard property {invalid.name} no mapping to VSS was found.")
 
         return self.__property_map, self.__properties_without_source
@@ -192,39 +206,78 @@ class VhalMapper:
             node_name_flat = node.get_fqn()
             node_data = node.get_vss_data()
 
-            mapping = self.__property_map.get(node_name_flat)
+            matches = [v for v in self.__property_map.values() if any(s == node_name_flat for s in v.sources)]
+            if len(matches) > 1:
+                raise Exception(f"Multiple mapping entries found for VSS node '{node_name_flat}'!")
+            mapping = matches[0] if matches else None
             if mapping or self.__include_new:
                 if node_data.deprecation:  # ignore deprecated property
                     return
 
-                vss_property = VehicleMappingItem(
-                    name=mapping.name
-                    if mapping
-                    else re.sub(
-                        r"([a-z])([A-Z])", r"\1_\2", node_name_flat.replace("Vehicle.", "").replace(".", "_")
-                    ).upper(),
-                    property_id=mapping.property_id if mapping else self.__get_next_vhal_property_id(node),
-                    area_id=mapping.area_id if mapping else self.__get_vhal_vehicle_area_id(node),
-                    access=mapping.access if mapping else VhalMapper.__get_vhal_access(node),
-                    change_mode=mapping.change_mode if mapping else self.__get_vhal_change_mode(node),
-                    unit=mapping.unit
-                    if mapping and not self.__override_units
-                    else getattr_nn(node_data, "unit", mapping.unit if mapping else ""),
-                    source=node_name_flat,
-                    formula=mapping.formula if mapping and mapping.formula else None,
-                    comment=getattr_nn(node_data, "comment", mapping.comment if mapping and mapping.comment else None),
-                    config_string=mapping.config_string if mapping and mapping.config_string else node_data.description,
-                    datatype=mapping.datatype
-                    if mapping and mapping.datatype and not self.__override_datatype
-                    else getattr_nn(node_data, "datatype", None),
-                    type=str(node_data.type.value),
-                    min=getattr_nn(node_data, "min", None),
-                    max=getattr_nn(node_data, "max", None),
-                    allowed=mapping.allowed if mapping and mapping.allowed else getattr_nn(node_data, "allowed", None),
-                    default=getattr_nn(node_data, "default", None),
-                    deprecation=node_data.deprecation,
-                )
-                self.__property_map[node_name_flat] = vss_property
+                area_type, area_id = self.__get_vhal_vehicle_area(node)
+                if area_type == VhalAreaType.VEHICLE_AREA_TYPE_GLOBAL.value:
+                    item_name = node_name_flat
+                else:
+                    instance_parts = get_extracted_instance_parts(node_name_flat)
+                    parts = node_name_flat.split(".")
+                    item_name = ".".join(p for p in parts if p not in instance_parts)
+                item_name = re.sub(
+                    r"([a-z])([A-Z])", r"\1_\2", item_name.replace("Vehicle.", "").replace(".", "_")
+                ).upper()
+
+                datatype = getattr_nn(node_data, "datatype", None)
+                if not datatype:
+                    raise Exception(f"Datatype not given for the VSS leaf {node.get_fqn()}")
+                property_type = VSSDatatypesToVhal.get(datatype)
+
+                if item_name in self.__property_map:
+                    self.__property_map[item_name].sources[node_name_flat] = area_id
+                    area_type_changed = self.__property_map[item_name].vhal_area != area_type
+                    property_type_changed = self.__property_map[item_name].vhal_type != property_type.value
+
+                    if property_type_changed and self.__override_datatype or area_type_changed:
+                        self.__property_map[item_name] = self.__property_map[item_name].model_copy(
+                            update={
+                                "property_id": self.__get_next_vhal_property_id(
+                                    area_type,
+                                    property_type if self.__override_datatype else property_type.value,
+                                    self.__property_map[item_name].vhal_id,
+                                )
+                            }
+                        )
+                else:
+                    vss_property = VehicleMappingItem(
+                        name=item_name,
+                        property_id=mapping.property_id
+                        if mapping
+                        else self.__get_next_vhal_property_id(area_type, property_type),
+                        access=mapping.access if mapping else VhalMapper.__get_vhal_access(node),
+                        change_mode=mapping.change_mode if mapping else self.__get_vhal_change_mode(node),
+                        unit=mapping.unit
+                        if mapping and not self.__override_units
+                        else getattr_nn(node_data, "unit", mapping.unit if mapping else ""),
+                        sources={node_name_flat: area_id},
+                        formula=mapping.formula if mapping and mapping.formula else None,
+                        comment=getattr_nn(
+                            node_data, "comment", mapping.comment if mapping and mapping.comment else None
+                        ),
+                        config_string=mapping.config_string
+                        if mapping and mapping.config_string
+                        else node_data.description,
+                        type=str(node_data.type.value),
+                        min=getattr_nn(node_data, "min", None),
+                        max=getattr_nn(node_data, "max", None),
+                        allowed=mapping.allowed
+                        if mapping and mapping.allowed
+                        else getattr_nn(node_data, "allowed", None),
+                        default=getattr_nn(node_data, "default", None),
+                        deprecation=node_data.deprecation,
+                    )
+                    self.__property_map[item_name] = vss_property
+
+                # Remove duplicate item
+                if mapping and item_name != mapping.name:
+                    self.__property_map.pop(mapping.name)
 
         for child in node.children:
             self.load_vss_tree(child)
@@ -279,14 +332,11 @@ class VhalMapper:
                 content_lines.append("\t/**")
                 content_lines.extend(f"\t * {line}" for line in lines)
 
-                access = VehiclePropertyAccess.get_java_doc(item.access)
-                area_type = VhalAreaType.get_java_doc(item.area_id)
-                change_mode = VehiclePropertyChangeMode.get_java_doc(item.change_mode)
-                if item.datatype is not None:
-                    type_id = VSSDatatypesToVhal.get_property_type_id(item.datatype)
-                    property_type = VSSDatatypesToVhal.get_property_type_repr(type_id).split(".")[1].capitalize()
-                else:
-                    property_type = "Unknown"
+                access = VehiclePropertyAccess.get(item.access)
+                area_type = VhalAreaType.get(item.vhal_area)
+                change_mode = VehiclePropertyChangeMode.get(item.change_mode)
+                type_id = item.vhal_type
+                property_type = str(VhalPropertyType(type_id)).capitalize()
 
                 if item.access in (VehiclePropertyAccess.WRITE.value, VehiclePropertyAccess.READ_WRITE.value):
                     write_permission_str = (
@@ -300,9 +350,10 @@ class VhalMapper:
                     [
                         "\t * <p>Property Config:",
                         "\t * <ul>",  # the below @link entries must be fully qualified for VehiclePropertyIdsParser
-                        f"\t *  <li>{{@link android.car.hardware.CarPropertyConfig#{access}}}",
-                        f"\t *  <li>{{@link android.car.VehicleAreaType#{area_type}}}",
-                        f"\t *  <li>{{@link android.car.hardware.CarPropertyConfig#{change_mode}}}",
+                        f"\t *  <li>{{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_ACCESS_{access}}}",
+                        f"\t *  <li>{{@link android.car.VehicleAreaType#VEHICLE_AREA_TYPE_{area_type}}}",
+                        f"\t *  <li>{{@link android.car.hardware.CarPropertyConfig#VEHICLE_PROPERTY_CHANGE_MODE_"
+                        f"{str(change_mode).replace('_', '')}}}",
                         f"\t *  <li>{{@code {property_type}}} property type",
                         "\t * </ul>",
                         "\t *",
@@ -419,17 +470,10 @@ class VhalMapper:
 
         for item in mapping:
             if item.vhal_id >= self.__min_vhal_id:
-                vhal_property_group_str = str(VhalPropertyGroup.get(self.__group))
-                vhal_area_type_str = str(VhalAreaType.VEHICLE_AREA_TYPE_GLOBAL)
-                vhal_property_type_str = VSSDatatypesToVhal.get_property_type_repr(item.vhal_type << 16)
-
                 # JavaDoc
-                description = item.comment
-                if description is None:
-                    description = item.config_string
-                elif not description.endswith("."):
-                    description = f"{item.comment}. {item.config_string}"
-
+                description = " ".join(
+                    [s.removesuffix(".") + "." for s in [item.config_string, item.comment] if s is not None]
+                )
                 lines = textwrap.wrap(description, width=120) if description is not None else []
 
                 comment = "\n".join(f"\t * {line}" for line in lines)
@@ -437,8 +481,8 @@ class VhalMapper:
                     f"\t/**\n"
                     f"{comment}\n"
                     f"\t *\n"
-                    f"\t * @change_mode {str(VehiclePropertyChangeMode(item.change_mode))}\n"
-                    f"\t * @access {str(VehiclePropertyAccess(item.access))}\n"
+                    f"\t * @change_mode VehiclePropertyChangeMode.{str(VehiclePropertyChangeMode(item.change_mode))}\n"
+                    f"\t * @access VehiclePropertyAccess.{str(VehiclePropertyAccess(item.access))}\n"
                     f"\t * @version {property_version}\n"
                     f"\t */\n"
                 )
@@ -446,9 +490,9 @@ class VhalMapper:
                 aidl_variable = (
                     f"\t{item.name} = "
                     f"{(item.vhal_id << 0):#0{6}x} + "
-                    f"{vhal_property_group_str} + "
-                    f"{vhal_area_type_str} + "
-                    f"{vhal_property_type_str},\n"
+                    f"VehiclePropertyGroup.{VhalPropertyGroup.get(self.__group)} + "
+                    f"VehicleArea.{VhalAreaType.get(item.vhal_area)} + "
+                    f"VehiclePropertyType.{VhalPropertyType(item.vhal_type)},\n"
                 )
 
                 aidl_variable_with_comment = java_doc + aidl_variable
@@ -569,27 +613,31 @@ class VhalMapper:
 
         return manifest_xml_str, strings_xml_str
 
-    def __get_vhal_vehicle_area_id(self, node: VSSNode) -> int:
+    def __get_vhal_vehicle_area(self, node: VSSNode) -> Tuple[int, int]:
         """
         Android VHAL area ID is described here:
         https://android.googlesource.com/platform/packages/services/Car/+/refs/heads/main/car-lib/src/android/car/VehicleAreaType.java
         and
         https://cs.android.com/android/platform/superproject/main/+/main:hardware/interfaces/automotive/vehicle/aidl_property/android/hardware/automotive/vehicle/VehicleArea.aidl
 
-        Area type is always generated as GLOBAL. As of now the resulting mapping file needs to be manually edited
-        when GLOBAL is not fitting. Consequent runs will keep those edits.
+        Evaluates a VSSNode, finds the longest matching rule, and returns the actual VHAL Area ID.
 
-        A detection of area ID based on VSS tree may be implemented in the future.
-
-        Note that for vendor properties the area type VENDOR should be used.
-
-        :returns: VHAL Area ID.
+        :param node: VSS node (sensor, attribute or actuator).
+        :returns: VHAL Area type integer and area ID.
         """
-        return (
-            VhalAreaType.VEHICLE_AREA_TYPE_VENDOR.value
-            if self.__group == 2
-            else VhalAreaType.VEHICLE_AREA_TYPE_GLOBAL.value
-        )
+        node_name_flat = node.get_fqn()
+        matched_depth = 0
+        best_match = (VhalAreaType.VEHICLE_AREA_TYPE_GLOBAL, 0)
+
+        for config in self.__area_config:
+            if config.depth <= matched_depth:
+                continue
+
+            match = config.resolve_area_type(node_name_flat)
+            if match:
+                best_match = match
+                matched_depth = config.depth
+        return best_match
 
     @staticmethod
     def __get_vhal_access(node: VSSNode) -> int:

--- a/tests/vspec/test_static_uids_vhal/test_static_uids_vhal.py
+++ b/tests/vspec/test_static_uids_vhal/test_static_uids_vhal.py
@@ -201,9 +201,8 @@ def test_vhal_area_type():
     assert VhalAreaType.get("DOOR") == VhalAreaType.VEHICLE_AREA_TYPE_DOOR
     assert VhalAreaType.get("WHEEL") == VhalAreaType.VEHICLE_AREA_TYPE_WHEEL
     assert VhalAreaType.get("VENDOR") == VhalAreaType.VEHICLE_AREA_TYPE_VENDOR
-    with pytest.raises(SystemExit) as e:
+    with pytest.raises(Exception):
         VhalAreaType.get(2)
-    assert e.value.code == 1
 
 
 def test_vhal_property_group():
@@ -222,9 +221,8 @@ def test_vhal_property_group():
     assert str(VhalPropertyGroup.get(3)) == "BACKPORTED"
     assert str(VhalPropertyGroup.get(4)) == "OEM"
 
-    with pytest.raises(SystemExit) as e:
+    with pytest.raises(Exception):
         VhalPropertyGroup.get(5)
-    assert e.value.code == 1
 
 
 def test_vhal_vehicle_property_access():
@@ -239,9 +237,8 @@ def test_vhal_vehicle_property_access():
     assert str(VehiclePropertyAccess.get(1)) == "READ"
     assert str(VehiclePropertyAccess.get(2)) == "WRITE"
     assert str(VehiclePropertyAccess.get(3)) == "READ_WRITE"
-    with pytest.raises(SystemExit) as e:
+    with pytest.raises(Exception):
         VehiclePropertyAccess.get(4)
-    assert e.value.code == 1
 
 
 def test_vhal_vehicle_property_change_mode():
@@ -256,9 +253,8 @@ def test_vhal_vehicle_property_change_mode():
     assert str(VehiclePropertyChangeMode.get(0)) == "STATIC"
     assert str(VehiclePropertyChangeMode.get(1)) == "ON_CHANGE"
     assert str(VehiclePropertyChangeMode.get(2)) == "CONTINUOUS"
-    with pytest.raises(SystemExit) as e:
+    with pytest.raises(Exception):
         VehiclePropertyChangeMode.get(3)
-    assert e.value.code == 1
 
 
 def test_vhal_vehicle_area_door():

--- a/tests/vspec/test_static_uids_vhal/test_static_uids_vhal.py
+++ b/tests/vspec/test_static_uids_vhal/test_static_uids_vhal.py
@@ -16,15 +16,27 @@ from pathlib import Path
 from typing import List, Optional
 
 import pytest
+from pydantic import ValidationError
 from vss_tools.exporters.vhal import VhalMapper
 from vss_tools.main import get_trees
+from vss_tools.utils.vhal.area_constants import (
+    get_area_id,
+    get_explicit_area_id,
+    get_extracted_instance_parts,
+)
 from vss_tools.utils.vhal.property_constants import (
+    VehicleAreaDoor,
+    VehicleAreaMirror,
+    VehicleAreaSeat,
+    VehicleAreaWheel,
+    VehicleAreaWindow,
     VehiclePropertyAccess,
     VehiclePropertyChangeMode,
     VhalAreaType,
     VhalPropertyGroup,
 )
 from vss_tools.utils.vhal.vehicle_mapping import VehicleMappingItem
+from vss_tools.utils.vhal.vhal_area_config import VhalAreaConfigItem, VhalAreaRuleItem
 
 # HELPERS
 
@@ -174,10 +186,23 @@ def car_service_strings_code() -> str:
 
 
 def test_vhal_area_type():
-    assert VhalAreaType.get_java_doc(0) == "VEHICLE_AREA_TYPE_GLOBAL"
-    assert VhalAreaType.get_java_doc(7) == "VEHICLE_AREA_TYPE_VENDOR"
+    assert VhalAreaType.get(1) == VhalAreaType.VEHICLE_AREA_TYPE_GLOBAL
+    assert VhalAreaType.get(3) == VhalAreaType.VEHICLE_AREA_TYPE_WINDOW
+    assert VhalAreaType.get(4) == VhalAreaType.VEHICLE_AREA_TYPE_MIRROR
+    assert VhalAreaType.get(5) == VhalAreaType.VEHICLE_AREA_TYPE_SEAT
+    assert VhalAreaType.get(6) == VhalAreaType.VEHICLE_AREA_TYPE_DOOR
+    assert VhalAreaType.get(7) == VhalAreaType.VEHICLE_AREA_TYPE_WHEEL
+    assert VhalAreaType.get(8) == VhalAreaType.VEHICLE_AREA_TYPE_VENDOR
+
+    assert VhalAreaType.get("GLOBAL") == VhalAreaType.VEHICLE_AREA_TYPE_GLOBAL
+    assert VhalAreaType.get("WINDOW") == VhalAreaType.VEHICLE_AREA_TYPE_WINDOW
+    assert VhalAreaType.get("MIRROR") == VhalAreaType.VEHICLE_AREA_TYPE_MIRROR
+    assert VhalAreaType.get("SEAT") == VhalAreaType.VEHICLE_AREA_TYPE_SEAT
+    assert VhalAreaType.get("DOOR") == VhalAreaType.VEHICLE_AREA_TYPE_DOOR
+    assert VhalAreaType.get("WHEEL") == VhalAreaType.VEHICLE_AREA_TYPE_WHEEL
+    assert VhalAreaType.get("VENDOR") == VhalAreaType.VEHICLE_AREA_TYPE_VENDOR
     with pytest.raises(SystemExit) as e:
-        VhalAreaType.get_java_doc(2)
+        VhalAreaType.get(2)
     assert e.value.code == 1
 
 
@@ -186,27 +211,233 @@ def test_vhal_property_group():
     assert VhalPropertyGroup.get(2) == VhalPropertyGroup.VEHICLE_PROPERTY_GROUP_VENDOR
     assert VhalPropertyGroup.get(3) == VhalPropertyGroup.VEHICLE_PROPERTY_GROUP_BACKPORTED
     assert VhalPropertyGroup.get(4) == VhalPropertyGroup.VEHICLE_PROPERTY_GROUP_OEM
+
+    assert VhalPropertyGroup.get("SYSTEM") == VhalPropertyGroup.VEHICLE_PROPERTY_GROUP_SYSTEM
+    assert VhalPropertyGroup.get("VENDOR") == VhalPropertyGroup.VEHICLE_PROPERTY_GROUP_VENDOR
+    assert VhalPropertyGroup.get("BACKPORTED") == VhalPropertyGroup.VEHICLE_PROPERTY_GROUP_BACKPORTED
+    assert VhalPropertyGroup.get("OEM") == VhalPropertyGroup.VEHICLE_PROPERTY_GROUP_OEM
+
+    assert str(VhalPropertyGroup.get(1)) == "SYSTEM"
+    assert str(VhalPropertyGroup.get(2)) == "VENDOR"
+    assert str(VhalPropertyGroup.get(3)) == "BACKPORTED"
+    assert str(VhalPropertyGroup.get(4)) == "OEM"
+
     with pytest.raises(SystemExit) as e:
         VhalPropertyGroup.get(5)
     assert e.value.code == 1
 
 
 def test_vhal_vehicle_property_access():
-    assert VehiclePropertyAccess.get_java_doc(1) == "VEHICLE_PROPERTY_ACCESS_READ"
-    assert VehiclePropertyAccess.get_java_doc(2) == "VEHICLE_PROPERTY_ACCESS_WRITE"
-    assert VehiclePropertyAccess.get_java_doc(3) == "VEHICLE_PROPERTY_ACCESS_READ_WRITE"
+    assert VehiclePropertyAccess.get(1) == VehiclePropertyAccess.READ
+    assert VehiclePropertyAccess.get(2) == VehiclePropertyAccess.WRITE
+    assert VehiclePropertyAccess.get(3) == VehiclePropertyAccess.READ_WRITE
+
+    assert VehiclePropertyAccess.get("READ") == VehiclePropertyAccess.READ
+    assert VehiclePropertyAccess.get("WRITE") == VehiclePropertyAccess.WRITE
+    assert VehiclePropertyAccess.get("READ_WRITE") == VehiclePropertyAccess.READ_WRITE
+
+    assert str(VehiclePropertyAccess.get(1)) == "READ"
+    assert str(VehiclePropertyAccess.get(2)) == "WRITE"
+    assert str(VehiclePropertyAccess.get(3)) == "READ_WRITE"
     with pytest.raises(SystemExit) as e:
-        VehiclePropertyAccess.get_java_doc(4)
+        VehiclePropertyAccess.get(4)
     assert e.value.code == 1
 
 
 def test_vhal_vehicle_property_change_mode():
-    assert VehiclePropertyChangeMode.get_java_doc(0) == "VEHICLE_PROPERTY_CHANGE_MODE_STATIC"
-    assert VehiclePropertyChangeMode.get_java_doc(1) == "VEHICLE_PROPERTY_CHANGE_MODE_ONCHANGE"
-    assert VehiclePropertyChangeMode.get_java_doc(2) == "VEHICLE_PROPERTY_CHANGE_MODE_CONTINUOUS"
+    assert VehiclePropertyChangeMode.get(0) == VehiclePropertyChangeMode.STATIC
+    assert VehiclePropertyChangeMode.get(1) == VehiclePropertyChangeMode.ON_CHANGE
+    assert VehiclePropertyChangeMode.get(2) == VehiclePropertyChangeMode.CONTINUOUS
+
+    assert VehiclePropertyChangeMode.get("STATIC") == VehiclePropertyChangeMode.STATIC
+    assert VehiclePropertyChangeMode.get("ON_CHANGE") == VehiclePropertyChangeMode.ON_CHANGE
+    assert VehiclePropertyChangeMode.get("CONTINUOUS") == VehiclePropertyChangeMode.CONTINUOUS
+
+    assert str(VehiclePropertyChangeMode.get(0)) == "STATIC"
+    assert str(VehiclePropertyChangeMode.get(1)) == "ON_CHANGE"
+    assert str(VehiclePropertyChangeMode.get(2)) == "CONTINUOUS"
     with pytest.raises(SystemExit) as e:
-        VehiclePropertyChangeMode.get_java_doc(3)
+        VehiclePropertyChangeMode.get(3)
     assert e.value.code == 1
+
+
+def test_vhal_vehicle_area_door():
+    assert VehicleAreaDoor.ROW_1_LEFT.value == 0x00000001
+    assert VehicleAreaDoor.ROW_1_RIGHT.value == 0x00000004
+    assert VehicleAreaDoor.ROW_2_LEFT.value == 0x00000010
+    assert VehicleAreaDoor.ROW_2_RIGHT.value == 0x00000040
+    assert VehicleAreaDoor.ROW_3_LEFT.value == 0x00000100
+    assert VehicleAreaDoor.ROW_3_RIGHT.value == 0x00000400
+    assert VehicleAreaDoor.HOOD.value == 0x10000000
+    assert VehicleAreaDoor.REAR.value == 0x20000000
+
+
+def test_vhal_vehicle_area_mirror():
+    assert VehicleAreaMirror.DRIVER_LEFT.value == 0x00000001
+    assert VehicleAreaMirror.DRIVER_RIGHT.value == 0x00000002
+    assert VehicleAreaMirror.DRIVER_CENTER.value == 0x00000004
+
+
+def test_vhal_vehicle_area_seat():
+    assert VehicleAreaSeat.UNKNOWN.value == 0x0000
+    assert VehicleAreaSeat.ROW_1_LEFT.value == 0x0001
+    assert VehicleAreaSeat.ROW_1_CENTER.value == 0x0002
+    assert VehicleAreaSeat.ROW_1_RIGHT.value == 0x0004
+    assert VehicleAreaSeat.ROW_2_LEFT.value == 0x0010
+    assert VehicleAreaSeat.ROW_2_CENTER.value == 0x0020
+    assert VehicleAreaSeat.ROW_2_RIGHT.value == 0x0040
+    assert VehicleAreaSeat.ROW_3_LEFT.value == 0x0100
+    assert VehicleAreaSeat.ROW_3_CENTER.value == 0x0200
+    assert VehicleAreaSeat.ROW_3_RIGHT.value == 0x0400
+
+
+def test_vhal_vehicle_area_wheel():
+    assert VehicleAreaWheel.UNKNOWN.value == 0x00
+    assert VehicleAreaWheel.LEFT_FRONT.value == 0x01
+    assert VehicleAreaWheel.RIGHT_FRONT.value == 0x02
+    assert VehicleAreaWheel.LEFT_REAR.value == 0x04
+    assert VehicleAreaWheel.RIGHT_REAR.value == 0x08
+
+
+def test_vhal_vehicle_area_window():
+    assert VehicleAreaWindow.FRONT_WINDSHIELD.value == 0x00000001
+    assert VehicleAreaWindow.REAR_WINDSHIELD.value == 0x00000002
+    assert VehicleAreaWindow.ROW_1_LEFT.value == 0x00000010
+    assert VehicleAreaWindow.ROW_1_RIGHT.value == 0x00000040
+    assert VehicleAreaWindow.ROW_2_LEFT.value == 0x00000100
+    assert VehicleAreaWindow.ROW_2_RIGHT.value == 0x00000400
+    assert VehicleAreaWindow.ROW_3_LEFT.value == 0x00001000
+    assert VehicleAreaWindow.ROW_3_RIGHT.value == 0x00004000
+    assert VehicleAreaWindow.ROOF_TOP_1.value == 0x00010000
+    assert VehicleAreaWindow.ROOF_TOP_2.value == 0x00020000
+
+
+def test_vhal_area_rule_item_coerce_string():
+    item = VhalAreaRuleItem.model_validate("SEAT")
+    assert item.area_type == "SEAT"
+    assert item.map == {}
+    assert item.ignore == []
+    assert item.keep == []
+
+
+def test_vhal_area_rule_item_parse_explicit_map():
+    data = {
+        "area_type": "DOOR",
+        "map": {
+            "front": "hood",  # Should strip spaces, lowercase key, uppercase val
+            " rear": "REAR",  # Should strip spaces, lowercase key, uppercase val
+        },
+    }
+    item = VhalAreaRuleItem(**data)
+    assert item.map == {
+        ("front",): "HOOD",
+        ("rear",): "REAR",
+    }
+
+
+def test_vhal_area_rule_item_uppercase_area_type():
+    item = VhalAreaRuleItem(area_type="SEAT")
+    assert item.area_type == "SEAT"
+
+    with pytest.raises(ValidationError):
+        VhalAreaRuleItem(area_type="ROOF")
+
+
+def test_vhal_area_rule_item_lowercase_rule_lists():
+    data = {
+        "area_type": "WHEEL",
+        "ignore": [
+            "frontleft",
+            ["row1", "left"],
+        ],
+        "keep": [
+            "row2",
+        ],
+    }
+    item = VhalAreaRuleItem(**data)
+    assert item.ignore == ["frontleft", ["row1", "left"]]
+    assert item.keep == ["row2"]
+
+
+def test_vhal_are_config_compile_pattern():
+    rule = VhalAreaRuleItem.model_validate("DOOR")
+    pattern = "Vehicle.Cabin.Door.Row1.DriverSide.IsChildLockActive"
+    depth = 6
+    item = VhalAreaConfigItem(
+        pattern=pattern,
+        depth=depth,
+        rule=rule,
+    )
+    assert item.compiled_regex.match(pattern) is not None
+    assert item.compiled_regex.match("Vehicle.Cabin.Door") is None
+
+
+def test_vhal_are_config_from_rule():
+    rule = VhalAreaRuleItem.model_validate("MIRROR")
+    pattern = "Vehicle.Body.Mirrors.*"
+    depth = 4
+    item = VhalAreaConfigItem(rule=rule, pattern=pattern, depth=depth)
+
+    assert item.pattern == pattern
+    assert item.depth == depth
+    assert item.rule is rule
+
+
+def test_vhal_are_config_resolve_area_type():
+    data = {
+        "areaType": "WHEEL",
+        "map": {"row1, left": "LEFT_FRONT"},
+        "ignore": [
+            ["row1", "right"],
+            "row2",
+        ],
+        "keep": [
+            ["row1", "left"],
+        ],
+    }
+    rule = VhalAreaRuleItem(**data)
+    pattern = "Vehicle.MotionManagement.Suspension.Axle.*.Wheel.*"
+    depth = 7
+    item = VhalAreaConfigItem(rule=rule, pattern=pattern, depth=depth)
+
+    keep_path = "Vehicle.MotionManagement.Suspension.Axle.Row1.Wheel.Left.DampingForce"
+    keep_path_area_type = (VhalAreaType.VEHICLE_AREA_TYPE_WHEEL, 1)
+    ignore_path1 = "Vehicle.MotionManagement.Suspension.Axle.Row2.Wheel.Left.DampingForce"
+    ignore_path2 = "Vehicle.MotionManagement.Suspension.Axle.Row2.Wheel.Right.DampingForce"
+    ignore_path_fallback_to_global = (VhalAreaType.VEHICLE_AREA_TYPE_GLOBAL, 0)
+    assert item.resolve_area_type(keep_path) == keep_path_area_type
+    assert item.resolve_area_type(ignore_path1) == ignore_path_fallback_to_global
+    assert item.resolve_area_type(ignore_path2) == ignore_path_fallback_to_global
+
+
+def test_vhal_area_constants_get_extracted_instance():
+    vss_path = "Vehicle.Cabin.Door.Row1.DriverSide.IsChildLockActive"
+    assert get_extracted_instance_parts(vss_path) == ("Row1", "DriverSide")
+    assert get_extracted_instance_parts("Vehicle.Powertrain.FuelSystem.TankCapacity") == ()
+
+    vss_path_mixed = "Vehicle.MotionManagement.Brake.Axle.Row2.Wheel.Left.Torque"
+    assert get_extracted_instance_parts(vss_path_mixed) == ("Row2", "Left")
+    assert get_extracted_instance_parts("") == ()
+
+
+def test_vhal_area_constants_get_area_id():
+    seat_area_type = VhalAreaType.VEHICLE_AREA_TYPE_SEAT
+    seat_instances = ("Row1", "DriverSide")
+    seat_area_value = 1
+    assert get_area_id(seat_area_type, seat_instances) == seat_area_value
+
+    # No mapping found for the tuple
+    assert get_area_id(seat_area_type, ("Row4", "PassengerSide")) is None
+
+
+def test_vhal_area_constants_get_explicit_area_id():
+    window_area_type = VhalAreaType.VEHICLE_AREA_TYPE_WINDOW
+    window_area_value_str = "front_windshield"
+    window_area_value = 1
+    assert get_explicit_area_id(window_area_type, window_area_value_str) == window_area_value
+
+    # Invalid area value string
+    assert get_explicit_area_id(window_area_type, "front") is None
 
 
 def test_load_continuous_list():
@@ -241,6 +472,8 @@ def test_cli():
             HERE / "vehicle_signal_specification/vss.vspec",
             "--vhal-map",
             HERE / "validation_group_1_min_32768.json",
+            "--vhal-area-config",
+            HERE / "vhal_area_config.json",
             "--aosp-workspace-path",
             output_path,
         ]
@@ -266,8 +499,8 @@ def test_load_group_1(validation_properties_group_1):
 
     reference_file_path: Path = HERE / "validation_jsons/validation_group_1_min_32768.json"
     properties = mapper.load(reference_file_path, tree)
-    vss_dict = {leaf.source: leaf.property_id for leaf in properties}
-    validation_dict = {leaf.source: leaf.property_id for leaf in validation_properties_group_1}
+    vss_dict = {source: leaf.property_id for leaf in properties for source in leaf.sources}
+    validation_dict = {source: leaf.property_id for leaf in validation_properties_group_1 for source in leaf.sources}
     assert vss_dict == validation_dict
 
 
@@ -283,20 +516,20 @@ def test_determinism_for_group_1_invalid():
 
 
 def test_determinism_for_group_1(validation_properties_group_1, vss_properties_group_1: List[VehicleMappingItem]):
-    vss_dict = {leaf.source: leaf.property_id for leaf in vss_properties_group_1}
-    validation_dict = {leaf.source: leaf.property_id for leaf in validation_properties_group_1}
+    vss_dict = {source: leaf.property_id for leaf in vss_properties_group_1 for source in leaf.sources}
+    validation_dict = {source: leaf.property_id for leaf in validation_properties_group_1 for source in leaf.sources}
     assert vss_dict == validation_dict
 
 
 def test_determinism_for_group_2(validation_properties_group_2, vss_properties_group_2: List[VehicleMappingItem]):
-    vss_dict = {leaf.source: leaf.property_id for leaf in vss_properties_group_2}
-    validation_dict = {leaf.source: leaf.property_id for leaf in validation_properties_group_2}
+    vss_dict = {source: leaf.property_id for leaf in vss_properties_group_2 for source in leaf.sources}
+    validation_dict = {source: leaf.property_id for leaf in validation_properties_group_2 for source in leaf.sources}
     assert vss_dict == validation_dict
 
 
 def test_determinism_for_group_4(validation_properties_group_4, vss_properties_group_4: List[VehicleMappingItem]):
-    vss_dict = {leaf.source: leaf.property_id for leaf in vss_properties_group_4}
-    validation_dict = {leaf.source: leaf.property_id for leaf in validation_properties_group_4}
+    vss_dict = {source: leaf.property_id for leaf in vss_properties_group_4 for source in leaf.sources}
+    validation_dict = {source: leaf.property_id for leaf in validation_properties_group_4 for source in leaf.sources}
     assert vss_dict == validation_dict
 
 
@@ -304,8 +537,14 @@ def test_overwrite_manually_updated_mapping(
     validation_properties_group_4_with_manual_updates: List[VehicleMappingItem],
     vss_properties_group_4_with_manual_updates: List[VehicleMappingItem],
 ):
-    vss_dict = {leaf.source: leaf.property_id for leaf in vss_properties_group_4_with_manual_updates}
-    validation_dict = {leaf.source: leaf.property_id for leaf in validation_properties_group_4_with_manual_updates}
+    vss_dict = {
+        source: leaf.property_id for leaf in vss_properties_group_4_with_manual_updates for source in leaf.sources
+    }
+    validation_dict = {
+        source: leaf.property_id
+        for leaf in validation_properties_group_4_with_manual_updates
+        for source in leaf.sources
+    }
     assert vss_dict == validation_dict
 
 
@@ -313,8 +552,12 @@ def test_overwrite_manually_updated_mapping_override(
     validation_properties_group_4: List[VehicleMappingItem],
     vss_properties_group_4_with_manual_updates_override: List[VehicleMappingItem],
 ):
-    vss_dict = {leaf.source: leaf.property_id for leaf in vss_properties_group_4_with_manual_updates_override}
-    validation_dict = {leaf.source: leaf.property_id for leaf in validation_properties_group_4}
+    vss_dict = {
+        source: leaf.property_id
+        for leaf in vss_properties_group_4_with_manual_updates_override
+        for source in leaf.sources
+    }
+    validation_dict = {source: leaf.property_id for leaf in validation_properties_group_4 for source in leaf.sources}
     assert vss_dict == validation_dict
 
 
@@ -322,8 +565,10 @@ def test_vss_update(
     validation_properties_group_4_update: List[VehicleMappingItem],
     vss_properties_group_4_update: List[VehicleMappingItem],
 ):
-    vss_dict = {leaf.source: leaf.property_id for leaf in vss_properties_group_4_update}
-    validation_dict = {leaf.source: leaf.property_id for leaf in validation_properties_group_4_update}
+    vss_dict = {source: leaf.property_id for leaf in vss_properties_group_4_update for source in leaf.sources}
+    validation_dict = {
+        source: leaf.property_id for leaf in validation_properties_group_4_update for source in leaf.sources
+    }
     assert vss_dict == validation_dict
 
 

--- a/tests/vspec/test_static_uids_vhal/validation_jsons/VehiclePropertyOem.aidl
+++ b/tests/vspec/test_static_uids_vhal/validation_jsons/VehiclePropertyOem.aidl
@@ -9,10 +9,10 @@ import android.hardware.automotive.vehicle.VehiclePropertyGroup;
 enum VehiclePropertyOem {
 
 	/**
-	 * A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is
-	 * considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new
-	 * trip is started. Calculation of average speed may exclude periods when the vehicle for example is not moving or
-	 * transmission is in neutral.
+	 * Average speed for the current trip. A new trip is considered to start when engine gets enabled (e.g.
+	 * LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The signal may
+	 * however keep the value of the last trip until a new trip is started. Calculation of average speed may exclude periods
+	 * when the vehicle for example is not moving or transmission is in neutral.
 	 *
 	 * @change_mode VehiclePropertyChangeMode.ON_CHANGE
 	 * @access VehiclePropertyAccess.READ
@@ -179,7 +179,10 @@ enum VehiclePropertyOem {
 	HEIGHT = 0x0021 + VehiclePropertyGroup.OEM + VehicleArea.GLOBAL + VehiclePropertyType.INT32,
 
 	/**
-	 * Actual criteria and method used to decide if a vehicle is broken down is implementation specific.
+	 * Vehicle breakdown or any similar event causing vehicle to stop on the road, that might pose a risk to other road users.
+	 * True = Vehicle broken down on the road, due to e.g. engine problems, flat tire, out of gas, brake problems. False =
+	 * Vehicle not broken down. Actual criteria and method used to decide if a vehicle is broken down is implementation
+	 * specific.
 	 *
 	 * @change_mode VehiclePropertyChangeMode.ON_CHANGE
 	 * @access VehiclePropertyAccess.READ
@@ -323,7 +326,7 @@ enum VehiclePropertyOem {
 	POWERTRAIN_FUEL_SYSTEM_AVERAGE_CONSUMPTION = 0x0046 + VehiclePropertyGroup.OEM + VehicleArea.GLOBAL + VehiclePropertyType.FLOAT,
 
 	/**
-	 * Amount of fuel consumed since last refueling.
+	 * Fuel consumption since last refueling. Amount of fuel consumed since last refueling.
 	 *
 	 * @change_mode VehiclePropertyChangeMode.ON_CHANGE
 	 * @access VehiclePropertyAccess.READ
@@ -332,9 +335,9 @@ enum VehiclePropertyOem {
 	POWERTRAIN_FUEL_SYSTEM_CONSUMPTION_SINCE_LAST_REFUEL = 0x0048 + VehiclePropertyGroup.OEM + VehicleArea.GLOBAL + VehiclePropertyType.FLOAT,
 
 	/**
-	 * A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is
-	 * considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new
-	 * trip is started.
+	 * Fuel amount in liters consumed since start of current trip. A new trip is considered to start when engine gets enabled
+	 * (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The
+	 * signal may however keep the value of the last trip until a new trip is started.
 	 *
 	 * @change_mode VehiclePropertyChangeMode.ON_CHANGE
 	 * @access VehiclePropertyAccess.READ
@@ -415,7 +418,8 @@ enum VehiclePropertyOem {
 	POWERTRAIN_FUEL_SYSTEM_RELATIVE_LEVEL = 0x0042 + VehiclePropertyGroup.OEM + VehicleArea.GLOBAL + VehiclePropertyType.INT32,
 
 	/**
-	 * RON 95 is sometimes referred to as Super, RON 98 as Super Plus.
+	 * Detailed information on fuels supported by the vehicle. Identifiers originating from DIN EN 16942:2021-08, appendix B,
+	 * with additional suffix for octane (RON) where relevant. RON 95 is sometimes referred to as Super, RON 98 as Super Plus.
 	 *
 	 * @change_mode VehiclePropertyChangeMode.STATIC
 	 * @access VehiclePropertyAccess.READ
@@ -424,7 +428,8 @@ enum VehiclePropertyOem {
 	POWERTRAIN_FUEL_SYSTEM_SUPPORTED_FUEL = 0x003e + VehiclePropertyGroup.OEM + VehicleArea.GLOBAL + VehiclePropertyType.STRING,
 
 	/**
-	 * If a vehicle also has an electric drivetrain (e.g. hybrid) that will be obvious from the PowerTrain.Type signal.
+	 * High level information of fuel types supported. If a vehicle also has an electric drivetrain (e.g. hybrid) that will be
+	 * obvious from the PowerTrain.Type signal.
 	 *
 	 * @change_mode VehiclePropertyChangeMode.STATIC
 	 * @access VehiclePropertyAccess.READ
@@ -469,8 +474,8 @@ enum VehiclePropertyOem {
 	POWERTRAIN_TIME_REMAINING = 0x0034 + VehiclePropertyGroup.OEM + VehicleArea.GLOBAL + VehiclePropertyType.INT32,
 
 	/**
-	 * For vehicles with a combustion engine (including hybrids) more detailed information on fuels supported can be found in
-	 * FuelSystem.SupportedFuelTypes and FuelSystem.SupportedFuels.
+	 * Defines the powertrain type of the vehicle. For vehicles with a combustion engine (including hybrids) more detailed
+	 * information on fuels supported can be found in FuelSystem.SupportedFuelTypes and FuelSystem.SupportedFuels.
 	 *
 	 * @change_mode VehiclePropertyChangeMode.STATIC
 	 * @access VehiclePropertyAccess.READ
@@ -497,9 +502,10 @@ enum VehiclePropertyOem {
 	SPEED = 0x000f + VehiclePropertyGroup.OEM + VehicleArea.GLOBAL + VehiclePropertyType.FLOAT,
 
 	/**
-	 * This signal is supposed to be set whenever a new trip starts. A new trip is considered to start when engine gets enabled
-	 * (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The
-	 * default value indicates that the vehicle never has been started, or that latest start time is unknown.
+	 * Start time of current or latest trip, formatted according to ISO 8601 with UTC time zone. This signal is supposed to be
+	 * set whenever a new trip starts. A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState
+	 * in ON or START mode). A trip is considered to end when engine is no longer enabled. The default value indicates that the
+	 * vehicle never has been started, or that latest start time is unknown.
 	 *
 	 * @change_mode VehiclePropertyChangeMode.STATIC
 	 * @access VehiclePropertyAccess.READ
@@ -526,9 +532,9 @@ enum VehiclePropertyOem {
 	TRAVELED_DISTANCE = 0x0010 + VehiclePropertyGroup.OEM + VehicleArea.GLOBAL + VehiclePropertyType.FLOAT,
 
 	/**
-	 * A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is
-	 * considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new
-	 * trip is started.
+	 * Distance traveled since start of current trip. A new trip is considered to start when engine gets enabled (e.g.
+	 * LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The signal may
+	 * however keep the value of the last trip until a new trip is started.
 	 *
 	 * @change_mode VehiclePropertyChangeMode.ON_CHANGE
 	 * @access VehiclePropertyAccess.READ
@@ -537,9 +543,9 @@ enum VehiclePropertyOem {
 	TRAVELED_DISTANCE_SINCE_START = 0x0011 + VehiclePropertyGroup.OEM + VehicleArea.GLOBAL + VehiclePropertyType.FLOAT,
 
 	/**
-	 * This signal is not assumed to be continuously updated, but instead set to 0 when a trip starts and set to the actual
-	 * duration of the trip when a trip ends. A new trip is considered to start when engine gets enabled (e.g.
-	 * LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled.
+	 * Duration of latest trip. This signal is not assumed to be continuously updated, but instead set to 0 when a trip starts
+	 * and set to the actual duration of the trip when a trip ends. A new trip is considered to start when engine gets enabled
+	 * (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled.
 	 *
 	 * @change_mode VehiclePropertyChangeMode.ON_CHANGE
 	 * @access VehiclePropertyAccess.READ
@@ -548,7 +554,7 @@ enum VehiclePropertyOem {
 	TRIP_DURATION = 0x0013 + VehiclePropertyGroup.OEM + VehicleArea.GLOBAL + VehiclePropertyType.FLOAT,
 
 	/**
-	 * The trip meter is an odometer that can be manually reset by the driver. Trip meter reading.
+	 * Trip meter reading. The trip meter is an odometer that can be manually reset by the driver.
 	 *
 	 * @change_mode VehiclePropertyChangeMode.ON_CHANGE
 	 * @access VehiclePropertyAccess.READ_WRITE
@@ -593,8 +599,8 @@ enum VehiclePropertyOem {
 	VEHICLE_IDENTIFICATION_DATE_VEHICLE_FIRST_REGISTERED = 0x0007 + VehiclePropertyGroup.OEM + VehicleArea.GLOBAL + VehiclePropertyType.STRING,
 
 	/**
-	 * Depending on the context, this attribute might not be up to date or might be misconfigured, and therefore should be
-	 * considered untrustworthy in the absence of another method of verification.
+	 * The license plate of the vehicle. Depending on the context, this attribute might not be up to date or might be
+	 * misconfigured, and therefore should be considered untrustworthy in the absence of another method of verification.
 	 *
 	 * @change_mode VehiclePropertyChangeMode.STATIC
 	 * @access VehiclePropertyAccess.READ

--- a/tests/vspec/test_static_uids_vhal/validation_jsons/validation_group_1_min_32768.json
+++ b/tests/vspec/test_static_uids_vhal/validation_jsons/validation_group_1_min_32768.json
@@ -2,15 +2,16 @@
   {
     "name": "AVERAGE_SPEED",
     "propertyId": 291536918,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "km/h",
-    "source": "Vehicle.AverageSpeed",
+    "sources": {
+      "Vehicle.AverageSpeed": 0
+    },
     "formula": null,
     "comment": "A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new trip is started. Calculation of average speed may exclude periods when the vehicle for example is not moving or transmission is in neutral.",
     "configString": "Average speed for the current trip.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -21,15 +22,16 @@
   {
     "name": "CARGO_VOLUME",
     "propertyId": 291536920,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "l",
-    "source": "Vehicle.CargoVolume",
+    "sources": {
+      "Vehicle.CargoVolume": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The available volume for cargo or luggage. For automobiles, this is usually the trunk volume.",
-    "datatype": "float",
     "type": "attribute",
     "min": 0,
     "max": null,
@@ -40,15 +42,16 @@
   {
     "name": "CURB_WEIGHT",
     "propertyId": 289439771,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.CurbWeight",
+    "sources": {
+      "Vehicle.CurbWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Vehicle curb weight, including all liquids and full tank of fuel, but no cargo or passengers.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -59,15 +62,16 @@
   {
     "name": "CURRENT_LOCATION_ALTITUDE",
     "propertyId": 291536939,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.CurrentLocation.Altitude",
+    "sources": {
+      "Vehicle.CurrentLocation.Altitude": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current altitude relative to WGS 84 reference ellipsoid, as measured at the position of GNSS receiver antenna.",
-    "datatype": "double",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -78,15 +82,16 @@
   {
     "name": "CURRENT_LOCATION_GNSSRECEIVER_FIX_TYPE",
     "propertyId": 286294061,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.CurrentLocation.GNSSReceiver.FixType",
+    "sources": {
+      "Vehicle.CurrentLocation.GNSSReceiver.FixType": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Fix status of GNSS receiver.",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -107,15 +112,16 @@
   {
     "name": "CURRENT_LOCATION_GNSSRECEIVER_MOUNTING_POSITION_X",
     "propertyId": 289439790,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.X",
+    "sources": {
+      "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.X": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Mounting position of GNSS receiver antenna relative to vehicle coordinate system. Axis definitions according to ISO 8855. Origin at center of (first) rear axle. Positive values = forward of rear axle. Negative values = backward of rear axle.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -126,15 +132,16 @@
   {
     "name": "CURRENT_LOCATION_GNSSRECEIVER_MOUNTING_POSITION_Y",
     "propertyId": 289439791,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.Y",
+    "sources": {
+      "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.Y": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Mounting position of GNSS receiver antenna relative to vehicle coordinate system. Axis definitions according to ISO 8855. Origin at center of (first) rear axle. Positive values = left of origin. Negative values = right of origin. Left/Right is as seen from driver perspective, i.e. by a person looking forward.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -145,15 +152,16 @@
   {
     "name": "CURRENT_LOCATION_GNSSRECEIVER_MOUNTING_POSITION_Z",
     "propertyId": 289439792,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.Z",
+    "sources": {
+      "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.Z": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Mounting position of GNSS receiver on Z-axis. Axis definitions according to ISO 8855. Origin at center of (first) rear axle. Positive values = above center of rear axle. Negative values = below center of rear axle.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -164,15 +172,16 @@
   {
     "name": "CURRENT_LOCATION_HEADING",
     "propertyId": 291536937,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "degrees",
-    "source": "Vehicle.CurrentLocation.Heading",
+    "sources": {
+      "Vehicle.CurrentLocation.Heading": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current heading relative to geographic north. 0 = North, 90 = East, 180 = South, 270 = West.",
-    "datatype": "double",
     "type": "sensor",
     "min": 0,
     "max": 360,
@@ -183,15 +192,16 @@
   {
     "name": "CURRENT_LOCATION_HORIZONTAL_ACCURACY",
     "propertyId": 291536938,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.CurrentLocation.HorizontalAccuracy",
+    "sources": {
+      "Vehicle.CurrentLocation.HorizontalAccuracy": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Accuracy of the latitude and longitude coordinates.",
-    "datatype": "double",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -202,15 +212,16 @@
   {
     "name": "CURRENT_LOCATION_LATITUDE",
     "propertyId": 291536935,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "degrees",
-    "source": "Vehicle.CurrentLocation.Latitude",
+    "sources": {
+      "Vehicle.CurrentLocation.Latitude": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current latitude of vehicle in WGS 84 geodetic coordinates, as measured at the position of GNSS receiver antenna.",
-    "datatype": "double",
     "type": "sensor",
     "min": -90,
     "max": 90,
@@ -221,15 +232,16 @@
   {
     "name": "CURRENT_LOCATION_LONGITUDE",
     "propertyId": 291536936,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "degrees",
-    "source": "Vehicle.CurrentLocation.Longitude",
+    "sources": {
+      "Vehicle.CurrentLocation.Longitude": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current longitude of vehicle in WGS 84 geodetic coordinates, as measured at the position of GNSS receiver antenna.",
-    "datatype": "double",
     "type": "sensor",
     "min": -180,
     "max": 180,
@@ -240,15 +252,16 @@
   {
     "name": "CURRENT_LOCATION_TIMESTAMP",
     "propertyId": 286294054,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "iso8601",
-    "source": "Vehicle.CurrentLocation.Timestamp",
+    "sources": {
+      "Vehicle.CurrentLocation.Timestamp": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Timestamp from GNSS system for current location, formatted according to ISO 8601 with UTC time zone.",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -259,15 +272,16 @@
   {
     "name": "CURRENT_LOCATION_VERTICAL_ACCURACY",
     "propertyId": 291536940,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.CurrentLocation.VerticalAccuracy",
+    "sources": {
+      "Vehicle.CurrentLocation.VerticalAccuracy": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Accuracy of altitude.",
-    "datatype": "double",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -278,15 +292,16 @@
   {
     "name": "CURRENT_OVERALL_WEIGHT",
     "propertyId": 289439770,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "kg",
-    "source": "Vehicle.CurrentOverallWeight",
+    "sources": {
+      "Vehicle.CurrentOverallWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current overall Vehicle weight. Including passengers, cargo and other load inside the car.",
-    "datatype": "uint16",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -297,15 +312,16 @@
   {
     "name": "EMISSIONS_CO2",
     "propertyId": 289439769,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "g/km",
-    "source": "Vehicle.EmissionsCO2",
+    "sources": {
+      "Vehicle.EmissionsCO2": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The CO2 emissions.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -316,15 +332,16 @@
   {
     "name": "GROSS_WEIGHT",
     "propertyId": 289439772,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.GrossWeight",
+    "sources": {
+      "Vehicle.GrossWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Curb weight of vehicle, including all liquids and full tank of fuel and full load of cargo and passengers.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -335,15 +352,16 @@
   {
     "name": "HEIGHT",
     "propertyId": 289439776,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.Height",
+    "sources": {
+      "Vehicle.Height": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle height.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -354,15 +372,16 @@
   {
     "name": "IS_BROKEN_DOWN",
     "propertyId": 287342612,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.IsBrokenDown",
+    "sources": {
+      "Vehicle.IsBrokenDown": 0
+    },
     "formula": null,
     "comment": "Actual criteria and method used to decide if a vehicle is broken down is implementation specific.",
     "configString": "Vehicle breakdown or any similar event causing vehicle to stop on the road, that might pose a risk to other road users. True = Vehicle broken down on the road, due to e.g. engine problems, flat tire, out of gas, brake problems. False = Vehicle not broken down.",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -373,15 +392,16 @@
   {
     "name": "IS_MOVING",
     "propertyId": 287342613,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.IsMoving",
+    "sources": {
+      "Vehicle.IsMoving": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates whether the vehicle is stationary or moving.",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -392,15 +412,16 @@
   {
     "name": "LENGTH",
     "propertyId": 289439775,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.Length",
+    "sources": {
+      "Vehicle.Length": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle length.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -411,15 +432,16 @@
   {
     "name": "LOW_VOLTAGE_SYSTEM_STATE",
     "propertyId": 286294029,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.LowVoltageSystemState",
+    "sources": {
+      "Vehicle.LowVoltageSystemState": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "State of the supply voltage of the control units (usually 12V).",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -437,15 +459,16 @@
   {
     "name": "MAX_TOW_BALL_WEIGHT",
     "propertyId": 289439774,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.MaxTowBallWeight",
+    "sources": {
+      "Vehicle.MaxTowBallWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Maximum vertical weight on the tow ball of a trailer.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -456,15 +479,16 @@
   {
     "name": "MAX_TOW_WEIGHT",
     "propertyId": 289439773,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.MaxTowWeight",
+    "sources": {
+      "Vehicle.MaxTowWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Maximum weight of trailer.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -475,15 +499,16 @@
   {
     "name": "POWERTRAIN_ACCUMULATED_BRAKING_ENERGY",
     "propertyId": 291536945,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "kWh",
-    "source": "Vehicle.Powertrain.AccumulatedBrakingEnergy",
+    "sources": {
+      "Vehicle.Powertrain.AccumulatedBrakingEnergy": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The accumulated energy from regenerative braking over lifetime.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -494,15 +519,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_COOLANT_LEVEL",
     "propertyId": 286294075,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineCoolant.Level",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineCoolant.Level": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine coolant level.",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -517,15 +543,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_COOLANT_TEMPERATURE",
     "propertyId": 291536954,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "celsius",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineCoolant.Temperature",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineCoolant.Temperature": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine coolant temperature.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -536,15 +563,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_OIL_CAPACITY",
     "propertyId": 291536951,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "l",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineOil.Capacity",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineOil.Capacity": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine oil capacity in liters.",
-    "datatype": "float",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -555,15 +583,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_OIL_LEVEL",
     "propertyId": 286294072,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineOil.Level",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineOil.Level": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine oil level.",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -580,15 +609,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_OIL_TEMPERATURE",
     "propertyId": 291536953,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "celsius",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineOil.Temperature",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineOil.Temperature": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "EOT, Engine oil temperature.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -599,15 +629,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_IS_RUNNING",
     "propertyId": 287342645,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.CombustionEngine.IsRunning",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.IsRunning": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine Running. True if engine is rotating (Speed > 0).",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -618,15 +649,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_SPEED",
     "propertyId": 289439798,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "rpm",
-    "source": "Vehicle.Powertrain.CombustionEngine.Speed",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.Speed": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine speed measured as rotations per minute.",
-    "datatype": "uint16",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -637,15 +669,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_ABSOLUTE_LEVEL",
     "propertyId": 291536960,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l",
-    "source": "Vehicle.Powertrain.FuelSystem.AbsoluteLevel",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.AbsoluteLevel": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current available fuel in the fuel tank expressed in liters.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -656,15 +689,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_AVERAGE_CONSUMPTION",
     "propertyId": 291536965,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l/100km",
-    "source": "Vehicle.Powertrain.FuelSystem.AverageConsumption",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.AverageConsumption": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Average consumption in liters per 100 km.",
-    "datatype": "float",
     "type": "sensor",
     "min": 0,
     "max": null,
@@ -675,15 +709,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_CONSUMPTION_SINCE_LAST_REFUEL",
     "propertyId": 291536967,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l",
-    "source": "Vehicle.Powertrain.FuelSystem.ConsumptionSinceLastRefuel",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.ConsumptionSinceLastRefuel": 0
+    },
     "formula": null,
     "comment": "Amount of fuel consumed since last refueling.",
     "configString": "Fuel consumption since last refueling.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -694,15 +729,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_CONSUMPTION_SINCE_START",
     "propertyId": 291536966,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l",
-    "source": "Vehicle.Powertrain.FuelSystem.ConsumptionSinceStart",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.ConsumptionSinceStart": 0
+    },
     "formula": null,
     "comment": "A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new trip is started.",
     "configString": "Fuel amount in liters consumed since start of current trip.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -713,15 +749,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_HYBRID_TYPE",
     "propertyId": 286294078,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.HybridType",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.HybridType": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Defines the hybrid type of the vehicle.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -739,15 +776,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_INSTANT_CONSUMPTION",
     "propertyId": 291536964,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l/100km",
-    "source": "Vehicle.Powertrain.FuelSystem.InstantConsumption",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.InstantConsumption": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current consumption in liters per 100 km.",
-    "datatype": "float",
     "type": "sensor",
     "min": 0,
     "max": null,
@@ -758,15 +796,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_IS_ENGINE_STOP_START_ENABLED",
     "propertyId": 287342664,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.IsEngineStopStartEnabled",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.IsEngineStopStartEnabled": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates whether eco start stop is currently enabled.",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -777,15 +816,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_IS_FUEL_LEVEL_LOW",
     "propertyId": 287342665,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.IsFuelLevelLow",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.IsFuelLevelLow": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates that the fuel level is low (e.g. <50km range).",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -796,15 +836,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_IS_FUEL_PORT_FLAP_OPEN",
     "propertyId": 287342667,
-    "areaId": 0,
+    "areaType": 0,
     "access": 3,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.IsFuelPortFlapOpen",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.IsFuelPortFlapOpen": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Status of the fuel port flap(s). True if at least one is open.",
-    "datatype": "boolean",
     "type": "actuator",
     "min": null,
     "max": null,
@@ -815,15 +856,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_RANGE",
     "propertyId": 289439810,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.Powertrain.FuelSystem.Range",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.Range": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Remaining range in meters using only liquid fuel.",
-    "datatype": "uint32",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -834,11 +876,13 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_REFUEL_PORT_POSITION",
     "propertyId": 286294090,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.RefuelPortPosition",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.RefuelPortPosition": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Position of refuel port(s). First part indicates side of vehicle, second part relative position on that side.",
@@ -866,15 +910,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_RELATIVE_LEVEL",
     "propertyId": 289439809,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "percent",
-    "source": "Vehicle.Powertrain.FuelSystem.RelativeLevel",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.RelativeLevel": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Level in fuel tank as percent of capacity. 0 = empty. 100 = full.",
-    "datatype": "uint8",
     "type": "sensor",
     "min": 0,
     "max": 100,
@@ -885,11 +930,13 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_SUPPORTED_FUEL",
     "propertyId": 286294077,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.SupportedFuel",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.SupportedFuel": 0
+    },
     "formula": null,
     "comment": "RON 95 is sometimes referred to as Super, RON 98 as Super Plus.",
     "configString": "Detailed information on fuels supported by the vehicle. Identifiers originating from DIN EN 16942:2021-08, appendix B, with additional suffix for octane (RON) where relevant.",
@@ -921,11 +968,13 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_SUPPORTED_FUEL_TYPES",
     "propertyId": 286294076,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.SupportedFuelTypes",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.SupportedFuelTypes": 0
+    },
     "formula": null,
     "comment": "If a vehicle also has an electric drivetrain (e.g. hybrid) that will be obvious from the PowerTrain.Type signal.",
     "configString": "High level information of fuel types supported",
@@ -949,15 +998,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_TANK_CAPACITY",
     "propertyId": 291536959,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "l",
-    "source": "Vehicle.Powertrain.FuelSystem.TankCapacity",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.TankCapacity": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Capacity of the fuel tank in liters.",
-    "datatype": "float",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -968,15 +1018,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_TIME_REMAINING",
     "propertyId": 289439811,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "s",
-    "source": "Vehicle.Powertrain.FuelSystem.TimeRemaining",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.TimeRemaining": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Time remaining in seconds before the fuel tank is empty.",
-    "datatype": "uint32",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -987,15 +1038,16 @@
   {
     "name": "POWERTRAIN_RANGE",
     "propertyId": 289439794,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.Powertrain.Range",
+    "sources": {
+      "Vehicle.Powertrain.Range": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Remaining range in meters using all energy sources available in the vehicle.",
-    "datatype": "uint32",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1006,15 +1058,16 @@
   {
     "name": "POWERTRAIN_TIME_REMAINING",
     "propertyId": 289439795,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "s",
-    "source": "Vehicle.Powertrain.TimeRemaining",
+    "sources": {
+      "Vehicle.Powertrain.TimeRemaining": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Time remaining in seconds before all energy sources available in the vehicle are empty.",
-    "datatype": "uint32",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1025,15 +1078,16 @@
   {
     "name": "POWERTRAIN_TYPE",
     "propertyId": 286294068,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.Type",
+    "sources": {
+      "Vehicle.Powertrain.Type": 0
+    },
     "formula": null,
     "comment": "For vehicles with a combustion engine (including hybrids) more detailed information on fuels supported can be found in FuelSystem.SupportedFuelTypes and FuelSystem.SupportedFuels.",
     "configString": "Defines the powertrain type of the vehicle.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1048,15 +1102,16 @@
   {
     "name": "ROOF_LOAD",
     "propertyId": 289439767,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.RoofLoad",
+    "sources": {
+      "Vehicle.RoofLoad": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The permitted total weight of cargo and installations (e.g. a roof rack) on top of the vehicle.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1067,15 +1122,16 @@
   {
     "name": "SPEED",
     "propertyId": 291536910,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "km/h",
-    "source": "Vehicle.Speed",
+    "sources": {
+      "Vehicle.Speed": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Vehicle speed.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1086,15 +1142,16 @@
   {
     "name": "START_TIME",
     "propertyId": 286294033,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "iso8601",
-    "source": "Vehicle.StartTime",
+    "sources": {
+      "Vehicle.StartTime": 0
+    },
     "formula": null,
     "comment": "This signal is supposed to be set whenever a new trip starts. A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The default value indicates that the vehicle never has been started, or that latest start time is unknown.",
     "configString": "Start time of current or latest trip, formatted according to ISO 8601 with UTC time zone.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1105,15 +1162,16 @@
   {
     "name": "TRAILER_IS_CONNECTED",
     "propertyId": 287342629,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Trailer.IsConnected",
+    "sources": {
+      "Vehicle.Trailer.IsConnected": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Signal indicating if trailer is connected or not.",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1124,15 +1182,16 @@
   {
     "name": "TRAVELED_DISTANCE",
     "propertyId": 291536911,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "km",
-    "source": "Vehicle.TraveledDistance",
+    "sources": {
+      "Vehicle.TraveledDistance": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Odometer reading, total distance traveled during the lifetime of the vehicle.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1143,15 +1202,16 @@
   {
     "name": "TRAVELED_DISTANCE_SINCE_START",
     "propertyId": 291536912,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "km",
-    "source": "Vehicle.TraveledDistanceSinceStart",
+    "sources": {
+      "Vehicle.TraveledDistanceSinceStart": 0
+    },
     "formula": null,
     "comment": "A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new trip is started.",
     "configString": "Distance traveled since start of current trip.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1162,15 +1222,16 @@
   {
     "name": "TRIP_DURATION",
     "propertyId": 291536914,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "s",
-    "source": "Vehicle.TripDuration",
+    "sources": {
+      "Vehicle.TripDuration": 0
+    },
     "formula": null,
     "comment": "This signal is not assumed to be continuously updated, but instead set to 0 when a trip starts and set to the actual duration of the trip when a trip ends. A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled.",
     "configString": "Duration of latest trip.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1181,15 +1242,16 @@
   {
     "name": "TRIP_METER_READING",
     "propertyId": 291536915,
-    "areaId": 0,
+    "areaType": 0,
     "access": 3,
     "changeMode": 1,
     "unit": "km",
-    "source": "Vehicle.TripMeterReading",
+    "sources": {
+      "Vehicle.TripMeterReading": 0
+    },
     "formula": null,
     "comment": "The trip meter is an odometer that can be manually reset by the driver",
     "configString": "Trip meter reading.",
-    "datatype": "float",
     "type": "actuator",
     "min": null,
     "max": null,
@@ -1200,15 +1262,16 @@
   {
     "name": "TURNING_DIAMETER",
     "propertyId": 289439780,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.TurningDiameter",
+    "sources": {
+      "Vehicle.TurningDiameter": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Minimum turning diameter, Wall-to-Wall, as defined by SAE J1100-2009 D102.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1219,15 +1282,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_BODY_TYPE",
     "propertyId": 286294021,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.BodyType",
+    "sources": {
+      "Vehicle.VehicleIdentification.BodyType": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates the design and body style of the vehicle (e.g. station wagon, hatchback, etc.).",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1238,15 +1302,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_BRAND",
     "propertyId": 286294018,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.Brand",
+    "sources": {
+      "Vehicle.VehicleIdentification.Brand": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Vehicle brand or manufacturer.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1257,15 +1322,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_DATE_VEHICLE_FIRST_REGISTERED",
     "propertyId": 286294022,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "iso8601",
-    "source": "Vehicle.VehicleIdentification.DateVehicleFirstRegistered",
+    "sources": {
+      "Vehicle.VehicleIdentification.DateVehicleFirstRegistered": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The date in ISO 8601 format of the first registration of the vehicle with the respective public authorities.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1276,15 +1342,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_LICENSE_PLATE",
     "propertyId": 286294023,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.LicensePlate",
+    "sources": {
+      "Vehicle.VehicleIdentification.LicensePlate": 0
+    },
     "formula": null,
     "comment": "Depending on the context, this attribute might not be up to date or might be misconfigured, and therefore should be considered untrustworthy in the absence of another method of verification.",
     "configString": "The license plate of the vehicle.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1295,15 +1362,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_MEETS_EMISSION_STANDARD",
     "propertyId": 286294024,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.MeetsEmissionStandard",
+    "sources": {
+      "Vehicle.VehicleIdentification.MeetsEmissionStandard": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates that the vehicle meets the respective emission standard.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1314,15 +1382,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_MODEL",
     "propertyId": 286294019,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.Model",
+    "sources": {
+      "Vehicle.VehicleIdentification.Model": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Vehicle model.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1333,15 +1402,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_PRODUCTION_DATE",
     "propertyId": 286294025,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "iso8601",
-    "source": "Vehicle.VehicleIdentification.ProductionDate",
+    "sources": {
+      "Vehicle.VehicleIdentification.ProductionDate": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The date in ISO 8601 format of production of the item, e.g. vehicle.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1352,15 +1422,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_VEHICLE_EXTERIOR_COLOR",
     "propertyId": 286294028,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.VehicleExteriorColor",
+    "sources": {
+      "Vehicle.VehicleIdentification.VehicleExteriorColor": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The main color of the exterior within the basic color palette (eg. red, blue, black, white, ...).",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1371,15 +1442,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_VEHICLE_MODEL_DATE",
     "propertyId": 286294026,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "iso8601",
-    "source": "Vehicle.VehicleIdentification.VehicleModelDate",
+    "sources": {
+      "Vehicle.VehicleIdentification.VehicleModelDate": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The release date in ISO 8601 format of a vehicle model (often used to differentiate versions of the same make and model).",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1390,15 +1462,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_VEHICLE_SEATING_CAPACITY",
     "propertyId": 289439755,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.VehicleSeatingCapacity",
+    "sources": {
+      "Vehicle.VehicleIdentification.VehicleSeatingCapacity": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1409,15 +1482,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_VIN",
     "propertyId": 286294016,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.VIN",
+    "sources": {
+      "Vehicle.VehicleIdentification.VIN": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "17-character Vehicle Identification Number (VIN) as defined by ISO 3779.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1428,15 +1502,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_WMI",
     "propertyId": 286294017,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.WMI",
+    "sources": {
+      "Vehicle.VehicleIdentification.WMI": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "3-character World Manufacturer Identification (WMI) as defined by ISO 3780.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1447,15 +1522,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_YEAR",
     "propertyId": 289439748,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.Year",
+    "sources": {
+      "Vehicle.VehicleIdentification.Year": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Model year of the vehicle.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1466,15 +1542,16 @@
   {
     "name": "WIDTH_EXCLUDING_MIRRORS",
     "propertyId": 289439777,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.WidthExcludingMirrors",
+    "sources": {
+      "Vehicle.WidthExcludingMirrors": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle width excluding mirrors, as defined by SAE J1100-2009 W103.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1485,15 +1562,16 @@
   {
     "name": "WIDTH_FOLDED_MIRRORS",
     "propertyId": 289439779,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.WidthFoldedMirrors",
+    "sources": {
+      "Vehicle.WidthFoldedMirrors": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle width with mirrors folded, as defined by SAE J1100-2009 W145.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1504,15 +1582,16 @@
   {
     "name": "WIDTH_INCLUDING_MIRRORS",
     "propertyId": 289439778,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.WidthIncludingMirrors",
+    "sources": {
+      "Vehicle.WidthIncludingMirrors": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle width including mirrors, as defined by SAE J1100-2009 W144.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,

--- a/tests/vspec/test_static_uids_vhal/validation_jsons/validation_group_2.json
+++ b/tests/vspec/test_static_uids_vhal/validation_jsons/validation_group_2.json
@@ -2,15 +2,16 @@
   {
     "name": "AVERAGE_SPEED",
     "propertyId": 559939607,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "km/h",
-    "source": "Vehicle.AverageSpeed",
+    "sources": {
+      "Vehicle.AverageSpeed": 0
+    },
     "formula": null,
     "comment": "A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new trip is started. Calculation of average speed may exclude periods when the vehicle for example is not moving or transmission is in neutral.",
     "configString": "Average speed for the current trip.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -21,15 +22,16 @@
   {
     "name": "CARGO_VOLUME",
     "propertyId": 559939609,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "l",
-    "source": "Vehicle.CargoVolume",
+    "sources": {
+      "Vehicle.CargoVolume": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The available volume for cargo or luggage. For automobiles, this is usually the trunk volume.",
-    "datatype": "float",
     "type": "attribute",
     "min": 0,
     "max": null,
@@ -40,15 +42,16 @@
   {
     "name": "CURB_WEIGHT",
     "propertyId": 557842460,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.CurbWeight",
+    "sources": {
+      "Vehicle.CurbWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Vehicle curb weight, including all liquids and full tank of fuel, but no cargo or passengers.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -59,15 +62,16 @@
   {
     "name": "CURRENT_LOCATION_ALTITUDE",
     "propertyId": 559939628,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.CurrentLocation.Altitude",
+    "sources": {
+      "Vehicle.CurrentLocation.Altitude": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current altitude relative to WGS 84 reference ellipsoid, as measured at the position of GNSS receiver antenna.",
-    "datatype": "double",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -78,15 +82,16 @@
   {
     "name": "CURRENT_LOCATION_GNSSRECEIVER_FIX_TYPE",
     "propertyId": 554696750,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.CurrentLocation.GNSSReceiver.FixType",
+    "sources": {
+      "Vehicle.CurrentLocation.GNSSReceiver.FixType": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Fix status of GNSS receiver.",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -107,15 +112,16 @@
   {
     "name": "CURRENT_LOCATION_GNSSRECEIVER_MOUNTING_POSITION_X",
     "propertyId": 557842479,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.X",
+    "sources": {
+      "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.X": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Mounting position of GNSS receiver antenna relative to vehicle coordinate system. Axis definitions according to ISO 8855. Origin at center of (first) rear axle. Positive values = forward of rear axle. Negative values = backward of rear axle.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -126,15 +132,16 @@
   {
     "name": "CURRENT_LOCATION_GNSSRECEIVER_MOUNTING_POSITION_Y",
     "propertyId": 557842480,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.Y",
+    "sources": {
+      "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.Y": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Mounting position of GNSS receiver antenna relative to vehicle coordinate system. Axis definitions according to ISO 8855. Origin at center of (first) rear axle. Positive values = left of origin. Negative values = right of origin. Left/Right is as seen from driver perspective, i.e. by a person looking forward.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -145,15 +152,16 @@
   {
     "name": "CURRENT_LOCATION_GNSSRECEIVER_MOUNTING_POSITION_Z",
     "propertyId": 557842481,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.Z",
+    "sources": {
+      "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.Z": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Mounting position of GNSS receiver on Z-axis. Axis definitions according to ISO 8855. Origin at center of (first) rear axle. Positive values = above center of rear axle. Negative values = below center of rear axle.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -164,15 +172,16 @@
   {
     "name": "CURRENT_LOCATION_HEADING",
     "propertyId": 559939626,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "degrees",
-    "source": "Vehicle.CurrentLocation.Heading",
+    "sources": {
+      "Vehicle.CurrentLocation.Heading": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current heading relative to geographic north. 0 = North, 90 = East, 180 = South, 270 = West.",
-    "datatype": "double",
     "type": "sensor",
     "min": 0,
     "max": 360,
@@ -183,15 +192,16 @@
   {
     "name": "CURRENT_LOCATION_HORIZONTAL_ACCURACY",
     "propertyId": 559939627,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.CurrentLocation.HorizontalAccuracy",
+    "sources": {
+      "Vehicle.CurrentLocation.HorizontalAccuracy": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Accuracy of the latitude and longitude coordinates.",
-    "datatype": "double",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -202,15 +212,16 @@
   {
     "name": "CURRENT_LOCATION_LATITUDE",
     "propertyId": 559939624,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "degrees",
-    "source": "Vehicle.CurrentLocation.Latitude",
+    "sources": {
+      "Vehicle.CurrentLocation.Latitude": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current latitude of vehicle in WGS 84 geodetic coordinates, as measured at the position of GNSS receiver antenna.",
-    "datatype": "double",
     "type": "sensor",
     "min": -90,
     "max": 90,
@@ -221,15 +232,16 @@
   {
     "name": "CURRENT_LOCATION_LONGITUDE",
     "propertyId": 559939625,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "degrees",
-    "source": "Vehicle.CurrentLocation.Longitude",
+    "sources": {
+      "Vehicle.CurrentLocation.Longitude": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current longitude of vehicle in WGS 84 geodetic coordinates, as measured at the position of GNSS receiver antenna.",
-    "datatype": "double",
     "type": "sensor",
     "min": -180,
     "max": 180,
@@ -240,15 +252,16 @@
   {
     "name": "CURRENT_LOCATION_TIMESTAMP",
     "propertyId": 554696743,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "iso8601",
-    "source": "Vehicle.CurrentLocation.Timestamp",
+    "sources": {
+      "Vehicle.CurrentLocation.Timestamp": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Timestamp from GNSS system for current location, formatted according to ISO 8601 with UTC time zone.",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -259,15 +272,16 @@
   {
     "name": "CURRENT_LOCATION_VERTICAL_ACCURACY",
     "propertyId": 559939629,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.CurrentLocation.VerticalAccuracy",
+    "sources": {
+      "Vehicle.CurrentLocation.VerticalAccuracy": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Accuracy of altitude.",
-    "datatype": "double",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -278,15 +292,16 @@
   {
     "name": "CURRENT_OVERALL_WEIGHT",
     "propertyId": 557842459,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "kg",
-    "source": "Vehicle.CurrentOverallWeight",
+    "sources": {
+      "Vehicle.CurrentOverallWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current overall Vehicle weight. Including passengers, cargo and other load inside the car.",
-    "datatype": "uint16",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -297,15 +312,16 @@
   {
     "name": "EMISSIONS_CO2",
     "propertyId": 557842458,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "g/km",
-    "source": "Vehicle.EmissionsCO2",
+    "sources": {
+      "Vehicle.EmissionsCO2": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The CO2 emissions.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -316,15 +332,16 @@
   {
     "name": "GROSS_WEIGHT",
     "propertyId": 557842461,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.GrossWeight",
+    "sources": {
+      "Vehicle.GrossWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Curb weight of vehicle, including all liquids and full tank of fuel and full load of cargo and passengers.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -335,15 +352,16 @@
   {
     "name": "HEIGHT",
     "propertyId": 557842465,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.Height",
+    "sources": {
+      "Vehicle.Height": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle height.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -354,15 +372,16 @@
   {
     "name": "IS_BROKEN_DOWN",
     "propertyId": 555745301,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.IsBrokenDown",
+    "sources": {
+      "Vehicle.IsBrokenDown": 0
+    },
     "formula": null,
     "comment": "Actual criteria and method used to decide if a vehicle is broken down is implementation specific.",
     "configString": "Vehicle breakdown or any similar event causing vehicle to stop on the road, that might pose a risk to other road users. True = Vehicle broken down on the road, due to e.g. engine problems, flat tire, out of gas, brake problems. False = Vehicle not broken down.",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -373,15 +392,16 @@
   {
     "name": "IS_MOVING",
     "propertyId": 555745302,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.IsMoving",
+    "sources": {
+      "Vehicle.IsMoving": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates whether the vehicle is stationary or moving.",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -392,15 +412,16 @@
   {
     "name": "LENGTH",
     "propertyId": 557842464,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.Length",
+    "sources": {
+      "Vehicle.Length": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle length.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -411,15 +432,16 @@
   {
     "name": "LOW_VOLTAGE_SYSTEM_STATE",
     "propertyId": 554696718,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.LowVoltageSystemState",
+    "sources": {
+      "Vehicle.LowVoltageSystemState": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "State of the supply voltage of the control units (usually 12V).",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -437,15 +459,16 @@
   {
     "name": "MAX_TOW_BALL_WEIGHT",
     "propertyId": 557842463,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.MaxTowBallWeight",
+    "sources": {
+      "Vehicle.MaxTowBallWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Maximum vertical weight on the tow ball of a trailer.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -456,15 +479,16 @@
   {
     "name": "MAX_TOW_WEIGHT",
     "propertyId": 557842462,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.MaxTowWeight",
+    "sources": {
+      "Vehicle.MaxTowWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Maximum weight of trailer.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -475,15 +499,16 @@
   {
     "name": "POWERTRAIN_ACCUMULATED_BRAKING_ENERGY",
     "propertyId": 559939634,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "kWh",
-    "source": "Vehicle.Powertrain.AccumulatedBrakingEnergy",
+    "sources": {
+      "Vehicle.Powertrain.AccumulatedBrakingEnergy": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The accumulated energy from regenerative braking over lifetime.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -494,15 +519,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_COOLANT_LEVEL",
     "propertyId": 554696764,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineCoolant.Level",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineCoolant.Level": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine coolant level.",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -517,15 +543,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_COOLANT_TEMPERATURE",
     "propertyId": 559939643,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "celsius",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineCoolant.Temperature",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineCoolant.Temperature": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine coolant temperature.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -536,15 +563,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_OIL_CAPACITY",
     "propertyId": 559939640,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "l",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineOil.Capacity",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineOil.Capacity": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine oil capacity in liters.",
-    "datatype": "float",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -555,15 +583,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_OIL_LEVEL",
     "propertyId": 554696761,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineOil.Level",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineOil.Level": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine oil level.",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -580,15 +609,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_OIL_TEMPERATURE",
     "propertyId": 559939642,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "celsius",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineOil.Temperature",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineOil.Temperature": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "EOT, Engine oil temperature.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -599,15 +629,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_IS_RUNNING",
     "propertyId": 555745334,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.CombustionEngine.IsRunning",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.IsRunning": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine Running. True if engine is rotating (Speed > 0).",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -618,15 +649,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_SPEED",
     "propertyId": 557842487,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "rpm",
-    "source": "Vehicle.Powertrain.CombustionEngine.Speed",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.Speed": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine speed measured as rotations per minute.",
-    "datatype": "uint16",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -637,15 +669,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_ABSOLUTE_LEVEL",
     "propertyId": 559939649,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l",
-    "source": "Vehicle.Powertrain.FuelSystem.AbsoluteLevel",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.AbsoluteLevel": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current available fuel in the fuel tank expressed in liters.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -656,15 +689,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_AVERAGE_CONSUMPTION",
     "propertyId": 559939654,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l/100km",
-    "source": "Vehicle.Powertrain.FuelSystem.AverageConsumption",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.AverageConsumption": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Average consumption in liters per 100 km.",
-    "datatype": "float",
     "type": "sensor",
     "min": 0,
     "max": null,
@@ -675,15 +709,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_CONSUMPTION_SINCE_LAST_REFUEL",
     "propertyId": 559939656,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l",
-    "source": "Vehicle.Powertrain.FuelSystem.ConsumptionSinceLastRefuel",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.ConsumptionSinceLastRefuel": 0
+    },
     "formula": null,
     "comment": "Amount of fuel consumed since last refueling.",
     "configString": "Fuel consumption since last refueling.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -694,15 +729,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_CONSUMPTION_SINCE_START",
     "propertyId": 559939655,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l",
-    "source": "Vehicle.Powertrain.FuelSystem.ConsumptionSinceStart",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.ConsumptionSinceStart": 0
+    },
     "formula": null,
     "comment": "A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new trip is started.",
     "configString": "Fuel amount in liters consumed since start of current trip.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -713,15 +749,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_HYBRID_TYPE",
     "propertyId": 554696767,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.HybridType",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.HybridType": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Defines the hybrid type of the vehicle.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -739,15 +776,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_INSTANT_CONSUMPTION",
     "propertyId": 559939653,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l/100km",
-    "source": "Vehicle.Powertrain.FuelSystem.InstantConsumption",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.InstantConsumption": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current consumption in liters per 100 km.",
-    "datatype": "float",
     "type": "sensor",
     "min": 0,
     "max": null,
@@ -758,15 +796,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_IS_ENGINE_STOP_START_ENABLED",
     "propertyId": 555745353,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.IsEngineStopStartEnabled",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.IsEngineStopStartEnabled": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates whether eco start stop is currently enabled.",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -777,15 +816,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_IS_FUEL_LEVEL_LOW",
     "propertyId": 555745354,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.IsFuelLevelLow",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.IsFuelLevelLow": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates that the fuel level is low (e.g. <50km range).",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -796,15 +836,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_IS_FUEL_PORT_FLAP_OPEN",
     "propertyId": 555745356,
-    "areaId": 7,
+    "areaType": 0,
     "access": 3,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.IsFuelPortFlapOpen",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.IsFuelPortFlapOpen": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Status of the fuel port flap(s). True if at least one is open.",
-    "datatype": "boolean",
     "type": "actuator",
     "min": null,
     "max": null,
@@ -815,15 +856,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_RANGE",
     "propertyId": 557842499,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.Powertrain.FuelSystem.Range",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.Range": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Remaining range in meters using only liquid fuel.",
-    "datatype": "uint32",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -834,11 +876,13 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_REFUEL_PORT_POSITION",
     "propertyId": 554696779,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.RefuelPortPosition",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.RefuelPortPosition": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Position of refuel port(s). First part indicates side of vehicle, second part relative position on that side.",
@@ -866,15 +910,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_RELATIVE_LEVEL",
     "propertyId": 557842498,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "percent",
-    "source": "Vehicle.Powertrain.FuelSystem.RelativeLevel",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.RelativeLevel": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Level in fuel tank as percent of capacity. 0 = empty. 100 = full.",
-    "datatype": "uint8",
     "type": "sensor",
     "min": 0,
     "max": 100,
@@ -885,11 +930,13 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_SUPPORTED_FUEL",
     "propertyId": 554696766,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.SupportedFuel",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.SupportedFuel": 0
+    },
     "formula": null,
     "comment": "RON 95 is sometimes referred to as Super, RON 98 as Super Plus.",
     "configString": "Detailed information on fuels supported by the vehicle. Identifiers originating from DIN EN 16942:2021-08, appendix B, with additional suffix for octane (RON) where relevant.",
@@ -921,11 +968,13 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_SUPPORTED_FUEL_TYPES",
     "propertyId": 554696765,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.SupportedFuelTypes",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.SupportedFuelTypes": 0
+    },
     "formula": null,
     "comment": "If a vehicle also has an electric drivetrain (e.g. hybrid) that will be obvious from the PowerTrain.Type signal.",
     "configString": "High level information of fuel types supported",
@@ -949,15 +998,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_TANK_CAPACITY",
     "propertyId": 559939648,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "l",
-    "source": "Vehicle.Powertrain.FuelSystem.TankCapacity",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.TankCapacity": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Capacity of the fuel tank in liters.",
-    "datatype": "float",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -968,15 +1018,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_TIME_REMAINING",
     "propertyId": 557842500,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "s",
-    "source": "Vehicle.Powertrain.FuelSystem.TimeRemaining",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.TimeRemaining": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Time remaining in seconds before the fuel tank is empty.",
-    "datatype": "uint32",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -987,15 +1038,16 @@
   {
     "name": "POWERTRAIN_RANGE",
     "propertyId": 557842483,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.Powertrain.Range",
+    "sources": {
+      "Vehicle.Powertrain.Range": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Remaining range in meters using all energy sources available in the vehicle.",
-    "datatype": "uint32",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1006,15 +1058,16 @@
   {
     "name": "POWERTRAIN_TIME_REMAINING",
     "propertyId": 557842484,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "s",
-    "source": "Vehicle.Powertrain.TimeRemaining",
+    "sources": {
+      "Vehicle.Powertrain.TimeRemaining": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Time remaining in seconds before all energy sources available in the vehicle are empty.",
-    "datatype": "uint32",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1025,15 +1078,16 @@
   {
     "name": "POWERTRAIN_TYPE",
     "propertyId": 554696757,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.Type",
+    "sources": {
+      "Vehicle.Powertrain.Type": 0
+    },
     "formula": null,
     "comment": "For vehicles with a combustion engine (including hybrids) more detailed information on fuels supported can be found in FuelSystem.SupportedFuelTypes and FuelSystem.SupportedFuels.",
     "configString": "Defines the powertrain type of the vehicle.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1048,15 +1102,16 @@
   {
     "name": "ROOF_LOAD",
     "propertyId": 557842456,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.RoofLoad",
+    "sources": {
+      "Vehicle.RoofLoad": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The permitted total weight of cargo and installations (e.g. a roof rack) on top of the vehicle.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1067,15 +1122,16 @@
   {
     "name": "SPEED",
     "propertyId": 559939599,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "km/h",
-    "source": "Vehicle.Speed",
+    "sources": {
+      "Vehicle.Speed": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Vehicle speed.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1086,15 +1142,16 @@
   {
     "name": "START_TIME",
     "propertyId": 554696722,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "iso8601",
-    "source": "Vehicle.StartTime",
+    "sources": {
+      "Vehicle.StartTime": 0
+    },
     "formula": null,
     "comment": "This signal is supposed to be set whenever a new trip starts. A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The default value indicates that the vehicle never has been started, or that latest start time is unknown.",
     "configString": "Start time of current or latest trip, formatted according to ISO 8601 with UTC time zone.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1105,15 +1162,16 @@
   {
     "name": "TRAILER_IS_CONNECTED",
     "propertyId": 555745318,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Trailer.IsConnected",
+    "sources": {
+      "Vehicle.Trailer.IsConnected": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Signal indicating if trailer is connected or not.",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1124,15 +1182,16 @@
   {
     "name": "TRAVELED_DISTANCE",
     "propertyId": 559939600,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "km",
-    "source": "Vehicle.TraveledDistance",
+    "sources": {
+      "Vehicle.TraveledDistance": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Odometer reading, total distance traveled during the lifetime of the vehicle.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1143,15 +1202,16 @@
   {
     "name": "TRAVELED_DISTANCE_SINCE_START",
     "propertyId": 559939601,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "km",
-    "source": "Vehicle.TraveledDistanceSinceStart",
+    "sources": {
+      "Vehicle.TraveledDistanceSinceStart": 0
+    },
     "formula": null,
     "comment": "A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new trip is started.",
     "configString": "Distance traveled since start of current trip.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1162,15 +1222,16 @@
   {
     "name": "TRIP_DURATION",
     "propertyId": 559939603,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "s",
-    "source": "Vehicle.TripDuration",
+    "sources": {
+      "Vehicle.TripDuration": 0
+    },
     "formula": null,
     "comment": "This signal is not assumed to be continuously updated, but instead set to 0 when a trip starts and set to the actual duration of the trip when a trip ends. A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled.",
     "configString": "Duration of latest trip.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1181,15 +1242,16 @@
   {
     "name": "TRIP_METER_READING",
     "propertyId": 559939604,
-    "areaId": 7,
+    "areaType": 0,
     "access": 3,
     "changeMode": 1,
     "unit": "km",
-    "source": "Vehicle.TripMeterReading",
+    "sources": {
+      "Vehicle.TripMeterReading": 0
+    },
     "formula": null,
     "comment": "The trip meter is an odometer that can be manually reset by the driver",
     "configString": "Trip meter reading.",
-    "datatype": "float",
     "type": "actuator",
     "min": null,
     "max": null,
@@ -1200,15 +1262,16 @@
   {
     "name": "TURNING_DIAMETER",
     "propertyId": 557842469,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.TurningDiameter",
+    "sources": {
+      "Vehicle.TurningDiameter": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Minimum turning diameter, Wall-to-Wall, as defined by SAE J1100-2009 D102.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1219,15 +1282,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_BODY_TYPE",
     "propertyId": 554696710,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.BodyType",
+    "sources": {
+      "Vehicle.VehicleIdentification.BodyType": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates the design and body style of the vehicle (e.g. station wagon, hatchback, etc.).",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1238,15 +1302,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_BRAND",
     "propertyId": 554696707,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.Brand",
+    "sources": {
+      "Vehicle.VehicleIdentification.Brand": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Vehicle brand or manufacturer.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1257,15 +1322,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_DATE_VEHICLE_FIRST_REGISTERED",
     "propertyId": 554696711,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "iso8601",
-    "source": "Vehicle.VehicleIdentification.DateVehicleFirstRegistered",
+    "sources": {
+      "Vehicle.VehicleIdentification.DateVehicleFirstRegistered": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The date in ISO 8601 format of the first registration of the vehicle with the respective public authorities.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1276,15 +1342,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_LICENSE_PLATE",
     "propertyId": 554696712,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.LicensePlate",
+    "sources": {
+      "Vehicle.VehicleIdentification.LicensePlate": 0
+    },
     "formula": null,
     "comment": "Depending on the context, this attribute might not be up to date or might be misconfigured, and therefore should be considered untrustworthy in the absence of another method of verification.",
     "configString": "The license plate of the vehicle.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1295,15 +1362,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_MEETS_EMISSION_STANDARD",
     "propertyId": 554696713,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.MeetsEmissionStandard",
+    "sources": {
+      "Vehicle.VehicleIdentification.MeetsEmissionStandard": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates that the vehicle meets the respective emission standard.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1314,15 +1382,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_MODEL",
     "propertyId": 554696708,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.Model",
+    "sources": {
+      "Vehicle.VehicleIdentification.Model": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Vehicle model.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1333,15 +1402,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_PRODUCTION_DATE",
     "propertyId": 554696714,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "iso8601",
-    "source": "Vehicle.VehicleIdentification.ProductionDate",
+    "sources": {
+      "Vehicle.VehicleIdentification.ProductionDate": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The date in ISO 8601 format of production of the item, e.g. vehicle.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1352,15 +1422,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_VEHICLE_EXTERIOR_COLOR",
     "propertyId": 554696717,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.VehicleExteriorColor",
+    "sources": {
+      "Vehicle.VehicleIdentification.VehicleExteriorColor": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The main color of the exterior within the basic color palette (eg. red, blue, black, white, ...).",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1371,15 +1442,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_VEHICLE_MODEL_DATE",
     "propertyId": 554696715,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "iso8601",
-    "source": "Vehicle.VehicleIdentification.VehicleModelDate",
+    "sources": {
+      "Vehicle.VehicleIdentification.VehicleModelDate": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The release date in ISO 8601 format of a vehicle model (often used to differentiate versions of the same make and model).",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1390,15 +1462,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_VEHICLE_SEATING_CAPACITY",
     "propertyId": 557842444,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.VehicleSeatingCapacity",
+    "sources": {
+      "Vehicle.VehicleIdentification.VehicleSeatingCapacity": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1409,15 +1482,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_VIN",
     "propertyId": 554696705,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.VIN",
+    "sources": {
+      "Vehicle.VehicleIdentification.VIN": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "17-character Vehicle Identification Number (VIN) as defined by ISO 3779.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1428,15 +1502,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_WMI",
     "propertyId": 554696706,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.WMI",
+    "sources": {
+      "Vehicle.VehicleIdentification.WMI": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "3-character World Manufacturer Identification (WMI) as defined by ISO 3780.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1447,15 +1522,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_YEAR",
     "propertyId": 557842437,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.Year",
+    "sources": {
+      "Vehicle.VehicleIdentification.Year": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Model year of the vehicle.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1466,15 +1542,16 @@
   {
     "name": "WIDTH_EXCLUDING_MIRRORS",
     "propertyId": 557842466,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.WidthExcludingMirrors",
+    "sources": {
+      "Vehicle.WidthExcludingMirrors": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle width excluding mirrors, as defined by SAE J1100-2009 W103.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1485,15 +1562,16 @@
   {
     "name": "WIDTH_FOLDED_MIRRORS",
     "propertyId": 557842468,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.WidthFoldedMirrors",
+    "sources": {
+      "Vehicle.WidthFoldedMirrors": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle width with mirrors folded, as defined by SAE J1100-2009 W145.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1504,15 +1582,16 @@
   {
     "name": "WIDTH_INCLUDING_MIRRORS",
     "propertyId": 557842467,
-    "areaId": 7,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.WidthIncludingMirrors",
+    "sources": {
+      "Vehicle.WidthIncludingMirrors": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle width including mirrors, as defined by SAE J1100-2009 W144.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,

--- a/tests/vspec/test_static_uids_vhal/validation_jsons/validation_group_4.json
+++ b/tests/vspec/test_static_uids_vhal/validation_jsons/validation_group_4.json
@@ -2,15 +2,16 @@
   {
     "name": "AVERAGE_SPEED",
     "propertyId": 1096810519,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "km/h",
-    "source": "Vehicle.AverageSpeed",
+    "sources": {
+      "Vehicle.AverageSpeed": 0
+    },
     "formula": null,
     "comment": "A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new trip is started. Calculation of average speed may exclude periods when the vehicle for example is not moving or transmission is in neutral.",
     "configString": "Average speed for the current trip.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -21,15 +22,16 @@
   {
     "name": "CARGO_VOLUME",
     "propertyId": 1096810521,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "l",
-    "source": "Vehicle.CargoVolume",
+    "sources": {
+      "Vehicle.CargoVolume": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The available volume for cargo or luggage. For automobiles, this is usually the trunk volume.",
-    "datatype": "float",
     "type": "attribute",
     "min": 0,
     "max": null,
@@ -40,15 +42,16 @@
   {
     "name": "CURB_WEIGHT",
     "propertyId": 1094713372,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.CurbWeight",
+    "sources": {
+      "Vehicle.CurbWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Vehicle curb weight, including all liquids and full tank of fuel, but no cargo or passengers.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -59,15 +62,16 @@
   {
     "name": "CURRENT_LOCATION_ALTITUDE",
     "propertyId": 1096810540,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.CurrentLocation.Altitude",
+    "sources": {
+      "Vehicle.CurrentLocation.Altitude": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current altitude relative to WGS 84 reference ellipsoid, as measured at the position of GNSS receiver antenna.",
-    "datatype": "double",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -78,15 +82,16 @@
   {
     "name": "CURRENT_LOCATION_GNSSRECEIVER_FIX_TYPE",
     "propertyId": 1091567662,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.CurrentLocation.GNSSReceiver.FixType",
+    "sources": {
+      "Vehicle.CurrentLocation.GNSSReceiver.FixType": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Fix status of GNSS receiver.",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -107,15 +112,16 @@
   {
     "name": "CURRENT_LOCATION_GNSSRECEIVER_MOUNTING_POSITION_X",
     "propertyId": 1094713391,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.X",
+    "sources": {
+      "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.X": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Mounting position of GNSS receiver antenna relative to vehicle coordinate system. Axis definitions according to ISO 8855. Origin at center of (first) rear axle. Positive values = forward of rear axle. Negative values = backward of rear axle.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -126,15 +132,16 @@
   {
     "name": "CURRENT_LOCATION_GNSSRECEIVER_MOUNTING_POSITION_Y",
     "propertyId": 1094713392,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.Y",
+    "sources": {
+      "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.Y": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Mounting position of GNSS receiver antenna relative to vehicle coordinate system. Axis definitions according to ISO 8855. Origin at center of (first) rear axle. Positive values = left of origin. Negative values = right of origin. Left/Right is as seen from driver perspective, i.e. by a person looking forward.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -145,15 +152,16 @@
   {
     "name": "CURRENT_LOCATION_GNSSRECEIVER_MOUNTING_POSITION_Z",
     "propertyId": 1094713393,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.Z",
+    "sources": {
+      "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.Z": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Mounting position of GNSS receiver on Z-axis. Axis definitions according to ISO 8855. Origin at center of (first) rear axle. Positive values = above center of rear axle. Negative values = below center of rear axle.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -164,15 +172,16 @@
   {
     "name": "CURRENT_LOCATION_HEADING",
     "propertyId": 1096810538,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "degrees",
-    "source": "Vehicle.CurrentLocation.Heading",
+    "sources": {
+      "Vehicle.CurrentLocation.Heading": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current heading relative to geographic north. 0 = North, 90 = East, 180 = South, 270 = West.",
-    "datatype": "double",
     "type": "sensor",
     "min": 0,
     "max": 360,
@@ -183,15 +192,16 @@
   {
     "name": "CURRENT_LOCATION_HORIZONTAL_ACCURACY",
     "propertyId": 1096810539,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.CurrentLocation.HorizontalAccuracy",
+    "sources": {
+      "Vehicle.CurrentLocation.HorizontalAccuracy": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Accuracy of the latitude and longitude coordinates.",
-    "datatype": "double",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -202,15 +212,16 @@
   {
     "name": "CURRENT_LOCATION_LATITUDE",
     "propertyId": 1096810536,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "degrees",
-    "source": "Vehicle.CurrentLocation.Latitude",
+    "sources": {
+      "Vehicle.CurrentLocation.Latitude": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current latitude of vehicle in WGS 84 geodetic coordinates, as measured at the position of GNSS receiver antenna.",
-    "datatype": "double",
     "type": "sensor",
     "min": -90,
     "max": 90,
@@ -221,15 +232,16 @@
   {
     "name": "CURRENT_LOCATION_LONGITUDE",
     "propertyId": 1096810537,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "degrees",
-    "source": "Vehicle.CurrentLocation.Longitude",
+    "sources": {
+      "Vehicle.CurrentLocation.Longitude": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current longitude of vehicle in WGS 84 geodetic coordinates, as measured at the position of GNSS receiver antenna.",
-    "datatype": "double",
     "type": "sensor",
     "min": -180,
     "max": 180,
@@ -240,15 +252,16 @@
   {
     "name": "CURRENT_LOCATION_TIMESTAMP",
     "propertyId": 1091567655,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "iso8601",
-    "source": "Vehicle.CurrentLocation.Timestamp",
+    "sources": {
+      "Vehicle.CurrentLocation.Timestamp": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Timestamp from GNSS system for current location, formatted according to ISO 8601 with UTC time zone.",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -259,15 +272,16 @@
   {
     "name": "CURRENT_LOCATION_VERTICAL_ACCURACY",
     "propertyId": 1096810541,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.CurrentLocation.VerticalAccuracy",
+    "sources": {
+      "Vehicle.CurrentLocation.VerticalAccuracy": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Accuracy of altitude.",
-    "datatype": "double",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -278,15 +292,16 @@
   {
     "name": "CURRENT_OVERALL_WEIGHT",
     "propertyId": 1094713371,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "kg",
-    "source": "Vehicle.CurrentOverallWeight",
+    "sources": {
+      "Vehicle.CurrentOverallWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current overall Vehicle weight. Including passengers, cargo and other load inside the car.",
-    "datatype": "uint16",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -297,15 +312,16 @@
   {
     "name": "EMISSIONS_CO2",
     "propertyId": 1094713370,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "g/km",
-    "source": "Vehicle.EmissionsCO2",
+    "sources": {
+      "Vehicle.EmissionsCO2": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The CO2 emissions.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -316,15 +332,16 @@
   {
     "name": "GROSS_WEIGHT",
     "propertyId": 1094713373,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.GrossWeight",
+    "sources": {
+      "Vehicle.GrossWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Curb weight of vehicle, including all liquids and full tank of fuel and full load of cargo and passengers.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -335,15 +352,16 @@
   {
     "name": "HEIGHT",
     "propertyId": 1094713377,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.Height",
+    "sources": {
+      "Vehicle.Height": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle height.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -354,15 +372,16 @@
   {
     "name": "IS_BROKEN_DOWN",
     "propertyId": 1092616213,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.IsBrokenDown",
+    "sources": {
+      "Vehicle.IsBrokenDown": 0
+    },
     "formula": null,
     "comment": "Actual criteria and method used to decide if a vehicle is broken down is implementation specific.",
     "configString": "Vehicle breakdown or any similar event causing vehicle to stop on the road, that might pose a risk to other road users. True = Vehicle broken down on the road, due to e.g. engine problems, flat tire, out of gas, brake problems. False = Vehicle not broken down.",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -373,15 +392,16 @@
   {
     "name": "IS_MOVING",
     "propertyId": 1092616214,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.IsMoving",
+    "sources": {
+      "Vehicle.IsMoving": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates whether the vehicle is stationary or moving.",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -392,15 +412,16 @@
   {
     "name": "LENGTH",
     "propertyId": 1094713376,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.Length",
+    "sources": {
+      "Vehicle.Length": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle length.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -411,15 +432,16 @@
   {
     "name": "LOW_VOLTAGE_SYSTEM_STATE",
     "propertyId": 1091567630,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.LowVoltageSystemState",
+    "sources": {
+      "Vehicle.LowVoltageSystemState": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "State of the supply voltage of the control units (usually 12V).",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -437,15 +459,16 @@
   {
     "name": "MAX_TOW_BALL_WEIGHT",
     "propertyId": 1094713375,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.MaxTowBallWeight",
+    "sources": {
+      "Vehicle.MaxTowBallWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Maximum vertical weight on the tow ball of a trailer.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -456,15 +479,16 @@
   {
     "name": "MAX_TOW_WEIGHT",
     "propertyId": 1094713374,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.MaxTowWeight",
+    "sources": {
+      "Vehicle.MaxTowWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Maximum weight of trailer.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -475,15 +499,16 @@
   {
     "name": "POWERTRAIN_ACCUMULATED_BRAKING_ENERGY",
     "propertyId": 1096810546,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "kWh",
-    "source": "Vehicle.Powertrain.AccumulatedBrakingEnergy",
+    "sources": {
+      "Vehicle.Powertrain.AccumulatedBrakingEnergy": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The accumulated energy from regenerative braking over lifetime.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -494,15 +519,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_COOLANT_LEVEL",
     "propertyId": 1091567676,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineCoolant.Level",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineCoolant.Level": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine coolant level.",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -517,15 +543,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_COOLANT_TEMPERATURE",
     "propertyId": 1096810555,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "celsius",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineCoolant.Temperature",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineCoolant.Temperature": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine coolant temperature.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -536,15 +563,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_OIL_CAPACITY",
     "propertyId": 1096810552,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "l",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineOil.Capacity",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineOil.Capacity": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine oil capacity in liters.",
-    "datatype": "float",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -555,15 +583,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_OIL_LEVEL",
     "propertyId": 1091567673,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineOil.Level",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineOil.Level": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine oil level.",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -580,15 +609,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_OIL_TEMPERATURE",
     "propertyId": 1096810554,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "celsius",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineOil.Temperature",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineOil.Temperature": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "EOT, Engine oil temperature.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -599,15 +629,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_IS_RUNNING",
     "propertyId": 1092616246,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.CombustionEngine.IsRunning",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.IsRunning": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine Running. True if engine is rotating (Speed > 0).",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -618,15 +649,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_SPEED",
     "propertyId": 1094713399,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "rpm",
-    "source": "Vehicle.Powertrain.CombustionEngine.Speed",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.Speed": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine speed measured as rotations per minute.",
-    "datatype": "uint16",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -637,15 +669,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_ABSOLUTE_LEVEL",
     "propertyId": 1096810561,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l",
-    "source": "Vehicle.Powertrain.FuelSystem.AbsoluteLevel",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.AbsoluteLevel": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current available fuel in the fuel tank expressed in liters.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -656,15 +689,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_AVERAGE_CONSUMPTION",
     "propertyId": 1096810566,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l/100km",
-    "source": "Vehicle.Powertrain.FuelSystem.AverageConsumption",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.AverageConsumption": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Average consumption in liters per 100 km.",
-    "datatype": "float",
     "type": "sensor",
     "min": 0,
     "max": null,
@@ -675,15 +709,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_CONSUMPTION_SINCE_LAST_REFUEL",
     "propertyId": 1096810568,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l",
-    "source": "Vehicle.Powertrain.FuelSystem.ConsumptionSinceLastRefuel",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.ConsumptionSinceLastRefuel": 0
+    },
     "formula": null,
     "comment": "Amount of fuel consumed since last refueling.",
     "configString": "Fuel consumption since last refueling.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -694,15 +729,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_CONSUMPTION_SINCE_START",
     "propertyId": 1096810567,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l",
-    "source": "Vehicle.Powertrain.FuelSystem.ConsumptionSinceStart",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.ConsumptionSinceStart": 0
+    },
     "formula": null,
     "comment": "A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new trip is started.",
     "configString": "Fuel amount in liters consumed since start of current trip.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -713,15 +749,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_HYBRID_TYPE",
     "propertyId": 1091567679,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.HybridType",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.HybridType": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Defines the hybrid type of the vehicle.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -739,15 +776,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_INSTANT_CONSUMPTION",
     "propertyId": 1096810565,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l/100km",
-    "source": "Vehicle.Powertrain.FuelSystem.InstantConsumption",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.InstantConsumption": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current consumption in liters per 100 km.",
-    "datatype": "float",
     "type": "sensor",
     "min": 0,
     "max": null,
@@ -758,15 +796,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_IS_ENGINE_STOP_START_ENABLED",
     "propertyId": 1092616265,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.IsEngineStopStartEnabled",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.IsEngineStopStartEnabled": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates whether eco start stop is currently enabled.",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -777,15 +816,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_IS_FUEL_LEVEL_LOW",
     "propertyId": 1092616266,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.IsFuelLevelLow",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.IsFuelLevelLow": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates that the fuel level is low (e.g. <50km range).",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -796,15 +836,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_IS_FUEL_PORT_FLAP_OPEN",
     "propertyId": 1092616268,
-    "areaId": 0,
+    "areaType": 0,
     "access": 3,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.IsFuelPortFlapOpen",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.IsFuelPortFlapOpen": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Status of the fuel port flap(s). True if at least one is open.",
-    "datatype": "boolean",
     "type": "actuator",
     "min": null,
     "max": null,
@@ -815,15 +856,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_RANGE",
     "propertyId": 1094713411,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.Powertrain.FuelSystem.Range",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.Range": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Remaining range in meters using only liquid fuel.",
-    "datatype": "uint32",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -834,11 +876,13 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_REFUEL_PORT_POSITION",
     "propertyId": 1091567691,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.RefuelPortPosition",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.RefuelPortPosition": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Position of refuel port(s). First part indicates side of vehicle, second part relative position on that side.",
@@ -866,15 +910,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_RELATIVE_LEVEL",
     "propertyId": 1094713410,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "percent",
-    "source": "Vehicle.Powertrain.FuelSystem.RelativeLevel",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.RelativeLevel": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Level in fuel tank as percent of capacity. 0 = empty. 100 = full.",
-    "datatype": "uint8",
     "type": "sensor",
     "min": 0,
     "max": 100,
@@ -885,11 +930,13 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_SUPPORTED_FUEL",
     "propertyId": 1091567678,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.SupportedFuel",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.SupportedFuel": 0
+    },
     "formula": null,
     "comment": "RON 95 is sometimes referred to as Super, RON 98 as Super Plus.",
     "configString": "Detailed information on fuels supported by the vehicle. Identifiers originating from DIN EN 16942:2021-08, appendix B, with additional suffix for octane (RON) where relevant.",
@@ -921,11 +968,13 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_SUPPORTED_FUEL_TYPES",
     "propertyId": 1091567677,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.SupportedFuelTypes",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.SupportedFuelTypes": 0
+    },
     "formula": null,
     "comment": "If a vehicle also has an electric drivetrain (e.g. hybrid) that will be obvious from the PowerTrain.Type signal.",
     "configString": "High level information of fuel types supported",
@@ -949,15 +998,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_TANK_CAPACITY",
     "propertyId": 1096810560,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "l",
-    "source": "Vehicle.Powertrain.FuelSystem.TankCapacity",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.TankCapacity": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Capacity of the fuel tank in liters.",
-    "datatype": "float",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -968,15 +1018,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_TIME_REMAINING",
     "propertyId": 1094713412,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "s",
-    "source": "Vehicle.Powertrain.FuelSystem.TimeRemaining",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.TimeRemaining": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Time remaining in seconds before the fuel tank is empty.",
-    "datatype": "uint32",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -987,15 +1038,16 @@
   {
     "name": "POWERTRAIN_RANGE",
     "propertyId": 1094713395,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.Powertrain.Range",
+    "sources": {
+      "Vehicle.Powertrain.Range": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Remaining range in meters using all energy sources available in the vehicle.",
-    "datatype": "uint32",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1006,15 +1058,16 @@
   {
     "name": "POWERTRAIN_TIME_REMAINING",
     "propertyId": 1094713396,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "s",
-    "source": "Vehicle.Powertrain.TimeRemaining",
+    "sources": {
+      "Vehicle.Powertrain.TimeRemaining": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Time remaining in seconds before all energy sources available in the vehicle are empty.",
-    "datatype": "uint32",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1025,15 +1078,16 @@
   {
     "name": "POWERTRAIN_TYPE",
     "propertyId": 1091567669,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.Type",
+    "sources": {
+      "Vehicle.Powertrain.Type": 0
+    },
     "formula": null,
     "comment": "For vehicles with a combustion engine (including hybrids) more detailed information on fuels supported can be found in FuelSystem.SupportedFuelTypes and FuelSystem.SupportedFuels.",
     "configString": "Defines the powertrain type of the vehicle.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1048,15 +1102,16 @@
   {
     "name": "ROOF_LOAD",
     "propertyId": 1094713368,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.RoofLoad",
+    "sources": {
+      "Vehicle.RoofLoad": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The permitted total weight of cargo and installations (e.g. a roof rack) on top of the vehicle.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1067,15 +1122,16 @@
   {
     "name": "SPEED",
     "propertyId": 1096810511,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "km/h",
-    "source": "Vehicle.Speed",
+    "sources": {
+      "Vehicle.Speed": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Vehicle speed.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1086,15 +1142,16 @@
   {
     "name": "START_TIME",
     "propertyId": 1091567634,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "iso8601",
-    "source": "Vehicle.StartTime",
+    "sources": {
+      "Vehicle.StartTime": 0
+    },
     "formula": null,
     "comment": "This signal is supposed to be set whenever a new trip starts. A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The default value indicates that the vehicle never has been started, or that latest start time is unknown.",
     "configString": "Start time of current or latest trip, formatted according to ISO 8601 with UTC time zone.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1105,15 +1162,16 @@
   {
     "name": "TRAILER_IS_CONNECTED",
     "propertyId": 1092616230,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Trailer.IsConnected",
+    "sources": {
+      "Vehicle.Trailer.IsConnected": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Signal indicating if trailer is connected or not.",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1124,15 +1182,16 @@
   {
     "name": "TRAVELED_DISTANCE",
     "propertyId": 1096810512,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "km",
-    "source": "Vehicle.TraveledDistance",
+    "sources": {
+      "Vehicle.TraveledDistance": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Odometer reading, total distance traveled during the lifetime of the vehicle.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1143,15 +1202,16 @@
   {
     "name": "TRAVELED_DISTANCE_SINCE_START",
     "propertyId": 1096810513,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "km",
-    "source": "Vehicle.TraveledDistanceSinceStart",
+    "sources": {
+      "Vehicle.TraveledDistanceSinceStart": 0
+    },
     "formula": null,
     "comment": "A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new trip is started.",
     "configString": "Distance traveled since start of current trip.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1162,15 +1222,16 @@
   {
     "name": "TRIP_DURATION",
     "propertyId": 1096810515,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "s",
-    "source": "Vehicle.TripDuration",
+    "sources": {
+      "Vehicle.TripDuration": 0
+    },
     "formula": null,
     "comment": "This signal is not assumed to be continuously updated, but instead set to 0 when a trip starts and set to the actual duration of the trip when a trip ends. A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled.",
     "configString": "Duration of latest trip.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1181,15 +1242,16 @@
   {
     "name": "TRIP_METER_READING",
     "propertyId": 1096810516,
-    "areaId": 0,
+    "areaType": 0,
     "access": 3,
     "changeMode": 1,
     "unit": "km",
-    "source": "Vehicle.TripMeterReading",
+    "sources": {
+      "Vehicle.TripMeterReading": 0
+    },
     "formula": null,
     "comment": "The trip meter is an odometer that can be manually reset by the driver",
     "configString": "Trip meter reading.",
-    "datatype": "float",
     "type": "actuator",
     "min": null,
     "max": null,
@@ -1200,15 +1262,16 @@
   {
     "name": "TURNING_DIAMETER",
     "propertyId": 1094713381,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.TurningDiameter",
+    "sources": {
+      "Vehicle.TurningDiameter": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Minimum turning diameter, Wall-to-Wall, as defined by SAE J1100-2009 D102.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1219,15 +1282,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_BODY_TYPE",
     "propertyId": 1091567622,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.BodyType",
+    "sources": {
+      "Vehicle.VehicleIdentification.BodyType": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates the design and body style of the vehicle (e.g. station wagon, hatchback, etc.).",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1238,15 +1302,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_BRAND",
     "propertyId": 1091567619,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.Brand",
+    "sources": {
+      "Vehicle.VehicleIdentification.Brand": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Vehicle brand or manufacturer.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1257,15 +1322,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_DATE_VEHICLE_FIRST_REGISTERED",
     "propertyId": 1091567623,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "iso8601",
-    "source": "Vehicle.VehicleIdentification.DateVehicleFirstRegistered",
+    "sources": {
+      "Vehicle.VehicleIdentification.DateVehicleFirstRegistered": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The date in ISO 8601 format of the first registration of the vehicle with the respective public authorities.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1276,15 +1342,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_LICENSE_PLATE",
     "propertyId": 1091567624,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.LicensePlate",
+    "sources": {
+      "Vehicle.VehicleIdentification.LicensePlate": 0
+    },
     "formula": null,
     "comment": "Depending on the context, this attribute might not be up to date or might be misconfigured, and therefore should be considered untrustworthy in the absence of another method of verification.",
     "configString": "The license plate of the vehicle.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1295,15 +1362,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_MEETS_EMISSION_STANDARD",
     "propertyId": 1091567625,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.MeetsEmissionStandard",
+    "sources": {
+      "Vehicle.VehicleIdentification.MeetsEmissionStandard": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates that the vehicle meets the respective emission standard.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1314,15 +1382,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_MODEL",
     "propertyId": 1091567620,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.Model",
+    "sources": {
+      "Vehicle.VehicleIdentification.Model": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Vehicle model.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1333,15 +1402,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_PRODUCTION_DATE",
     "propertyId": 1091567626,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "iso8601",
-    "source": "Vehicle.VehicleIdentification.ProductionDate",
+    "sources": {
+      "Vehicle.VehicleIdentification.ProductionDate": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The date in ISO 8601 format of production of the item, e.g. vehicle.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1352,15 +1422,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_VEHICLE_EXTERIOR_COLOR",
     "propertyId": 1091567629,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.VehicleExteriorColor",
+    "sources": {
+      "Vehicle.VehicleIdentification.VehicleExteriorColor": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The main color of the exterior within the basic color palette (eg. red, blue, black, white, ...).",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1371,15 +1442,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_VEHICLE_MODEL_DATE",
     "propertyId": 1091567627,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "iso8601",
-    "source": "Vehicle.VehicleIdentification.VehicleModelDate",
+    "sources": {
+      "Vehicle.VehicleIdentification.VehicleModelDate": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The release date in ISO 8601 format of a vehicle model (often used to differentiate versions of the same make and model).",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1390,15 +1462,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_VEHICLE_SEATING_CAPACITY",
     "propertyId": 1094713356,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.VehicleSeatingCapacity",
+    "sources": {
+      "Vehicle.VehicleIdentification.VehicleSeatingCapacity": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1409,15 +1482,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_VIN",
     "propertyId": 1091567617,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.VIN",
+    "sources": {
+      "Vehicle.VehicleIdentification.VIN": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "17-character Vehicle Identification Number (VIN) as defined by ISO 3779.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1428,15 +1502,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_WMI",
     "propertyId": 1091567618,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.WMI",
+    "sources": {
+      "Vehicle.VehicleIdentification.WMI": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "3-character World Manufacturer Identification (WMI) as defined by ISO 3780.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1447,15 +1522,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_YEAR",
     "propertyId": 1094713349,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.Year",
+    "sources": {
+      "Vehicle.VehicleIdentification.Year": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Model year of the vehicle.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1466,15 +1542,16 @@
   {
     "name": "WIDTH_EXCLUDING_MIRRORS",
     "propertyId": 1094713378,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.WidthExcludingMirrors",
+    "sources": {
+      "Vehicle.WidthExcludingMirrors": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle width excluding mirrors, as defined by SAE J1100-2009 W103.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1485,15 +1562,16 @@
   {
     "name": "WIDTH_FOLDED_MIRRORS",
     "propertyId": 1094713380,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.WidthFoldedMirrors",
+    "sources": {
+      "Vehicle.WidthFoldedMirrors": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle width with mirrors folded, as defined by SAE J1100-2009 W145.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1504,15 +1582,16 @@
   {
     "name": "WIDTH_INCLUDING_MIRRORS",
     "propertyId": 1094713379,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.WidthIncludingMirrors",
+    "sources": {
+      "Vehicle.WidthIncludingMirrors": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle width including mirrors, as defined by SAE J1100-2009 W144.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,

--- a/tests/vspec/test_static_uids_vhal/validation_jsons/validation_group_4_manual_updates.json
+++ b/tests/vspec/test_static_uids_vhal/validation_jsons/validation_group_4_manual_updates.json
@@ -2,15 +2,16 @@
   {
     "name": "AVERAGE_SPEED",
     "propertyId": 1096810519,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m/s",
-    "source": "Vehicle.AverageSpeed",
+    "sources": {
+      "Vehicle.AverageSpeed": 0
+    },
     "formula": null,
     "comment": "A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new trip is started. Calculation of average speed may exclude periods when the vehicle for example is not moving or transmission is in neutral.",
     "configString": "Average speed for the current trip.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -21,15 +22,16 @@
   {
     "name": "CARGO_VOLUME",
     "propertyId": 1096810521,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "ml",
-    "source": "Vehicle.CargoVolume",
+    "sources": {
+      "Vehicle.CargoVolume": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The available volume for cargo or luggage. For automobiles, this is usually the trunk volume.",
-    "datatype": "double",
     "type": "attribute",
     "min": 0,
     "max": null,
@@ -40,15 +42,16 @@
   {
     "name": "CURB_WEIGHT",
     "propertyId": 1094713372,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.CurbWeight",
+    "sources": {
+      "Vehicle.CurbWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Vehicle curb weight, including all liquids and full tank of fuel, but no cargo or passengers.",
-    "datatype": "uint32",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -59,15 +62,16 @@
   {
     "name": "CURRENT_LOCATION_ALTITUDE",
     "propertyId": 1096810540,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.CurrentLocation.Altitude",
+    "sources": {
+      "Vehicle.CurrentLocation.Altitude": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current altitude relative to WGS 84 reference ellipsoid, as measured at the position of GNSS receiver antenna.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -78,15 +82,16 @@
   {
     "name": "CURRENT_LOCATION_GNSSRECEIVER_FIX_TYPE",
     "propertyId": 1091567662,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.CurrentLocation.GNSSReceiver.FixType",
+    "sources": {
+      "Vehicle.CurrentLocation.GNSSReceiver.FixType": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Fix status of GNSS receiver.",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -107,15 +112,16 @@
   {
     "name": "CURRENT_LOCATION_GNSSRECEIVER_MOUNTING_POSITION_X",
     "propertyId": 1094713391,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.X",
+    "sources": {
+      "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.X": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Mounting position of GNSS receiver antenna relative to vehicle coordinate system. Axis definitions according to ISO 8855. Origin at center of (first) rear axle. Positive values = forward of rear axle. Negative values = backward of rear axle.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -126,15 +132,16 @@
   {
     "name": "CURRENT_LOCATION_GNSSRECEIVER_MOUNTING_POSITION_Y",
     "propertyId": 1094713392,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.Y",
+    "sources": {
+      "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.Y": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Mounting position of GNSS receiver antenna relative to vehicle coordinate system. Axis definitions according to ISO 8855. Origin at center of (first) rear axle. Positive values = left of origin. Negative values = right of origin. Left/Right is as seen from driver perspective, i.e. by a person looking forward.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -145,15 +152,16 @@
   {
     "name": "CURRENT_LOCATION_GNSSRECEIVER_MOUNTING_POSITION_Z",
     "propertyId": 1094713393,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.Z",
+    "sources": {
+      "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.Z": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Mounting position of GNSS receiver on Z-axis. Axis definitions according to ISO 8855. Origin at center of (first) rear axle. Positive values = above center of rear axle. Negative values = below center of rear axle.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -164,15 +172,16 @@
   {
     "name": "CURRENT_LOCATION_HEADING",
     "propertyId": 1096810538,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "degrees",
-    "source": "Vehicle.CurrentLocation.Heading",
+    "sources": {
+      "Vehicle.CurrentLocation.Heading": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current heading relative to geographic north. 0 = North, 90 = East, 180 = South, 270 = West.",
-    "datatype": "double",
     "type": "sensor",
     "min": 0,
     "max": 360,
@@ -183,15 +192,16 @@
   {
     "name": "CURRENT_LOCATION_HORIZONTAL_ACCURACY",
     "propertyId": 1096810539,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.CurrentLocation.HorizontalAccuracy",
+    "sources": {
+      "Vehicle.CurrentLocation.HorizontalAccuracy": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Accuracy of the latitude and longitude coordinates.",
-    "datatype": "double",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -202,15 +212,16 @@
   {
     "name": "CURRENT_LOCATION_LATITUDE",
     "propertyId": 1096810536,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "degrees",
-    "source": "Vehicle.CurrentLocation.Latitude",
+    "sources": {
+      "Vehicle.CurrentLocation.Latitude": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current latitude of vehicle in WGS 84 geodetic coordinates, as measured at the position of GNSS receiver antenna.",
-    "datatype": "double",
     "type": "sensor",
     "min": -90,
     "max": 90,
@@ -221,15 +232,16 @@
   {
     "name": "CURRENT_LOCATION_LONGITUDE",
     "propertyId": 1096810537,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "degrees",
-    "source": "Vehicle.CurrentLocation.Longitude",
+    "sources": {
+      "Vehicle.CurrentLocation.Longitude": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current longitude of vehicle in WGS 84 geodetic coordinates, as measured at the position of GNSS receiver antenna.",
-    "datatype": "double",
     "type": "sensor",
     "min": -180,
     "max": 180,
@@ -240,15 +252,16 @@
   {
     "name": "CURRENT_LOCATION_TIMESTAMP",
     "propertyId": 1091567655,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "iso8601",
-    "source": "Vehicle.CurrentLocation.Timestamp",
+    "sources": {
+      "Vehicle.CurrentLocation.Timestamp": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Timestamp from GNSS system for current location, formatted according to ISO 8601 with UTC time zone.",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -259,15 +272,16 @@
   {
     "name": "CURRENT_LOCATION_VERTICAL_ACCURACY",
     "propertyId": 1096810541,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.CurrentLocation.VerticalAccuracy",
+    "sources": {
+      "Vehicle.CurrentLocation.VerticalAccuracy": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Accuracy of altitude.",
-    "datatype": "double",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -278,15 +292,16 @@
   {
     "name": "CURRENT_OVERALL_WEIGHT",
     "propertyId": 1094713371,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "kg",
-    "source": "Vehicle.CurrentOverallWeight",
+    "sources": {
+      "Vehicle.CurrentOverallWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current overall Vehicle weight. Including passengers, cargo and other load inside the car.",
-    "datatype": "uint16",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -297,15 +312,16 @@
   {
     "name": "EMISSIONS_CO2",
     "propertyId": 1094713370,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "g/km",
-    "source": "Vehicle.EmissionsCO2",
+    "sources": {
+      "Vehicle.EmissionsCO2": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The CO2 emissions.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -316,15 +332,16 @@
   {
     "name": "GROSS_WEIGHT",
     "propertyId": 1094713373,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.GrossWeight",
+    "sources": {
+      "Vehicle.GrossWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Curb weight of vehicle, including all liquids and full tank of fuel and full load of cargo and passengers.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -335,15 +352,16 @@
   {
     "name": "HEIGHT",
     "propertyId": 1094713377,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.Height",
+    "sources": {
+      "Vehicle.Height": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle height.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -354,15 +372,16 @@
   {
     "name": "IS_BROKEN_DOWN",
     "propertyId": 1092616213,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.IsBrokenDown",
+    "sources": {
+      "Vehicle.IsBrokenDown": 0
+    },
     "formula": null,
     "comment": "Actual criteria and method used to decide if a vehicle is broken down is implementation specific.",
     "configString": "Vehicle breakdown or any similar event causing vehicle to stop on the road, that might pose a risk to other road users. True = Vehicle broken down on the road, due to e.g. engine problems, flat tire, out of gas, brake problems. False = Vehicle not broken down.",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -373,15 +392,16 @@
   {
     "name": "IS_MOVING",
     "propertyId": 1092616214,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.IsMoving",
+    "sources": {
+      "Vehicle.IsMoving": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates whether the vehicle is stationary or moving.",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -392,15 +412,16 @@
   {
     "name": "LENGTH",
     "propertyId": 1094713376,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.Length",
+    "sources": {
+      "Vehicle.Length": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle length.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -411,15 +432,16 @@
   {
     "name": "LOW_VOLTAGE_SYSTEM_STATE",
     "propertyId": 1091567630,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.LowVoltageSystemState",
+    "sources": {
+      "Vehicle.LowVoltageSystemState": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "State of the supply voltage of the control units (usually 12V).",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -437,15 +459,16 @@
   {
     "name": "MAX_TOW_BALL_WEIGHT",
     "propertyId": 1094713375,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.MaxTowBallWeight",
+    "sources": {
+      "Vehicle.MaxTowBallWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Maximum vertical weight on the tow ball of a trailer.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -456,15 +479,16 @@
   {
     "name": "MAX_TOW_WEIGHT",
     "propertyId": 1094713374,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.MaxTowWeight",
+    "sources": {
+      "Vehicle.MaxTowWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Maximum weight of trailer.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -475,15 +499,16 @@
   {
     "name": "POWERTRAIN_ACCUMULATED_BRAKING_ENERGY",
     "propertyId": 1096810546,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "kWh",
-    "source": "Vehicle.Powertrain.AccumulatedBrakingEnergy",
+    "sources": {
+      "Vehicle.Powertrain.AccumulatedBrakingEnergy": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The accumulated energy from regenerative braking over lifetime.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -494,15 +519,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_COOLANT_LEVEL",
     "propertyId": 1091567676,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineCoolant.Level",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineCoolant.Level": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine coolant level.",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -517,15 +543,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_COOLANT_TEMPERATURE",
     "propertyId": 1096810555,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "celsius",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineCoolant.Temperature",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineCoolant.Temperature": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine coolant temperature.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -536,15 +563,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_OIL_CAPACITY",
     "propertyId": 1096810552,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "l",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineOil.Capacity",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineOil.Capacity": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine oil capacity in liters.",
-    "datatype": "float",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -555,15 +583,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_OIL_LEVEL",
     "propertyId": 1091567673,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineOil.Level",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineOil.Level": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine oil level.",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -580,15 +609,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_OIL_TEMPERATURE",
     "propertyId": 1096810554,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "celsius",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineOil.Temperature",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineOil.Temperature": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "EOT, Engine oil temperature.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -599,15 +629,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_IS_RUNNING",
     "propertyId": 1092616246,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.CombustionEngine.IsRunning",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.IsRunning": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine Running. True if engine is rotating (Speed > 0).",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -618,15 +649,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_SPEED",
     "propertyId": 1094713399,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "rpm",
-    "source": "Vehicle.Powertrain.CombustionEngine.Speed",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.Speed": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine speed measured as rotations per minute.",
-    "datatype": "uint16",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -637,15 +669,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_ABSOLUTE_LEVEL",
     "propertyId": 1096810561,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l",
-    "source": "Vehicle.Powertrain.FuelSystem.AbsoluteLevel",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.AbsoluteLevel": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current available fuel in the fuel tank expressed in liters.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -656,15 +689,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_AVERAGE_CONSUMPTION",
     "propertyId": 1096810566,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l/100km",
-    "source": "Vehicle.Powertrain.FuelSystem.AverageConsumption",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.AverageConsumption": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Average consumption in liters per 100 km.",
-    "datatype": "float",
     "type": "sensor",
     "min": 0,
     "max": null,
@@ -675,15 +709,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_CONSUMPTION_SINCE_LAST_REFUEL",
     "propertyId": 1096810568,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l",
-    "source": "Vehicle.Powertrain.FuelSystem.ConsumptionSinceLastRefuel",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.ConsumptionSinceLastRefuel": 0
+    },
     "formula": null,
     "comment": "Amount of fuel consumed since last refueling.",
     "configString": "Fuel consumption since last refueling.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -694,15 +729,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_CONSUMPTION_SINCE_START",
     "propertyId": 1096810567,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l",
-    "source": "Vehicle.Powertrain.FuelSystem.ConsumptionSinceStart",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.ConsumptionSinceStart": 0
+    },
     "formula": null,
     "comment": "A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new trip is started.",
     "configString": "Fuel amount in liters consumed since start of current trip.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -713,15 +749,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_HYBRID_TYPE",
     "propertyId": 1091567679,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.HybridType",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.HybridType": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Defines the hybrid type of the vehicle.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -739,15 +776,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_INSTANT_CONSUMPTION",
     "propertyId": 1096810565,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l/100km",
-    "source": "Vehicle.Powertrain.FuelSystem.InstantConsumption",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.InstantConsumption": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current consumption in liters per 100 km.",
-    "datatype": "float",
     "type": "sensor",
     "min": 0,
     "max": null,
@@ -758,15 +796,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_IS_ENGINE_STOP_START_ENABLED",
     "propertyId": 1092616265,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.IsEngineStopStartEnabled",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.IsEngineStopStartEnabled": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates whether eco start stop is currently enabled.",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -777,15 +816,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_IS_FUEL_LEVEL_LOW",
     "propertyId": 1092616266,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.IsFuelLevelLow",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.IsFuelLevelLow": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates that the fuel level is low (e.g. <50km range).",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -796,15 +836,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_IS_FUEL_PORT_FLAP_OPEN",
     "propertyId": 1092616268,
-    "areaId": 0,
+    "areaType": 0,
     "access": 3,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.IsFuelPortFlapOpen",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.IsFuelPortFlapOpen": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Status of the fuel port flap(s). True if at least one is open.",
-    "datatype": "boolean",
     "type": "actuator",
     "min": null,
     "max": null,
@@ -815,15 +856,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_RANGE",
     "propertyId": 1094713411,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.Powertrain.FuelSystem.Range",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.Range": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Remaining range in meters using only liquid fuel.",
-    "datatype": "uint32",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -834,11 +876,13 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_REFUEL_PORT_POSITION",
     "propertyId": 1091567691,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.RefuelPortPosition",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.RefuelPortPosition": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Position of refuel port(s). First part indicates side of vehicle, second part relative position on that side.",
@@ -866,15 +910,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_RELATIVE_LEVEL",
     "propertyId": 1094713410,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "percent",
-    "source": "Vehicle.Powertrain.FuelSystem.RelativeLevel",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.RelativeLevel": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Level in fuel tank as percent of capacity. 0 = empty. 100 = full.",
-    "datatype": "uint8",
     "type": "sensor",
     "min": 0,
     "max": 100,
@@ -885,11 +930,13 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_SUPPORTED_FUEL",
     "propertyId": 1091567678,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.SupportedFuel",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.SupportedFuel": 0
+    },
     "formula": null,
     "comment": "RON 95 is sometimes referred to as Super, RON 98 as Super Plus.",
     "configString": "Detailed information on fuels supported by the vehicle. Identifiers originating from DIN EN 16942:2021-08, appendix B, with additional suffix for octane (RON) where relevant.",
@@ -921,11 +968,13 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_SUPPORTED_FUEL_TYPES",
     "propertyId": 1091567677,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.SupportedFuelTypes",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.SupportedFuelTypes": 0
+    },
     "formula": null,
     "comment": "If a vehicle also has an electric drivetrain (e.g. hybrid) that will be obvious from the PowerTrain.Type signal.",
     "configString": "High level information of fuel types supported",
@@ -949,15 +998,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_TANK_CAPACITY",
     "propertyId": 1096810560,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "l",
-    "source": "Vehicle.Powertrain.FuelSystem.TankCapacity",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.TankCapacity": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Capacity of the fuel tank in liters.",
-    "datatype": "float",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -968,15 +1018,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_TIME_REMAINING",
     "propertyId": 1094713412,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "s",
-    "source": "Vehicle.Powertrain.FuelSystem.TimeRemaining",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.TimeRemaining": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Time remaining in seconds before the fuel tank is empty.",
-    "datatype": "uint32",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -987,15 +1038,16 @@
   {
     "name": "POWERTRAIN_RANGE",
     "propertyId": 1094713395,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.Powertrain.Range",
+    "sources": {
+      "Vehicle.Powertrain.Range": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Remaining range in meters using all energy sources available in the vehicle.",
-    "datatype": "uint32",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1006,15 +1058,16 @@
   {
     "name": "POWERTRAIN_TIME_REMAINING",
     "propertyId": 1094713396,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "s",
-    "source": "Vehicle.Powertrain.TimeRemaining",
+    "sources": {
+      "Vehicle.Powertrain.TimeRemaining": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Time remaining in seconds before all energy sources available in the vehicle are empty.",
-    "datatype": "uint32",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1025,15 +1078,16 @@
   {
     "name": "POWERTRAIN_TYPE",
     "propertyId": 1091567669,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.Type",
+    "sources": {
+      "Vehicle.Powertrain.Type": 0
+    },
     "formula": null,
     "comment": "For vehicles with a combustion engine (including hybrids) more detailed information on fuels supported can be found in FuelSystem.SupportedFuelTypes and FuelSystem.SupportedFuels.",
     "configString": "Defines the powertrain type of the vehicle.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1048,15 +1102,16 @@
   {
     "name": "ROOF_LOAD",
     "propertyId": 1094713368,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.RoofLoad",
+    "sources": {
+      "Vehicle.RoofLoad": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The permitted total weight of cargo and installations (e.g. a roof rack) on top of the vehicle.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1067,15 +1122,16 @@
   {
     "name": "SPEED",
     "propertyId": 1096810511,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "km/h",
-    "source": "Vehicle.Speed",
+    "sources": {
+      "Vehicle.Speed": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Vehicle speed.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1086,15 +1142,16 @@
   {
     "name": "START_TIME",
     "propertyId": 1091567634,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "iso8601",
-    "source": "Vehicle.StartTime",
+    "sources": {
+      "Vehicle.StartTime": 0
+    },
     "formula": null,
     "comment": "This signal is supposed to be set whenever a new trip starts. A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The default value indicates that the vehicle never has been started, or that latest start time is unknown.",
     "configString": "Start time of current or latest trip, formatted according to ISO 8601 with UTC time zone.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1105,15 +1162,16 @@
   {
     "name": "TRAILER_IS_CONNECTED",
     "propertyId": 1092616230,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Trailer.IsConnected",
+    "sources": {
+      "Vehicle.Trailer.IsConnected": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Signal indicating if trailer is connected or not.",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1124,15 +1182,16 @@
   {
     "name": "TRAVELED_DISTANCE",
     "propertyId": 1096810512,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "km",
-    "source": "Vehicle.TraveledDistance",
+    "sources": {
+      "Vehicle.TraveledDistance": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Odometer reading, total distance traveled during the lifetime of the vehicle.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1143,15 +1202,16 @@
   {
     "name": "TRAVELED_DISTANCE_SINCE_START",
     "propertyId": 1096810513,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "km",
-    "source": "Vehicle.TraveledDistanceSinceStart",
+    "sources": {
+      "Vehicle.TraveledDistanceSinceStart": 0
+    },
     "formula": null,
     "comment": "A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new trip is started.",
     "configString": "Distance traveled since start of current trip.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1162,15 +1222,16 @@
   {
     "name": "TRIP_DURATION",
     "propertyId": 1096810515,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "s",
-    "source": "Vehicle.TripDuration",
+    "sources": {
+      "Vehicle.TripDuration": 0
+    },
     "formula": null,
     "comment": "This signal is not assumed to be continuously updated, but instead set to 0 when a trip starts and set to the actual duration of the trip when a trip ends. A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled.",
     "configString": "Duration of latest trip.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1181,15 +1242,16 @@
   {
     "name": "TRIP_METER_READING",
     "propertyId": 1096810516,
-    "areaId": 0,
+    "areaType": 0,
     "access": 3,
     "changeMode": 0,
     "unit": "km",
-    "source": "Vehicle.TripMeterReading",
+    "sources": {
+      "Vehicle.TripMeterReading": 0
+    },
     "formula": null,
     "comment": "The trip meter is an odometer that can be manually reset by the driver",
     "configString": "Trip meter reading.",
-    "datatype": "float",
     "type": "actuator",
     "min": null,
     "max": null,
@@ -1200,15 +1262,16 @@
   {
     "name": "TURNING_DIAMETER",
     "propertyId": 1094713381,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.TurningDiameter",
+    "sources": {
+      "Vehicle.TurningDiameter": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Minimum turning diameter, Wall-to-Wall, as defined by SAE J1100-2009 D102.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1219,15 +1282,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_BODY_TYPE",
     "propertyId": 1091567622,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.BodyType",
+    "sources": {
+      "Vehicle.VehicleIdentification.BodyType": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates the design and body style of the vehicle (e.g. station wagon, hatchback, etc.).",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1238,15 +1302,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_BRAND",
     "propertyId": 1091567619,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.Brand",
+    "sources": {
+      "Vehicle.VehicleIdentification.Brand": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Vehicle brand or manufacturer.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1257,15 +1322,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_DATE_VEHICLE_FIRST_REGISTERED",
     "propertyId": 1091567623,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "iso8601",
-    "source": "Vehicle.VehicleIdentification.DateVehicleFirstRegistered",
+    "sources": {
+      "Vehicle.VehicleIdentification.DateVehicleFirstRegistered": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The date in ISO 8601 format of the first registration of the vehicle with the respective public authorities.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1276,15 +1342,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_LICENSE_PLATE",
     "propertyId": 1091567624,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.LicensePlate",
+    "sources": {
+      "Vehicle.VehicleIdentification.LicensePlate": 0
+    },
     "formula": null,
     "comment": "Depending on the context, this attribute might not be up to date or might be misconfigured, and therefore should be considered untrustworthy in the absence of another method of verification.",
     "configString": "The license plate of the vehicle.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1295,15 +1362,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_MEETS_EMISSION_STANDARD",
     "propertyId": 1091567625,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.MeetsEmissionStandard",
+    "sources": {
+      "Vehicle.VehicleIdentification.MeetsEmissionStandard": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates that the vehicle meets the respective emission standard.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1314,15 +1382,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_MODEL",
     "propertyId": 1091567620,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.Model",
+    "sources": {
+      "Vehicle.VehicleIdentification.Model": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Vehicle model.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1333,15 +1402,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_PRODUCTION_DATE",
     "propertyId": 1091567626,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "iso8601",
-    "source": "Vehicle.VehicleIdentification.ProductionDate",
+    "sources": {
+      "Vehicle.VehicleIdentification.ProductionDate": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The date in ISO 8601 format of production of the item, e.g. vehicle.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1352,15 +1422,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_VEHICLE_EXTERIOR_COLOR",
     "propertyId": 1091567629,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.VehicleExteriorColor",
+    "sources": {
+      "Vehicle.VehicleIdentification.VehicleExteriorColor": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The main color of the exterior within the basic color palette (eg. red, blue, black, white, ...).",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1371,15 +1442,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_VEHICLE_MODEL_DATE",
     "propertyId": 1091567627,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "iso8601",
-    "source": "Vehicle.VehicleIdentification.VehicleModelDate",
+    "sources": {
+      "Vehicle.VehicleIdentification.VehicleModelDate": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The release date in ISO 8601 format of a vehicle model (often used to differentiate versions of the same make and model).",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1390,15 +1462,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_VEHICLE_SEATING_CAPACITY",
     "propertyId": 1094713356,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.VehicleSeatingCapacity",
+    "sources": {
+      "Vehicle.VehicleIdentification.VehicleSeatingCapacity": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1409,15 +1482,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_VIN",
     "propertyId": 1091567617,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.VIN",
+    "sources": {
+      "Vehicle.VehicleIdentification.VIN": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "17-character Vehicle Identification Number (VIN) as defined by ISO 3779.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1428,15 +1502,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_WMI",
     "propertyId": 1091567618,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.WMI",
+    "sources": {
+      "Vehicle.VehicleIdentification.WMI": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "3-character World Manufacturer Identification (WMI) as defined by ISO 3780.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1447,15 +1522,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_YEAR",
     "propertyId": 1094713349,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.Year",
+    "sources": {
+      "Vehicle.VehicleIdentification.Year": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Model year of the vehicle.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1466,15 +1542,16 @@
   {
     "name": "WIDTH_EXCLUDING_MIRRORS",
     "propertyId": 1094713378,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.WidthExcludingMirrors",
+    "sources": {
+      "Vehicle.WidthExcludingMirrors": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle width excluding mirrors, as defined by SAE J1100-2009 W103.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1485,15 +1562,16 @@
   {
     "name": "WIDTH_FOLDED_MIRRORS",
     "propertyId": 1094713380,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.WidthFoldedMirrors",
+    "sources": {
+      "Vehicle.WidthFoldedMirrors": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle width with mirrors folded, as defined by SAE J1100-2009 W145.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1504,15 +1582,16 @@
   {
     "name": "WIDTH_INCLUDING_MIRRORS",
     "propertyId": 1094713379,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.WidthIncludingMirrors",
+    "sources": {
+      "Vehicle.WidthIncludingMirrors": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle width including mirrors, as defined by SAE J1100-2009 W144.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,

--- a/tests/vspec/test_static_uids_vhal/validation_jsons/validation_group_4_update.json
+++ b/tests/vspec/test_static_uids_vhal/validation_jsons/validation_group_4_update.json
@@ -2,15 +2,16 @@
   {
     "name": "AVERAGE_SPEED",
     "propertyId": 1096810519,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "km/h",
-    "source": "Vehicle.AverageSpeed",
+    "sources": {
+      "Vehicle.AverageSpeed": 0
+    },
     "formula": null,
     "comment": "A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new trip is started. Calculation of average speed may exclude periods when the vehicle for example is not moving or transmission is in neutral.",
     "configString": "Average speed for the current trip.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -21,15 +22,16 @@
   {
     "name": "CARGO_VOLUME",
     "propertyId": 1096810521,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "l",
-    "source": "Vehicle.CargoVolume",
+    "sources": {
+      "Vehicle.CargoVolume": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The available volume for cargo or luggage. For automobiles, this is usually the trunk volume.",
-    "datatype": "float",
     "type": "attribute",
     "min": 0,
     "max": null,
@@ -40,15 +42,16 @@
   {
     "name": "CURB_WEIGHT",
     "propertyId": 1094713372,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.CurbWeight",
+    "sources": {
+      "Vehicle.CurbWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Vehicle curb weight, including all liquids and full tank of fuel, but no cargo or passengers.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -59,15 +62,16 @@
   {
     "name": "CURRENT_LOCATION_ALTITUDE",
     "propertyId": 1096810540,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.CurrentLocation.Altitude",
+    "sources": {
+      "Vehicle.CurrentLocation.Altitude": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current altitude relative to WGS 84 reference ellipsoid, as measured at the position of GNSS receiver antenna.",
-    "datatype": "double",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -78,15 +82,16 @@
   {
     "name": "CURRENT_LOCATION_GNSSRECEIVER_FIX_TYPE",
     "propertyId": 1091567662,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.CurrentLocation.GNSSReceiver.FixType",
+    "sources": {
+      "Vehicle.CurrentLocation.GNSSReceiver.FixType": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Fix status of GNSS receiver.",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -107,15 +112,16 @@
   {
     "name": "CURRENT_LOCATION_GNSSRECEIVER_MOUNTING_POSITION_X",
     "propertyId": 1094713391,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.X",
+    "sources": {
+      "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.X": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Mounting position of GNSS receiver antenna relative to vehicle coordinate system. Axis definitions according to ISO 8855. Origin at center of (first) rear axle. Positive values = forward of rear axle. Negative values = backward of rear axle.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -126,15 +132,16 @@
   {
     "name": "CURRENT_LOCATION_GNSSRECEIVER_MOUNTING_POSITION_Y",
     "propertyId": 1094713392,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.Y",
+    "sources": {
+      "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.Y": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Mounting position of GNSS receiver antenna relative to vehicle coordinate system. Axis definitions according to ISO 8855. Origin at center of (first) rear axle. Positive values = left of origin. Negative values = right of origin. Left/Right is as seen from driver perspective, i.e. by a person looking forward.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -145,15 +152,16 @@
   {
     "name": "CURRENT_LOCATION_GNSSRECEIVER_MOUNTING_POSITION_Z",
     "propertyId": 1094713393,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.Z",
+    "sources": {
+      "Vehicle.CurrentLocation.GNSSReceiver.MountingPosition.Z": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Mounting position of GNSS receiver on Z-axis. Axis definitions according to ISO 8855. Origin at center of (first) rear axle. Positive values = above center of rear axle. Negative values = below center of rear axle.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -164,15 +172,16 @@
   {
     "name": "CURRENT_LOCATION_HEADING",
     "propertyId": 1096810538,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "degrees",
-    "source": "Vehicle.CurrentLocation.Heading",
+    "sources": {
+      "Vehicle.CurrentLocation.Heading": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current heading relative to geographic north. 0 = North, 90 = East, 180 = South, 270 = West.",
-    "datatype": "double",
     "type": "sensor",
     "min": 0,
     "max": 360,
@@ -183,15 +192,16 @@
   {
     "name": "CURRENT_LOCATION_HORIZONTAL_ACCURACY",
     "propertyId": 1096810539,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.CurrentLocation.HorizontalAccuracy",
+    "sources": {
+      "Vehicle.CurrentLocation.HorizontalAccuracy": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Accuracy of the latitude and longitude coordinates.",
-    "datatype": "double",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -202,15 +212,16 @@
   {
     "name": "CURRENT_LOCATION_LATITUDE",
     "propertyId": 1096810536,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "degrees",
-    "source": "Vehicle.CurrentLocation.Latitude",
+    "sources": {
+      "Vehicle.CurrentLocation.Latitude": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current latitude of vehicle in WGS 84 geodetic coordinates, as measured at the position of GNSS receiver antenna.",
-    "datatype": "double",
     "type": "sensor",
     "min": -90,
     "max": 90,
@@ -221,15 +232,16 @@
   {
     "name": "CURRENT_LOCATION_LONGITUDE",
     "propertyId": 1096810537,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "degrees",
-    "source": "Vehicle.CurrentLocation.Longitude",
+    "sources": {
+      "Vehicle.CurrentLocation.Longitude": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current longitude of vehicle in WGS 84 geodetic coordinates, as measured at the position of GNSS receiver antenna.",
-    "datatype": "double",
     "type": "sensor",
     "min": -180,
     "max": 180,
@@ -240,15 +252,16 @@
   {
     "name": "CURRENT_LOCATION_TIMESTAMP",
     "propertyId": 1091567655,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "iso8601",
-    "source": "Vehicle.CurrentLocation.Timestamp",
+    "sources": {
+      "Vehicle.CurrentLocation.Timestamp": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Timestamp from GNSS system for current location, formatted according to ISO 8601 with UTC time zone.",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -259,15 +272,16 @@
   {
     "name": "CURRENT_LOCATION_VERTICAL_ACCURACY",
     "propertyId": 1096810541,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.CurrentLocation.VerticalAccuracy",
+    "sources": {
+      "Vehicle.CurrentLocation.VerticalAccuracy": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Accuracy of altitude.",
-    "datatype": "double",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -278,15 +292,16 @@
   {
     "name": "CURRENT_OVERALL_WEIGHT",
     "propertyId": 1094713371,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "kg",
-    "source": "Vehicle.CurrentOverallWeight",
+    "sources": {
+      "Vehicle.CurrentOverallWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current overall Vehicle weight. Including passengers, cargo and other load inside the car.",
-    "datatype": "uint16",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -297,15 +312,16 @@
   {
     "name": "EMISSIONS_CO2",
     "propertyId": 1094713370,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "g/km",
-    "source": "Vehicle.EmissionsCO2",
+    "sources": {
+      "Vehicle.EmissionsCO2": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The CO2 emissions.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -316,15 +332,16 @@
   {
     "name": "EXTERIOR_AIR_TEMPERATURE",
     "propertyId": 1096810573,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "celsius",
-    "source": "Vehicle.Exterior.AirTemperature",
+    "sources": {
+      "Vehicle.Exterior.AirTemperature": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Air temperature outside the vehicle.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -335,15 +352,16 @@
   {
     "name": "EXTERIOR_HUMIDITY",
     "propertyId": 1096810574,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "percent",
-    "source": "Vehicle.Exterior.Humidity",
+    "sources": {
+      "Vehicle.Exterior.Humidity": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Relative humidity outside the vehicle. 0 = Dry, 100 = Air fully saturated.",
-    "datatype": "float",
     "type": "sensor",
     "min": 0,
     "max": 100,
@@ -354,15 +372,16 @@
   {
     "name": "EXTERIOR_LIGHT_INTENSITY",
     "propertyId": 1096810575,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "percent",
-    "source": "Vehicle.Exterior.LightIntensity",
+    "sources": {
+      "Vehicle.Exterior.LightIntensity": 0
+    },
     "formula": null,
     "comment": "Mapping to physical units and calculation method is sensor specific.",
     "configString": "Light intensity outside the vehicle. 0 = No light detected, 100 = Fully lit.",
-    "datatype": "float",
     "type": "sensor",
     "min": 0,
     "max": 100,
@@ -373,15 +392,16 @@
   {
     "name": "GROSS_WEIGHT",
     "propertyId": 1094713373,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.GrossWeight",
+    "sources": {
+      "Vehicle.GrossWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Curb weight of vehicle, including all liquids and full tank of fuel and full load of cargo and passengers.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -392,15 +412,16 @@
   {
     "name": "HEIGHT",
     "propertyId": 1094713377,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.Height",
+    "sources": {
+      "Vehicle.Height": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle height.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -411,15 +432,16 @@
   {
     "name": "IS_BROKEN_DOWN",
     "propertyId": 1092616213,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.IsBrokenDown",
+    "sources": {
+      "Vehicle.IsBrokenDown": 0
+    },
     "formula": null,
     "comment": "Actual criteria and method used to decide if a vehicle is broken down is implementation specific.",
     "configString": "Vehicle breakdown or any similar event causing vehicle to stop on the road, that might pose a risk to other road users. True = Vehicle broken down on the road, due to e.g. engine problems, flat tire, out of gas, brake problems. False = Vehicle not broken down.",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -430,15 +452,16 @@
   {
     "name": "IS_MOVING",
     "propertyId": 1092616214,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.IsMoving",
+    "sources": {
+      "Vehicle.IsMoving": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates whether the vehicle is stationary or moving.",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -449,15 +472,16 @@
   {
     "name": "LENGTH",
     "propertyId": 1094713376,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.Length",
+    "sources": {
+      "Vehicle.Length": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle length.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -468,15 +492,16 @@
   {
     "name": "LOW_VOLTAGE_SYSTEM_STATE",
     "propertyId": 1091567630,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.LowVoltageSystemState",
+    "sources": {
+      "Vehicle.LowVoltageSystemState": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "State of the supply voltage of the control units (usually 12V).",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -494,15 +519,16 @@
   {
     "name": "MAX_TOW_BALL_WEIGHT",
     "propertyId": 1094713375,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.MaxTowBallWeight",
+    "sources": {
+      "Vehicle.MaxTowBallWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Maximum vertical weight on the tow ball of a trailer.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -513,15 +539,16 @@
   {
     "name": "MAX_TOW_WEIGHT",
     "propertyId": 1094713374,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.MaxTowWeight",
+    "sources": {
+      "Vehicle.MaxTowWeight": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Maximum weight of trailer.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -532,15 +559,16 @@
   {
     "name": "POWERTRAIN_ACCUMULATED_BRAKING_ENERGY",
     "propertyId": 1096810546,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "kWh",
-    "source": "Vehicle.Powertrain.AccumulatedBrakingEnergy",
+    "sources": {
+      "Vehicle.Powertrain.AccumulatedBrakingEnergy": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The accumulated energy from regenerative braking over lifetime.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -551,15 +579,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_COOLANT_LEVEL",
     "propertyId": 1091567676,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineCoolant.Level",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineCoolant.Level": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine coolant level.",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -574,15 +603,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_COOLANT_TEMPERATURE",
     "propertyId": 1096810555,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "celsius",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineCoolant.Temperature",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineCoolant.Temperature": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine coolant temperature.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -593,15 +623,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_OIL_CAPACITY",
     "propertyId": 1096810552,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "l",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineOil.Capacity",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineOil.Capacity": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine oil capacity in liters.",
-    "datatype": "float",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -612,15 +643,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_OIL_LEVEL",
     "propertyId": 1091567673,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineOil.Level",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineOil.Level": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine oil level.",
-    "datatype": "string",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -637,15 +669,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_ENGINE_OIL_TEMPERATURE",
     "propertyId": 1096810554,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "celsius",
-    "source": "Vehicle.Powertrain.CombustionEngine.EngineOil.Temperature",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.EngineOil.Temperature": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "EOT, Engine oil temperature.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -656,15 +689,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_IS_RUNNING",
     "propertyId": 1092616246,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.CombustionEngine.IsRunning",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.IsRunning": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine Running. True if engine is rotating (Speed > 0).",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -675,15 +709,16 @@
   {
     "name": "POWERTRAIN_COMBUSTION_ENGINE_SPEED",
     "propertyId": 1094713399,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "rpm",
-    "source": "Vehicle.Powertrain.CombustionEngine.Speed",
+    "sources": {
+      "Vehicle.Powertrain.CombustionEngine.Speed": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Engine speed measured as rotations per minute.",
-    "datatype": "uint16",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -694,15 +729,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_ABSOLUTE_LEVEL",
     "propertyId": 1096810561,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l",
-    "source": "Vehicle.Powertrain.FuelSystem.AbsoluteLevel",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.AbsoluteLevel": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current available fuel in the fuel tank expressed in liters.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -713,15 +749,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_AVERAGE_CONSUMPTION",
     "propertyId": 1096810566,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l/100km",
-    "source": "Vehicle.Powertrain.FuelSystem.AverageConsumption",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.AverageConsumption": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Average consumption in liters per 100 km.",
-    "datatype": "float",
     "type": "sensor",
     "min": 0,
     "max": null,
@@ -732,15 +769,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_CONSUMPTION_SINCE_LAST_REFUEL",
     "propertyId": 1096810568,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l",
-    "source": "Vehicle.Powertrain.FuelSystem.ConsumptionSinceLastRefuel",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.ConsumptionSinceLastRefuel": 0
+    },
     "formula": null,
     "comment": "Amount of fuel consumed since last refueling.",
     "configString": "Fuel consumption since last refueling.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -751,15 +789,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_CONSUMPTION_SINCE_START",
     "propertyId": 1096810567,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l",
-    "source": "Vehicle.Powertrain.FuelSystem.ConsumptionSinceStart",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.ConsumptionSinceStart": 0
+    },
     "formula": null,
     "comment": "A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new trip is started.",
     "configString": "Fuel amount in liters consumed since start of current trip.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -770,15 +809,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_HYBRID_TYPE",
     "propertyId": 1091567679,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.HybridType",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.HybridType": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Defines the hybrid type of the vehicle.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -796,15 +836,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_INSTANT_CONSUMPTION",
     "propertyId": 1096810565,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "l/100km",
-    "source": "Vehicle.Powertrain.FuelSystem.InstantConsumption",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.InstantConsumption": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Current consumption in liters per 100 km.",
-    "datatype": "float",
     "type": "sensor",
     "min": 0,
     "max": null,
@@ -815,15 +856,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_IS_ENGINE_STOP_START_ENABLED",
     "propertyId": 1092616265,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.IsEngineStopStartEnabled",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.IsEngineStopStartEnabled": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates whether eco start stop is currently enabled.",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -834,15 +876,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_IS_FUEL_LEVEL_LOW",
     "propertyId": 1092616266,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.IsFuelLevelLow",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.IsFuelLevelLow": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates that the fuel level is low (e.g. <50km range).",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -853,15 +896,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_IS_FUEL_PORT_FLAP_OPEN",
     "propertyId": 1092616268,
-    "areaId": 0,
+    "areaType": 0,
     "access": 3,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.IsFuelPortFlapOpen",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.IsFuelPortFlapOpen": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Status of the fuel port flap(s). True if at least one is open.",
-    "datatype": "boolean",
     "type": "actuator",
     "min": null,
     "max": null,
@@ -872,15 +916,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_RANGE",
     "propertyId": 1094713411,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.Powertrain.FuelSystem.Range",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.Range": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Remaining range in meters using only liquid fuel.",
-    "datatype": "uint32",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -891,11 +936,13 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_REFUEL_PORT_POSITION",
     "propertyId": 1091567691,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.RefuelPortPosition",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.RefuelPortPosition": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Position of refuel port(s). First part indicates side of vehicle, second part relative position on that side.",
@@ -923,15 +970,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_RELATIVE_LEVEL",
     "propertyId": 1094713410,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "percent",
-    "source": "Vehicle.Powertrain.FuelSystem.RelativeLevel",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.RelativeLevel": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Level in fuel tank as percent of capacity. 0 = empty. 100 = full.",
-    "datatype": "uint8",
     "type": "sensor",
     "min": 0,
     "max": 100,
@@ -942,11 +990,13 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_SUPPORTED_FUEL",
     "propertyId": 1091567678,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.SupportedFuel",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.SupportedFuel": 0
+    },
     "formula": null,
     "comment": "RON 95 is sometimes referred to as Super, RON 98 as Super Plus.",
     "configString": "Detailed information on fuels supported by the vehicle. Identifiers originating from DIN EN 16942:2021-08, appendix B, with additional suffix for octane (RON) where relevant.",
@@ -978,11 +1028,13 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_SUPPORTED_FUEL_TYPES",
     "propertyId": 1091567677,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.FuelSystem.SupportedFuelTypes",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.SupportedFuelTypes": 0
+    },
     "formula": null,
     "comment": "If a vehicle also has an electric drivetrain (e.g. hybrid) that will be obvious from the PowerTrain.Type signal.",
     "configString": "High level information of fuel types supported",
@@ -1006,15 +1058,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_TANK_CAPACITY",
     "propertyId": 1096810560,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "l",
-    "source": "Vehicle.Powertrain.FuelSystem.TankCapacity",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.TankCapacity": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Capacity of the fuel tank in liters.",
-    "datatype": "float",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1025,15 +1078,16 @@
   {
     "name": "POWERTRAIN_FUEL_SYSTEM_TIME_REMAINING",
     "propertyId": 1094713412,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "s",
-    "source": "Vehicle.Powertrain.FuelSystem.TimeRemaining",
+    "sources": {
+      "Vehicle.Powertrain.FuelSystem.TimeRemaining": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Time remaining in seconds before the fuel tank is empty.",
-    "datatype": "uint32",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1044,15 +1098,16 @@
   {
     "name": "POWERTRAIN_RANGE",
     "propertyId": 1094713395,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "m",
-    "source": "Vehicle.Powertrain.Range",
+    "sources": {
+      "Vehicle.Powertrain.Range": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Remaining range in meters using all energy sources available in the vehicle.",
-    "datatype": "uint32",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1063,15 +1118,16 @@
   {
     "name": "POWERTRAIN_TIME_REMAINING",
     "propertyId": 1094713396,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "s",
-    "source": "Vehicle.Powertrain.TimeRemaining",
+    "sources": {
+      "Vehicle.Powertrain.TimeRemaining": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Time remaining in seconds before all energy sources available in the vehicle are empty.",
-    "datatype": "uint32",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1082,15 +1138,16 @@
   {
     "name": "POWERTRAIN_TYPE",
     "propertyId": 1091567669,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.Powertrain.Type",
+    "sources": {
+      "Vehicle.Powertrain.Type": 0
+    },
     "formula": null,
     "comment": "For vehicles with a combustion engine (including hybrids) more detailed information on fuels supported can be found in FuelSystem.SupportedFuelTypes and FuelSystem.SupportedFuels.",
     "configString": "Defines the powertrain type of the vehicle.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1105,15 +1162,16 @@
   {
     "name": "ROOF_LOAD",
     "propertyId": 1094713368,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "kg",
-    "source": "Vehicle.RoofLoad",
+    "sources": {
+      "Vehicle.RoofLoad": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The permitted total weight of cargo and installations (e.g. a roof rack) on top of the vehicle.",
-    "datatype": "int16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1124,15 +1182,16 @@
   {
     "name": "SPEED",
     "propertyId": 1096810511,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "km/h",
-    "source": "Vehicle.Speed",
+    "sources": {
+      "Vehicle.Speed": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Vehicle speed.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1143,15 +1202,16 @@
   {
     "name": "START_TIME",
     "propertyId": 1091567634,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "iso8601",
-    "source": "Vehicle.StartTime",
+    "sources": {
+      "Vehicle.StartTime": 0
+    },
     "formula": null,
     "comment": "This signal is supposed to be set whenever a new trip starts. A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The default value indicates that the vehicle never has been started, or that latest start time is unknown.",
     "configString": "Start time of current or latest trip, formatted according to ISO 8601 with UTC time zone.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1162,15 +1222,16 @@
   {
     "name": "TRAILER_IS_CONNECTED",
     "propertyId": 1092616230,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "",
-    "source": "Vehicle.Trailer.IsConnected",
+    "sources": {
+      "Vehicle.Trailer.IsConnected": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Signal indicating if trailer is connected or not.",
-    "datatype": "boolean",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1181,15 +1242,16 @@
   {
     "name": "TRAVELED_DISTANCE",
     "propertyId": 1096810512,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "km",
-    "source": "Vehicle.TraveledDistance",
+    "sources": {
+      "Vehicle.TraveledDistance": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Odometer reading, total distance traveled during the lifetime of the vehicle.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1200,15 +1262,16 @@
   {
     "name": "TRAVELED_DISTANCE_SINCE_START",
     "propertyId": 1096810513,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "km",
-    "source": "Vehicle.TraveledDistanceSinceStart",
+    "sources": {
+      "Vehicle.TraveledDistanceSinceStart": 0
+    },
     "formula": null,
     "comment": "A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled. The signal may however keep the value of the last trip until a new trip is started.",
     "configString": "Distance traveled since start of current trip.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1219,15 +1282,16 @@
   {
     "name": "TRIP_DURATION",
     "propertyId": 1096810515,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 1,
     "unit": "s",
-    "source": "Vehicle.TripDuration",
+    "sources": {
+      "Vehicle.TripDuration": 0
+    },
     "formula": null,
     "comment": "This signal is not assumed to be continuously updated, but instead set to 0 when a trip starts and set to the actual duration of the trip when a trip ends. A new trip is considered to start when engine gets enabled (e.g. LowVoltageSystemState in ON or START mode). A trip is considered to end when engine is no longer enabled.",
     "configString": "Duration of latest trip.",
-    "datatype": "float",
     "type": "sensor",
     "min": null,
     "max": null,
@@ -1238,15 +1302,16 @@
   {
     "name": "TRIP_METER_READING",
     "propertyId": 1096810516,
-    "areaId": 0,
+    "areaType": 0,
     "access": 3,
     "changeMode": 1,
     "unit": "km",
-    "source": "Vehicle.TripMeterReading",
+    "sources": {
+      "Vehicle.TripMeterReading": 0
+    },
     "formula": null,
     "comment": "The trip meter is an odometer that can be manually reset by the driver",
     "configString": "Trip meter reading.",
-    "datatype": "float",
     "type": "actuator",
     "min": null,
     "max": null,
@@ -1257,15 +1322,16 @@
   {
     "name": "TURNING_DIAMETER",
     "propertyId": 1094713381,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.TurningDiameter",
+    "sources": {
+      "Vehicle.TurningDiameter": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Minimum turning diameter, Wall-to-Wall, as defined by SAE J1100-2009 D102.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1276,15 +1342,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_BODY_TYPE",
     "propertyId": 1091567622,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.BodyType",
+    "sources": {
+      "Vehicle.VehicleIdentification.BodyType": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates the design and body style of the vehicle (e.g. station wagon, hatchback, etc.).",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1295,15 +1362,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_BRAND",
     "propertyId": 1091567619,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.Brand",
+    "sources": {
+      "Vehicle.VehicleIdentification.Brand": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Vehicle brand or manufacturer.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1314,15 +1382,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_DATE_VEHICLE_FIRST_REGISTERED",
     "propertyId": 1091567623,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "iso8601",
-    "source": "Vehicle.VehicleIdentification.DateVehicleFirstRegistered",
+    "sources": {
+      "Vehicle.VehicleIdentification.DateVehicleFirstRegistered": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The date in ISO 8601 format of the first registration of the vehicle with the respective public authorities.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1333,15 +1402,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_LICENSE_PLATE",
     "propertyId": 1091567624,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.LicensePlate",
+    "sources": {
+      "Vehicle.VehicleIdentification.LicensePlate": 0
+    },
     "formula": null,
     "comment": "Depending on the context, this attribute might not be up to date or might be misconfigured, and therefore should be considered untrustworthy in the absence of another method of verification.",
     "configString": "The license plate of the vehicle.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1352,15 +1422,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_MEETS_EMISSION_STANDARD",
     "propertyId": 1091567625,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.MeetsEmissionStandard",
+    "sources": {
+      "Vehicle.VehicleIdentification.MeetsEmissionStandard": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Indicates that the vehicle meets the respective emission standard.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1371,15 +1442,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_MODEL",
     "propertyId": 1091567620,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.Model",
+    "sources": {
+      "Vehicle.VehicleIdentification.Model": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Vehicle model.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1390,15 +1462,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_PRODUCTION_DATE",
     "propertyId": 1091567626,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "iso8601",
-    "source": "Vehicle.VehicleIdentification.ProductionDate",
+    "sources": {
+      "Vehicle.VehicleIdentification.ProductionDate": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The date in ISO 8601 format of production of the item, e.g. vehicle.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1409,15 +1482,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_VEHICLE_EXTERIOR_COLOR",
     "propertyId": 1091567629,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.VehicleExteriorColor",
+    "sources": {
+      "Vehicle.VehicleIdentification.VehicleExteriorColor": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The main color of the exterior within the basic color palette (eg. red, blue, black, white, ...).",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1428,15 +1502,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_VEHICLE_MODEL_DATE",
     "propertyId": 1091567627,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "iso8601",
-    "source": "Vehicle.VehicleIdentification.VehicleModelDate",
+    "sources": {
+      "Vehicle.VehicleIdentification.VehicleModelDate": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The release date in ISO 8601 format of a vehicle model (often used to differentiate versions of the same make and model).",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1447,15 +1522,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_VEHICLE_SEATING_CAPACITY",
     "propertyId": 1094713356,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.VehicleSeatingCapacity",
+    "sources": {
+      "Vehicle.VehicleIdentification.VehicleSeatingCapacity": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "The number of passengers that can be seated in the vehicle, both in terms of the physical space available, and in terms of limitations set by law.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1466,15 +1542,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_VIN",
     "propertyId": 1091567617,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.VIN",
+    "sources": {
+      "Vehicle.VehicleIdentification.VIN": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "17-character Vehicle Identification Number (VIN) as defined by ISO 3779.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1485,15 +1562,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_WMI",
     "propertyId": 1091567618,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.WMI",
+    "sources": {
+      "Vehicle.VehicleIdentification.WMI": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "3-character World Manufacturer Identification (WMI) as defined by ISO 3780.",
-    "datatype": "string",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1504,15 +1582,16 @@
   {
     "name": "VEHICLE_IDENTIFICATION_YEAR",
     "propertyId": 1094713349,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "",
-    "source": "Vehicle.VehicleIdentification.Year",
+    "sources": {
+      "Vehicle.VehicleIdentification.Year": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Model year of the vehicle.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1523,15 +1602,16 @@
   {
     "name": "WIDTH_EXCLUDING_MIRRORS",
     "propertyId": 1094713378,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.WidthExcludingMirrors",
+    "sources": {
+      "Vehicle.WidthExcludingMirrors": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle width excluding mirrors, as defined by SAE J1100-2009 W103.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1542,15 +1622,16 @@
   {
     "name": "WIDTH_FOLDED_MIRRORS",
     "propertyId": 1094713380,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.WidthFoldedMirrors",
+    "sources": {
+      "Vehicle.WidthFoldedMirrors": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle width with mirrors folded, as defined by SAE J1100-2009 W145.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,
@@ -1561,15 +1642,16 @@
   {
     "name": "WIDTH_INCLUDING_MIRRORS",
     "propertyId": 1094713379,
-    "areaId": 0,
+    "areaType": 0,
     "access": 1,
     "changeMode": 0,
     "unit": "mm",
-    "source": "Vehicle.WidthIncludingMirrors",
+    "sources": {
+      "Vehicle.WidthIncludingMirrors": 0
+    },
     "formula": null,
     "comment": null,
     "configString": "Overall vehicle width including mirrors, as defined by SAE J1100-2009 W144.",
-    "datatype": "uint16",
     "type": "attribute",
     "min": null,
     "max": null,

--- a/tests/vspec/test_static_uids_vhal/vhal_area_config.json
+++ b/tests/vspec/test_static_uids_vhal/vhal_area_config.json
@@ -1,0 +1,51 @@
+{
+  "Vehicle.Cabin.Door.*": "DOOR",
+
+  "Vehicle.Body.Trunk.*": {
+    "areaType": "DOOR",
+    "map": {
+      "front": "HOOD",
+      "rear": "REAR"
+    },
+    "_comment": "Trunk explicitly maps 'front' to HOOD and 'rear' to REAR."
+  },
+  "Vehicle.Body.Mirrors.*": "MIRROR",
+
+  "Vehicle.Occupant.*": "SEAT",
+  "Vehicle.Cabin.Seat.*": "SEAT",
+  "Vehicle.Cabin.HVAC.Station.*": {
+    "areaType": "SEAT",
+    "ignore": ["row4"]
+  },
+  "Vehicle.Cabin.Light.Spotlight.*": "SEAT",
+  "Vehicle.Cabin.Light.AmbientLight.*": "SEAT",
+
+  "Vehicle.Chassis.Axle.*.Wheel.*": "WHEEL",
+  "Vehicle.MotionManagement.Brake.Axle.*.Wheel.*": "WHEEL",
+  "Vehicle.MotionManagement.Suspension.Axle.*.Wheel.*": {
+    "areaType": "WHEEL",
+    "map": {
+      "row1, left": "LEFT_FRONT"
+    },
+    "keep": [
+      ["row1", "left"],
+      ["row1", "right"],
+      "row2"
+    ]
+  },
+  "Vehicle.Powertrain.ElectricMotor.*": {
+    "areaType": "WHEEL",
+    "ignore": ["front", "rear"]
+  },
+
+  "Vehicle.Body.Windshield.*": "WINDOW",
+
+  "Vehicle.ADAS.ObstacleDetection.*": "GLOBAL",
+  "Vehicle.Body.Lights.Beam.*": "GLOBAL",
+  "Vehicle.Body.Lights.Fog.*": "GLOBAL",
+  "Vehicle.Body.Lights.DirectionIndicator.*": "GLOBAL",
+  "Vehicle.ControlUnit.*": "GLOBAL",
+  "Vehicle.MotionManagement.ElectricAxle.*": "GLOBAL",
+  "Vehicle.Powertrain.Tractionbattery.Charging.ChargingPort.*": "GLOBAL"
+}
+


### PR DESCRIPTION
Enables VHAL Area IDs

Maps instances into areas, e.g., seats, windows, mirrors.