### PR TITLE
fix: reintroduce extended attributes support in jsonschema exporter

### DIFF
--- a/docs/export.md
+++ b/docs/export.md
@@ -362,7 +362,7 @@ In this case the expectation is, that the generated output will contain the whit
 
 > [!WARNING]
 > Not all exporters (need to) support (all) extended metadata attributes!
-> Currently, the `yaml`, `csv`, and `json` exporters support arbitrary metadata.
+> Currently, the `yaml`, `csv`, `jsonschema` and `json` exporters support arbitrary metadata.
 
 ## JSON exporter notes
 

--- a/src/vss_tools/exporters/jsonschema.py
+++ b/src/vss_tools/exporters/jsonschema.py
@@ -153,7 +153,7 @@ def add_node(
     if extend_all_attributes:
         add_x_attributes(schema, node)
     for field in vss_data.get_extra_attributes():
-        schema[field] = getattr(vss_data, field)        
+        schema[field] = getattr(vss_data, field)
     if isinstance(node.data, VSSDataDatatype):
         ref = schema
         if is_array(node.data.datatype):

--- a/src/vss_tools/exporters/jsonschema.py
+++ b/src/vss_tools/exporters/jsonschema.py
@@ -146,11 +146,14 @@ def add_node(
     require_all_properties: bool,
     extend_all_attributes: bool,
 ) -> None:
+    vss_data = node.get_vss_data()
     schema["type"] = "object"
-    if node.get_vss_data().description is not None:
-        schema["description"] = node.get_vss_data().description
+    if vss_data.description is not None:
+        schema["description"] = vss_data.description
     if extend_all_attributes:
         add_x_attributes(schema, node)
+    for field in vss_data.get_extra_attributes():
+        schema[field] = getattr(vss_data, field)        
     if isinstance(node.data, VSSDataDatatype):
         ref = schema
         if is_array(node.data.datatype):

--- a/src/vss_tools/exporters/jsonschema.py
+++ b/src/vss_tools/exporters/jsonschema.py
@@ -152,8 +152,11 @@ def add_node(
         schema["description"] = vss_data.description
     if extend_all_attributes:
         add_x_attributes(schema, node)
-    for field in vss_data.get_extra_attributes():
-        schema[field] = getattr(vss_data, field)
+    extra_attributes = vss_data.get_extra_attributes()
+    if extra_attributes:
+        schema["x-extra"] = {}
+    for field in extra_attributes:
+        schema["x-extra"][field] = getattr(vss_data, field)
     if isinstance(node.data, VSSDataDatatype):
         ref = schema
         if is_array(node.data.datatype):


### PR DESCRIPTION
- Reintroduce processing of extended attributes in jsonschema export. The functionality had disappeared between 5.0 and 6.0 in this commit: https://github.com/COVESA/vss-tools/commit/526754f388303f401584d100230c784fe2e62b4c
- Group extra attributes inside a x-extra object containing all the mappings, as requested by Sebastian Schleemilch
- Update doc accordingly.