### PR TITLE
fix(id): output into two files when structs present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **Breaking**: Unit descriptions (`unit` field) must now be globally unique across all quantities. Previously accepted duplicate unit descriptions in `units.yaml` will now fail validation with a clear error message identifying the conflicting unit keys.
+- **Breaking**: `vspec export id` now writes struct/type static UIDs to `--types-output` (or, if omitted, to a file named `structs_<output>` next to `--output`) instead of merging them into the main `--output` file. Previously, using `--types` produced a vspec with two top-level roots that other tools cannot load.
 - Enhanced `s2dm` exporter that provides increased traceability of the performed mapping, reporting name conversions, correspondences, etc.
 
 ## 6.0

--- a/docs/id.md
+++ b/docs/id.md
@@ -32,11 +32,10 @@ identifiers.
 │                                                               VSPEC/quantities.yaml]                       │
 │    --units                -u  FILE                            Unit files. [default: VSPEC/units.yaml]      │
 │    --types                -t  FILE                            Data types files.                            │
-│    --types-output             FILE                            Output file for writing data types from      │
-│                                                               vspec file. If not specified, a single file  │
-│                                                               is used where applicable. In case of JSON    │
-│                                                               and YAML, the data is exported under a       │
-│                                                               special key: "ComplexDataTypes",             │
+│    --types-output             FILE                            Output file for writing static UIDs of      │
+│                                                               struct/type nodes. If '--types' is used and  │
+│                                                               '--types-output' is not given, it defaults   │
+│                                                               to 'structs_<output>' next to '--output'.    │
 │    --validate-static-uid      FILE                            Validation file.                             │
 │    --validate-only                                            Only validating. Not exporting.              │
 │    --case-sensitive                                           Whether the generation of static UIDs is     │
@@ -78,6 +77,38 @@ using `-u`.
 ```bash
 cd path/to/your/vss
 vspec export yaml --vspec output_id_v1.vspec --output vehicle_specification_with_uids.yaml -e staticUID -u spec/units.yaml
+```
+
+### Custom data types (structs)
+
+If your specification uses custom struct types (passed via `--types`/`-t`), the
+`id` exporter generates static UIDs for the struct and property nodes as well.
+However, since the main tree and the types tree each have their own root, they
+cannot be written into the same vspec file (a single vspec file can only have
+one root). For that reason struct/type static UIDs are always written to a
+separate file, specified with `--types-output`:
+
+```bash
+cd path/to/your/vss
+vspec export id --vspec spec/VehicleSignalSpecification.vspec \
+  --types spec/types.vspec \
+  --output output_id_v1.vspec \
+  --types-output output_id_v1_types.vspec
+```
+
+If you omit `--types-output`, it defaults to `structs_<output-filename>` in the
+same directory as `--output`. For example, `--output output_id_v1.vspec`
+without `--types-output` will write struct UIDs to `structs_output_id_v1.vspec`.
+
+When chaining this into another exporter, pass both generated files back in:
+the main output as an overlay (`-l`/`--overlays`) and the types output as the
+types file (`-t`/`--types`), replacing the original types file:
+
+```bash
+vspec export yaml --vspec spec/VehicleSignalSpecification.vspec \
+  --overlays output_id_v1.vspec \
+  --types output_id_v1_types.vspec \
+  --output vehicle_specification_with_uids.yaml -e staticUID -u spec/units.yaml
 ```
 
 ### Using constant UIDs for specific attributes

--- a/src/vss_tools/exporters/id.py
+++ b/src/vss_tools/exporters/id.py
@@ -145,6 +145,7 @@ def export_node(data: dict[str, Any], node: VSSNode, id_counter, strict_mode: bo
 @clo.quantities_opt
 @clo.units_opt
 @clo.types_opt
+@clo.types_output_opt
 @clo.strict_exceptions_opt
 @click.option(
     "--validate-static-uid",
@@ -169,6 +170,7 @@ def cli(
     quantities: tuple[Path],
     units: tuple[Path],
     types: tuple[Path],
+    types_output: Path | None,
     validate_static_uid: Path,
     validate_only: bool,
     case_sensitive: bool,
@@ -192,11 +194,21 @@ def cli(
     )
     log.info("Generating vspec output including static UIDs...")
 
+    if datatype_tree and not types_output:
+        types_output = output.with_name(f"structs_{output.name}")
+        log.info(
+            f"'--types' was provided but no '--types-output' was given. Struct/type IDs will "
+            f"be written to '{types_output}' instead of being merged into '{output}', since "
+            "that would produce a vspec with multiple roots, which is unsupported downstream."
+        )
+
     id_counter: int = 0
     signals_yaml_dict: Dict[str, str] = {}  # Use str for ID values
     id_counter, _ = export_node(signals_yaml_dict, tree, id_counter, case_sensitive)
+
+    types_signals_yaml_dict: Dict[str, str] = {}
     if datatype_tree:
-        id_counter, _ = export_node(signals_yaml_dict, datatype_tree, id_counter, case_sensitive)
+        id_counter, _ = export_node(types_signals_yaml_dict, datatype_tree, id_counter, case_sensitive)
 
     if validate_static_uid:
         log.info(f"Now validating nodes, static UIDs, types, units and description with file '{validate_static_uid}'")
@@ -217,3 +229,6 @@ def cli(
     if not validate_only:
         with open(output, "w", encoding="utf-8") as f:
             yaml.dump(signals_yaml_dict, f)
+        if types_output and types_signals_yaml_dict:
+            with open(types_output, "w", encoding="utf-8") as f:
+                yaml.dump(types_signals_yaml_dict, f)

--- a/tests/vspec/test_id_struct/test_id_struct.py
+++ b/tests/vspec/test_id_struct/test_id_struct.py
@@ -16,8 +16,43 @@ TEST_UNITS = HERE / ".." / "test_units.yaml"
 TEST_QUANT = HERE / ".." / "test_quantities.yaml"
 
 
-def test_id_exporter_includes_struct_nodes(tmp_path: Path):
+def test_id_exporter_writes_struct_nodes_to_types_output(tmp_path: Path):
     output = tmp_path / "out.yaml"
+    types_output = tmp_path / "out_types.yaml"
+    cmd = (
+        f"vspec export id -s {HERE / 'test.vspec'}"
+        f" -u {TEST_UNITS} -q {TEST_QUANT}"
+        f" --types {HERE / 'types.vspec'}"
+        f" -o {output} --types-output {types_output}"
+    )
+    process = subprocess.run(cmd.split(), capture_output=True, text=True)
+    assert process.returncode == 0, process.stderr
+
+    ids = yaml.safe_load(output.read_text())
+    assert ids is not None
+    types_ids = yaml.safe_load(types_output.read_text())
+    assert types_ids is not None
+
+    # Struct and property nodes must appear in the types output, not the main one
+    assert "Types.Reading" in types_ids, "struct node missing from types output"
+    assert "Types.Reading.Value" in types_ids, "property node missing from types output"
+    assert "Types.Reading.Quality" in types_ids, "property node missing from types output"
+    assert "Types.Reading" not in ids
+    assert "Types.Reading.Value" not in ids
+    assert "Types.Reading.Quality" not in ids
+
+    # Each entry must have a staticUID
+    for key in ("Types.Reading", "Types.Reading.Value", "Types.Reading.Quality"):
+        assert "staticUID" in types_ids[key], f"{key} is missing staticUID"
+        assert types_ids[key]["staticUID"].startswith("0x"), f"{key} staticUID not hex"
+
+    # Regular signal nodes still present in the main output
+    assert "A.Signal" in ids
+
+
+def test_id_exporter_defaults_types_output_name_when_not_given(tmp_path: Path):
+    output = tmp_path / "out.yaml"
+    default_types_output = tmp_path / "structs_out.yaml"
     cmd = (
         f"vspec export id -s {HERE / 'test.vspec'}"
         f" -u {TEST_UNITS} -q {TEST_QUANT}"
@@ -26,19 +61,13 @@ def test_id_exporter_includes_struct_nodes(tmp_path: Path):
     )
     process = subprocess.run(cmd.split(), capture_output=True, text=True)
     assert process.returncode == 0, process.stderr
+    assert default_types_output.exists(), "default types-output file was not created"
 
     ids = yaml.safe_load(output.read_text())
     assert ids is not None
+    types_ids = yaml.safe_load(default_types_output.read_text())
+    assert types_ids is not None
 
-    # Struct and property nodes must appear in the output
-    assert "Types.Reading" in ids, "struct node missing from id output"
-    assert "Types.Reading.Value" in ids, "property node missing from id output"
-    assert "Types.Reading.Quality" in ids, "property node missing from id output"
-
-    # Each entry must have a staticUID
-    for key in ("Types.Reading", "Types.Reading.Value", "Types.Reading.Quality"):
-        assert "staticUID" in ids[key], f"{key} is missing staticUID"
-        assert ids[key]["staticUID"].startswith("0x"), f"{key} staticUID not hex"
-
-    # Regular signal nodes still present
+    assert "Types.Reading" in types_ids
+    assert "Types.Reading" not in ids
     assert "A.Signal" in ids


### PR DESCRIPTION
This PR addresses an issue introduced by #528 

### Problem

`vspec export id` writes static UIDs (`staticUID`) for every node in the tree into a single flat, FQN-keyed YAML dict, which is meant to be re-loaded as a normal vspec/overlay file downstream.

When `--types` was supplied, the struct/type tree's nodes were merged into that **same** dict as the main tree's nodes. Since both the main tree's root (e.g. `Vehicle`) and the types tree's root (e.g. `Types`) are separator-less top-level keys, the generated file ended up with **two roots**. Feeding that file back into any other `vss-tools` command (as `--overlays`) then failed with `MultipleRootsException`, since a single vspec file is only allowed to have one root.

### Root cause

In id.py's `cli()`, both trees were exported into the same dict:

```python
id_counter, _ = export_node(signals_yaml_dict, tree, id_counter, case_sensitive)
if datatype_tree:
    id_counter, _ = export_node(signals_yaml_dict, datatype_tree, id_counter, case_sensitive)
```

Other exporters (`json`, `yaml`, `csv`, binary) already had a `--types-output` option to write type/struct data to a separate file — id.py never wired it up, even though id.md already (incorrectly) documented it as if it existed.

### Fix

- Struct/type static UIDs are now written to a **separate** dict/file instead of being merged into the main output.
- Added `--types-output` to `vspec export id`, consistent with other exporters.
- `--types-output` is **optional**: if `--types` is used and `--types-output` is not given, the tool now derives a default name automatically: `structs_<output-filename>` written next to `--output` (e.g. `--output out.vspec` → `structs_out.vspec`).
- Updated CHANGELOG.md and id.md (options table + new "Custom data types (structs)" section) to document the new behavior and the recommended chaining workflow (main output as `-l/--overlays`, types output as `-t/--types` — replacing, not supplementing, the original types file).
- Updated/added tests in test_id_struct.py covering both explicit `--types-output` and the new default-naming fallback.

### Usage change

```bash
# Before (broken): struct UIDs merged into the main output -> two roots, unusable downstream
vspec export id -s spec.vspec --types types.vspec -o ids_overlay.vspec

# After: struct UIDs written separately (explicit name)
vspec export id -s spec.vspec --types types.vspec \
  -o ids_overlay.vspec --types-output ids_types.vspec

# After: struct UIDs written separately (default name: structs_ids_overlay.vspec)
vspec export id -s spec.vspec --types types.vspec -o ids_overlay.vspec

# Chaining downstream:
vspec export <format> -s spec.vspec -l ids_overlay.vspec --types ids_types.vspec ...
```

### Testing

- test_id_struct.py: verifies struct/property nodes land in the types-output file (not the main one) both when `--types-output` is explicit and when it's omitted (default `structs_` naming).
- Full `id`/struct-related test suite passes (157 passed); 2 pre-existing, unrelated protobuf test failures confirmed to exist on `main` as well.